### PR TITLE
Add event parameter for wait callback

### DIFF
--- a/src/js/tippy.js
+++ b/src/js/tippy.js
@@ -491,7 +491,7 @@ export default class Tippy {
             }
         }
 
-        const show = () => this.callbacks.wait ? this.callbacks.wait(_show) : _show()
+        const show = (event) => this.callbacks.wait ? this.callbacks.wait(_show, event) : _show()
         const hide = () => this.hide(popper, settings.hideDuration)
 
         const handleTrigger = event => {
@@ -511,7 +511,7 @@ export default class Tippy {
                 return hide()
             }
 
-            show()
+            show(event)
         }
 
         const handleMouseleave = event => {


### PR DESCRIPTION
Sometimes you may need to check with event.target before calling show
callback.