### PR TITLE
Since this library is used in react-tippy, it's able to render on the…

### DIFF
--- a/src/js/tippy.js
+++ b/src/js/tippy.js
@@ -114,10 +114,13 @@ function handleDocumentClick(event) {
     hideAllPoppers()
 }
 
-// Prevent errors in <= IE8
-if (document.addEventListener) {
-    document.addEventListener('click', handleDocumentClick)
-    document.addEventListener('touchstart', handleDocumentTouchstart)
+// Hook events only if rendered on a browser
+if (!( typeof window === 'undefined' || typeof document === 'undefined' )) {
+    // Prevent errors in <= IE8
+    if (document.addEventListener) {
+        document.addEventListener('click', handleDocumentClick);
+        document.addEventListener('touchstart', handleDocumentTouchstart);
+    }
 }
 
 /**


### PR DESCRIPTION
… server.

This threw an exception since we we're trying to hook to client events on the server.
We now hook to client events only in the client.