### PR TITLE
Use appendChild instead of innerHtml for templates

### DIFF
--- a/src/js/tippy.js
+++ b/src/js/tippy.js
@@ -349,7 +349,7 @@ function createPopperElement(id, title, settings) {
         let templateId
 
         if (html instanceof Element) {
-            content.innerHTML = html.innerHTML
+            content.appendChild(html)
             templateId = html.id || 'tippy-html-template'
         } else {
             content.innerHTML = document.getElementById(html.replace('#', '')).innerHTML


### PR DESCRIPTION
- Replaced the use of innerHTML with appendChild when template
    content is inserted into a popper.

Why?
- The rest of tippy.js is written to nicely to add/remove the popper from
    the DOM while preserving events and element properties.
- By using innerHTML to insert the template it kills any events or
    element properties a dev added to the template structure.
- Using appendChild when you have already confirmed it is an HTML
    Element object preserves anything the dev adds to the template.
- This allows a dev to create interactive poppers with their own event
    handlers and more