### PR TITLE
Add support for array of elements as selector parameter

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -196,8 +196,9 @@ tippy.css</code></pre>
               <button class="btn tippy" title="I'm a tooltip!">Text</button>
             </div>
 
-            <p>You can also directly pass in a DOM element:</p>
+            <p>You can also directly pass in a DOM element or array of DOM elements:</p>
 <pre><code class="language-javascript">tippy(document.querySelector('#myElement'))</code></pre>
+<pre><code class="language-javascript">tippy(Array.prototype.slice.call(document.querySelector('.myElements')))</code></pre>
 
             <p>Elements without a <code>title</code> attribute or an HTML template will not receive a tooltip. You can pass in any CSS selector to initialize it. See <a class="tippy-link" href="https://developer.mozilla.org/en-US/docs/Web/API/Document/querySelectorAll" target="_blank" title="mozilla.org">document.querySelectorAll()</a> for reference.</p>
 

--- a/docs/tippy/tippy.css
+++ b/docs/tippy/tippy.css
@@ -1,1 +1,389 @@
-.tippy-touch{cursor:pointer!important}.tippy-notransition{-webkit-transition:none!important;transition:none!important}.tippy-popper{max-width:400px;-webkit-perspective:800px;perspective:800px;z-index:9999;outline:0;-webkit-transition-timing-function:cubic-bezier(.165,.84,.44,1);transition-timing-function:cubic-bezier(.165,.84,.44,1)}.tippy-popper.html-template{max-width:96%;max-width:calc(100% - 20px)}.tippy-popper[x-placement^=top] [x-arrow]{border-top:7px solid #333;border-right:7px solid transparent;border-left:7px solid transparent;bottom:-7px;margin:0 9px}.tippy-popper[x-placement^=top] [x-arrow].arrow-small{border-top:5px solid #333;border-right:5px solid transparent;border-left:5px solid transparent;bottom:-5px}.tippy-popper[x-placement^=top] [x-arrow].arrow-big{border-top:10px solid #333;border-right:10px solid transparent;border-left:10px solid transparent;bottom:-10px}.tippy-popper[x-placement^=top] [x-circle]{-webkit-transform-origin:0 33%;transform-origin:0 33%}.tippy-popper[x-placement^=top] [x-circle].enter{-webkit-transform:scale(1) translate(-50%,-55%);transform:scale(1) translate(-50%,-55%);opacity:1}.tippy-popper[x-placement^=top] [x-circle].leave{-webkit-transform:scale(.15) translate(-50%,-50%);transform:scale(.15) translate(-50%,-50%);opacity:0}.tippy-popper[x-placement^=top] .tippy-tooltip.light-theme [x-circle]{background-color:#fff}.tippy-popper[x-placement^=top] .tippy-tooltip.light-theme [x-arrow]{border-top:7px solid #fff;border-right:7px solid transparent;border-left:7px solid transparent}.tippy-popper[x-placement^=top] .tippy-tooltip.light-theme [x-arrow].arrow-small{border-top:5px solid #fff;border-right:5px solid transparent;border-left:5px solid transparent}.tippy-popper[x-placement^=top] .tippy-tooltip.light-theme [x-arrow].arrow-big{border-top:10px solid #fff;border-right:10px solid transparent;border-left:10px solid transparent}.tippy-popper[x-placement^=top] .tippy-tooltip.transparent-theme [x-circle]{background-color:rgba(0,0,0,.7)}.tippy-popper[x-placement^=top] .tippy-tooltip.transparent-theme [x-arrow]{border-top:7px solid rgba(0,0,0,.7);border-right:7px solid transparent;border-left:7px solid transparent}.tippy-popper[x-placement^=top] .tippy-tooltip.transparent-theme [x-arrow].arrow-small{border-top:5px solid rgba(0,0,0,.7);border-right:5px solid transparent;border-left:5px solid transparent}.tippy-popper[x-placement^=top] .tippy-tooltip.transparent-theme [x-arrow].arrow-big{border-top:10px solid rgba(0,0,0,.7);border-right:10px solid transparent;border-left:10px solid transparent}.tippy-popper[x-placement^=top] [data-animation=perspective]{-webkit-transform-origin:bottom;transform-origin:bottom}.tippy-popper[x-placement^=top] [data-animation=perspective].enter{opacity:1;-webkit-transform:translateY(-10px) rotateX(0);transform:translateY(-10px) rotateX(0)}.tippy-popper[x-placement^=top] [data-animation=perspective].leave{opacity:0;-webkit-transform:translateY(0) rotateX(90deg);transform:translateY(0) rotateX(90deg)}.tippy-popper[x-placement^=top] [data-animation=fade].enter{opacity:1;-webkit-transform:translateY(-10px);transform:translateY(-10px)}.tippy-popper[x-placement^=top] [data-animation=fade].leave{opacity:0;-webkit-transform:translateY(-10px);transform:translateY(-10px)}.tippy-popper[x-placement^=top] [data-animation=shift].enter{opacity:1;-webkit-transform:translateY(-10px);transform:translateY(-10px)}.tippy-popper[x-placement^=top] [data-animation=shift].leave{opacity:0;-webkit-transform:translateY(0);transform:translateY(0)}.tippy-popper[x-placement^=top] [data-animation=scale].enter{opacity:1;-webkit-transform:translateY(-10px) scale(1);transform:translateY(-10px) scale(1)}.tippy-popper[x-placement^=top] [data-animation=scale].leave{opacity:0;-webkit-transform:translateY(0) scale(0);transform:translateY(0) scale(0)}.tippy-popper[x-placement^=bottom] [x-arrow]{border-bottom:7px solid #333;border-right:7px solid transparent;border-left:7px solid transparent;top:-7px;margin:0 9px}.tippy-popper[x-placement^=bottom] [x-arrow].arrow-small{border-bottom:5px solid #333;border-right:5px solid transparent;border-left:5px solid transparent;top:-5px}.tippy-popper[x-placement^=bottom] [x-arrow].arrow-big{border-bottom:10px solid #333;border-right:10px solid transparent;border-left:10px solid transparent;top:-10px}.tippy-popper[x-placement^=bottom] [x-circle]{-webkit-transform-origin:0 -50%;transform-origin:0 -50%}.tippy-popper[x-placement^=bottom] [x-circle].enter{-webkit-transform:scale(1) translate(-50%,-45%);transform:scale(1) translate(-50%,-45%);opacity:1}.tippy-popper[x-placement^=bottom] [x-circle].leave{-webkit-transform:scale(.15) translate(-50%,-5%);transform:scale(.15) translate(-50%,-5%);opacity:0}.tippy-popper[x-placement^=bottom] .tippy-tooltip.light-theme [x-circle]{background-color:#fff}.tippy-popper[x-placement^=bottom] .tippy-tooltip.light-theme [x-arrow]{border-bottom:7px solid #fff;border-right:7px solid transparent;border-left:7px solid transparent}.tippy-popper[x-placement^=bottom] .tippy-tooltip.light-theme [x-arrow].arrow-small{border-bottom:5px solid #fff;border-right:5px solid transparent;border-left:5px solid transparent}.tippy-popper[x-placement^=bottom] .tippy-tooltip.light-theme [x-arrow].arrow-big{border-bottom:10px solid #fff;border-right:10px solid transparent;border-left:10px solid transparent}.tippy-popper[x-placement^=bottom] .tippy-tooltip.transparent-theme [x-circle]{background-color:rgba(0,0,0,.7)}.tippy-popper[x-placement^=bottom] .tippy-tooltip.transparent-theme [x-arrow]{border-bottom:7px solid rgba(0,0,0,.7);border-right:7px solid transparent;border-left:7px solid transparent}.tippy-popper[x-placement^=bottom] .tippy-tooltip.transparent-theme [x-arrow].arrow-small{border-bottom:5px solid rgba(0,0,0,.7);border-right:5px solid transparent;border-left:5px solid transparent}.tippy-popper[x-placement^=bottom] .tippy-tooltip.transparent-theme [x-arrow].arrow-big{border-bottom:10px solid rgba(0,0,0,.7);border-right:10px solid transparent;border-left:10px solid transparent}.tippy-popper[x-placement^=bottom] [data-animation=perspective]{-webkit-transform-origin:top;transform-origin:top}.tippy-popper[x-placement^=bottom] [data-animation=perspective].enter{opacity:1;-webkit-transform:translateY(10px) rotateX(0);transform:translateY(10px) rotateX(0)}.tippy-popper[x-placement^=bottom] [data-animation=perspective].leave{opacity:0;-webkit-transform:translateY(0) rotateX(-90deg);transform:translateY(0) rotateX(-90deg)}.tippy-popper[x-placement^=bottom] [data-animation=fade].enter{opacity:1;-webkit-transform:translateY(10px);transform:translateY(10px)}.tippy-popper[x-placement^=bottom] [data-animation=fade].leave{opacity:0;-webkit-transform:translateY(10px);transform:translateY(10px)}.tippy-popper[x-placement^=bottom] [data-animation=shift].enter{opacity:1;-webkit-transform:translateY(10px);transform:translateY(10px)}.tippy-popper[x-placement^=bottom] [data-animation=shift].leave{opacity:0;-webkit-transform:translateY(0);transform:translateY(0)}.tippy-popper[x-placement^=bottom] [data-animation=scale].enter{opacity:1;-webkit-transform:translateY(10px) scale(1);transform:translateY(10px) scale(1)}.tippy-popper[x-placement^=bottom] [data-animation=scale].leave{opacity:0;-webkit-transform:translateY(0) scale(0);transform:translateY(0) scale(0)}.tippy-popper[x-placement^=left] [x-arrow]{border-left:7px solid #333;border-top:7px solid transparent;border-bottom:7px solid transparent;right:-7px;margin:6px 0}.tippy-popper[x-placement^=left] [x-arrow].arrow-small{border-left:5px solid #333;border-top:5px solid transparent;border-bottom:5px solid transparent;right:-5px}.tippy-popper[x-placement^=left] [x-arrow].arrow-big{border-left:10px solid #333;border-top:10px solid transparent;border-bottom:10px solid transparent;right:-10px}.tippy-popper[x-placement^=left] [x-circle]{-webkit-transform-origin:50% 0;transform-origin:50% 0}.tippy-popper[x-placement^=left] [x-circle].enter{-webkit-transform:scale(1) translate(-50%,-50%);transform:scale(1) translate(-50%,-50%);opacity:1}.tippy-popper[x-placement^=left] [x-circle].leave{-webkit-transform:scale(.15) translate(-50%,-50%);transform:scale(.15) translate(-50%,-50%);opacity:0}.tippy-popper[x-placement^=left] .tippy-tooltip.light-theme [x-circle]{background-color:#fff}.tippy-popper[x-placement^=left] .tippy-tooltip.light-theme [x-arrow]{border-left:7px solid #fff;border-top:7px solid transparent;border-bottom:7px solid transparent}.tippy-popper[x-placement^=left] .tippy-tooltip.light-theme [x-arrow].arrow-small{border-left:5px solid #fff;border-top:5px solid transparent;border-bottom:5px solid transparent}.tippy-popper[x-placement^=left] .tippy-tooltip.light-theme [x-arrow].arrow-big{border-left:10px solid #fff;border-top:10px solid transparent;border-bottom:10px solid transparent}.tippy-popper[x-placement^=left] .tippy-tooltip.transparent-theme [x-circle]{background-color:rgba(0,0,0,.7)}.tippy-popper[x-placement^=left] .tippy-tooltip.transparent-theme [x-arrow]{border-left:7px solid rgba(0,0,0,.7);border-top:7px solid transparent;border-bottom:7px solid transparent}.tippy-popper[x-placement^=left] .tippy-tooltip.transparent-theme [x-arrow].arrow-small{border-left:5px solid rgba(0,0,0,.7);border-top:5px solid transparent;border-bottom:5px solid transparent}.tippy-popper[x-placement^=left] .tippy-tooltip.transparent-theme [x-arrow].arrow-big{border-left:10px solid rgba(0,0,0,.7);border-top:10px solid transparent;border-bottom:10px solid transparent}.tippy-popper[x-placement^=left] [data-animation=perspective]{-webkit-transform-origin:right;transform-origin:right}.tippy-popper[x-placement^=left] [data-animation=perspective].enter{opacity:1;-webkit-transform:translateX(-10px) rotateY(0);transform:translateX(-10px) rotateY(0)}.tippy-popper[x-placement^=left] [data-animation=perspective].leave{opacity:0;-webkit-transform:translateX(0) rotateY(-90deg);transform:translateX(0) rotateY(-90deg)}.tippy-popper[x-placement^=left] [data-animation=fade].enter{opacity:1;-webkit-transform:translateX(-10px);transform:translateX(-10px)}.tippy-popper[x-placement^=left] [data-animation=fade].leave{opacity:0;-webkit-transform:translateX(-10px);transform:translateX(-10px)}.tippy-popper[x-placement^=left] [data-animation=shift].enter{opacity:1;-webkit-transform:translateX(-10px);transform:translateX(-10px)}.tippy-popper[x-placement^=left] [data-animation=shift].leave{opacity:0;-webkit-transform:translateX(0);transform:translateX(0)}.tippy-popper[x-placement^=left] [data-animation=scale].enter{opacity:1;-webkit-transform:translateX(-10px) scale(1);transform:translateX(-10px) scale(1)}.tippy-popper[x-placement^=left] [data-animation=scale].leave{opacity:0;-webkit-transform:translateX(0) scale(0);transform:translateX(0) scale(0)}.tippy-popper[x-placement^=right] [x-arrow]{border-right:7px solid #333;border-top:7px solid transparent;border-bottom:7px solid transparent;left:-7px;margin:6px 0}.tippy-popper[x-placement^=right] [x-arrow].arrow-small{border-right:5px solid #333;border-top:5px solid transparent;border-bottom:5px solid transparent;left:-5px}.tippy-popper[x-placement^=right] [x-arrow].arrow-big{border-right:10px solid #333;border-top:10px solid transparent;border-bottom:10px solid transparent;left:-10px}.tippy-popper[x-placement^=right] [x-circle]{-webkit-transform-origin:-50% 0;transform-origin:-50% 0}.tippy-popper[x-placement^=right] [x-circle].enter{-webkit-transform:scale(1) translate(-50%,-50%);transform:scale(1) translate(-50%,-50%);opacity:1}.tippy-popper[x-placement^=right] [x-circle].leave{-webkit-transform:scale(.15) translate(-50%,-50%);transform:scale(.15) translate(-50%,-50%);opacity:0}.tippy-popper[x-placement^=right] .tippy-tooltip.light-theme [x-circle]{background-color:#fff}.tippy-popper[x-placement^=right] .tippy-tooltip.light-theme [x-arrow]{border-right:7px solid #fff;border-top:7px solid transparent;border-bottom:7px solid transparent}.tippy-popper[x-placement^=right] .tippy-tooltip.light-theme [x-arrow].arrow-small{border-right:5px solid #fff;border-top:5px solid transparent;border-bottom:5px solid transparent}.tippy-popper[x-placement^=right] .tippy-tooltip.light-theme [x-arrow].arrow-big{border-right:10px solid #fff;border-top:10px solid transparent;border-bottom:10px solid transparent}.tippy-popper[x-placement^=right] .tippy-tooltip.transparent-theme [x-circle]{background-color:rgba(0,0,0,.7)}.tippy-popper[x-placement^=right] .tippy-tooltip.transparent-theme [x-arrow]{border-right:7px solid rgba(0,0,0,.7);border-top:7px solid transparent;border-bottom:7px solid transparent}.tippy-popper[x-placement^=right] .tippy-tooltip.transparent-theme [x-arrow].arrow-small{border-right:5px solid rgba(0,0,0,.7);border-top:5px solid transparent;border-bottom:5px solid transparent}.tippy-popper[x-placement^=right] .tippy-tooltip.transparent-theme [x-arrow].arrow-big{border-right:10px solid rgba(0,0,0,.7);border-top:10px solid transparent;border-bottom:10px solid transparent}.tippy-popper[x-placement^=right] [data-animation=perspective]{-webkit-transform-origin:left;transform-origin:left}.tippy-popper[x-placement^=right] [data-animation=perspective].enter{opacity:1;-webkit-transform:translateX(10px) rotateY(0);transform:translateX(10px) rotateY(0)}.tippy-popper[x-placement^=right] [data-animation=perspective].leave{opacity:0;-webkit-transform:translateX(0) rotateY(90deg);transform:translateX(0) rotateY(90deg)}.tippy-popper[x-placement^=right] [data-animation=fade].enter{opacity:1;-webkit-transform:translateX(10px);transform:translateX(10px)}.tippy-popper[x-placement^=right] [data-animation=fade].leave{opacity:0;-webkit-transform:translateX(10px);transform:translateX(10px)}.tippy-popper[x-placement^=right] [data-animation=shift].enter{opacity:1;-webkit-transform:translateX(10px);transform:translateX(10px)}.tippy-popper[x-placement^=right] [data-animation=shift].leave{opacity:0;-webkit-transform:translateX(0);transform:translateX(0)}.tippy-popper[x-placement^=right] [data-animation=scale].enter{opacity:1;-webkit-transform:translateX(10px) scale(1);transform:translateX(10px) scale(1)}.tippy-popper[x-placement^=right] [data-animation=scale].leave{opacity:0;-webkit-transform:translateX(0) scale(0);transform:translateX(0) scale(0)}.tippy-popper .tippy-tooltip.transparent-theme{background-color:rgba(0,0,0,.7)}.tippy-popper .tippy-tooltip.transparent-theme[data-animatefill]{background-color:transparent}.tippy-popper .tippy-tooltip.light-theme{color:#26323d;box-shadow:0 4px 20px 4px rgba(0,20,60,.1),0 4px 80px -8px rgba(0,20,60,.2);background-color:#fff}.tippy-popper .tippy-tooltip.light-theme[data-animatefill]{background-color:transparent}.tippy-tooltip{position:relative;color:#fff;border-radius:4px;font-size:.95rem;padding:.4rem .8rem;text-align:center;will-change:transform;-webkit-font-smoothing:antialiased;-moz-osx-font-smoothing:grayscale;background-color:#333;pointer-events:none}.tippy-tooltip--small{padding:.25rem .5rem;font-size:.8rem}.tippy-tooltip--big{padding:.6rem 1.2rem;font-size:1.2rem}.tippy-tooltip[data-animatefill]{overflow:hidden;background-color:transparent}.tippy-tooltip[data-interactive]{pointer-events:auto}.tippy-tooltip[data-inertia]{-webkit-transition-timing-function:cubic-bezier(.53,1,.36,.85);transition-timing-function:cubic-bezier(.53,2,.36,.85)}.tippy-tooltip [x-arrow]{position:absolute;width:0;height:0}.tippy-tooltip [x-circle]{position:absolute;will-change:transform;background-color:#333;border-radius:50%;width:130%;width:calc(110% + 2rem);left:50%;top:50%;z-index:-1;overflow:hidden;-webkit-transition:all ease;transition:all ease}.tippy-tooltip [x-circle]:before{content:"";padding-top:90%;float:left}@media (max-width:450px){.tippy-popper{max-width:96%;max-width:calc(100% - 20px)}}
+.tippy-touch {
+  cursor: pointer !important; }
+
+.tippy-notransition {
+  transition: none !important; }
+
+.tippy-popper {
+  max-width: 400px;
+  perspective: 800px;
+  z-index: 9999;
+  outline: 0;
+  transition-timing-function: cubic-bezier(0.165, 0.84, 0.44, 1); }
+  .tippy-popper.html-template {
+    max-width: 96%;
+    max-width: calc(100% - 20px); }
+  .tippy-popper[x-placement^=top] [x-arrow] {
+    border-top: 7px solid #333;
+    border-right: 7px solid transparent;
+    border-left: 7px solid transparent;
+    bottom: -7px;
+    margin: 0 9px; }
+    .tippy-popper[x-placement^=top] [x-arrow].arrow-small {
+      border-top: 5px solid #333;
+      border-right: 5px solid transparent;
+      border-left: 5px solid transparent;
+      bottom: -5px; }
+    .tippy-popper[x-placement^=top] [x-arrow].arrow-big {
+      border-top: 10px solid #333;
+      border-right: 10px solid transparent;
+      border-left: 10px solid transparent;
+      bottom: -10px; }
+  .tippy-popper[x-placement^=top] [x-circle] {
+    transform-origin: 0% 33%; }
+    .tippy-popper[x-placement^=top] [x-circle].enter {
+      transform: scale(1) translate(-50%, -55%);
+      opacity: 1; }
+    .tippy-popper[x-placement^=top] [x-circle].leave {
+      transform: scale(0.15) translate(-50%, -50%);
+      opacity: 0; }
+  .tippy-popper[x-placement^=top] .tippy-tooltip.light-theme [x-circle] {
+    background-color: white; }
+  .tippy-popper[x-placement^=top] .tippy-tooltip.light-theme [x-arrow] {
+    border-top: 7px solid white;
+    border-right: 7px solid transparent;
+    border-left: 7px solid transparent; }
+    .tippy-popper[x-placement^=top] .tippy-tooltip.light-theme [x-arrow].arrow-small {
+      border-top: 5px solid white;
+      border-right: 5px solid transparent;
+      border-left: 5px solid transparent; }
+    .tippy-popper[x-placement^=top] .tippy-tooltip.light-theme [x-arrow].arrow-big {
+      border-top: 10px solid white;
+      border-right: 10px solid transparent;
+      border-left: 10px solid transparent; }
+  .tippy-popper[x-placement^=top] .tippy-tooltip.transparent-theme [x-circle] {
+    background-color: rgba(0, 0, 0, 0.7); }
+  .tippy-popper[x-placement^=top] .tippy-tooltip.transparent-theme [x-arrow] {
+    border-top: 7px solid rgba(0, 0, 0, 0.7);
+    border-right: 7px solid transparent;
+    border-left: 7px solid transparent; }
+    .tippy-popper[x-placement^=top] .tippy-tooltip.transparent-theme [x-arrow].arrow-small {
+      border-top: 5px solid rgba(0, 0, 0, 0.7);
+      border-right: 5px solid transparent;
+      border-left: 5px solid transparent; }
+    .tippy-popper[x-placement^=top] .tippy-tooltip.transparent-theme [x-arrow].arrow-big {
+      border-top: 10px solid rgba(0, 0, 0, 0.7);
+      border-right: 10px solid transparent;
+      border-left: 10px solid transparent; }
+  .tippy-popper[x-placement^=top] [data-animation=perspective] {
+    transform-origin: bottom; }
+    .tippy-popper[x-placement^=top] [data-animation=perspective].enter {
+      opacity: 1;
+      transform: translateY(-10px) rotateX(0); }
+    .tippy-popper[x-placement^=top] [data-animation=perspective].leave {
+      opacity: 0;
+      transform: translateY(0) rotateX(90deg); }
+  .tippy-popper[x-placement^=top] [data-animation=fade].enter {
+    opacity: 1;
+    transform: translateY(-10px); }
+  .tippy-popper[x-placement^=top] [data-animation=fade].leave {
+    opacity: 0;
+    transform: translateY(-10px); }
+  .tippy-popper[x-placement^=top] [data-animation=shift].enter {
+    opacity: 1;
+    transform: translateY(-10px); }
+  .tippy-popper[x-placement^=top] [data-animation=shift].leave {
+    opacity: 0;
+    transform: translateY(0); }
+  .tippy-popper[x-placement^=top] [data-animation=scale].enter {
+    opacity: 1;
+    transform: translateY(-10px) scale(1); }
+  .tippy-popper[x-placement^=top] [data-animation=scale].leave {
+    opacity: 0;
+    transform: translateY(0) scale(0); }
+  .tippy-popper[x-placement^=bottom] [x-arrow] {
+    border-bottom: 7px solid #333;
+    border-right: 7px solid transparent;
+    border-left: 7px solid transparent;
+    top: -7px;
+    margin: 0 9px; }
+    .tippy-popper[x-placement^=bottom] [x-arrow].arrow-small {
+      border-bottom: 5px solid #333;
+      border-right: 5px solid transparent;
+      border-left: 5px solid transparent;
+      top: -5px; }
+    .tippy-popper[x-placement^=bottom] [x-arrow].arrow-big {
+      border-bottom: 10px solid #333;
+      border-right: 10px solid transparent;
+      border-left: 10px solid transparent;
+      top: -10px; }
+  .tippy-popper[x-placement^=bottom] [x-circle] {
+    transform-origin: 0% -50%; }
+    .tippy-popper[x-placement^=bottom] [x-circle].enter {
+      transform: scale(1) translate(-50%, -45%);
+      opacity: 1; }
+    .tippy-popper[x-placement^=bottom] [x-circle].leave {
+      transform: scale(0.15) translate(-50%, -5%);
+      opacity: 0; }
+  .tippy-popper[x-placement^=bottom] .tippy-tooltip.light-theme [x-circle] {
+    background-color: white; }
+  .tippy-popper[x-placement^=bottom] .tippy-tooltip.light-theme [x-arrow] {
+    border-bottom: 7px solid white;
+    border-right: 7px solid transparent;
+    border-left: 7px solid transparent; }
+    .tippy-popper[x-placement^=bottom] .tippy-tooltip.light-theme [x-arrow].arrow-small {
+      border-bottom: 5px solid white;
+      border-right: 5px solid transparent;
+      border-left: 5px solid transparent; }
+    .tippy-popper[x-placement^=bottom] .tippy-tooltip.light-theme [x-arrow].arrow-big {
+      border-bottom: 10px solid white;
+      border-right: 10px solid transparent;
+      border-left: 10px solid transparent; }
+  .tippy-popper[x-placement^=bottom] .tippy-tooltip.transparent-theme [x-circle] {
+    background-color: rgba(0, 0, 0, 0.7); }
+  .tippy-popper[x-placement^=bottom] .tippy-tooltip.transparent-theme [x-arrow] {
+    border-bottom: 7px solid rgba(0, 0, 0, 0.7);
+    border-right: 7px solid transparent;
+    border-left: 7px solid transparent; }
+    .tippy-popper[x-placement^=bottom] .tippy-tooltip.transparent-theme [x-arrow].arrow-small {
+      border-bottom: 5px solid rgba(0, 0, 0, 0.7);
+      border-right: 5px solid transparent;
+      border-left: 5px solid transparent; }
+    .tippy-popper[x-placement^=bottom] .tippy-tooltip.transparent-theme [x-arrow].arrow-big {
+      border-bottom: 10px solid rgba(0, 0, 0, 0.7);
+      border-right: 10px solid transparent;
+      border-left: 10px solid transparent; }
+  .tippy-popper[x-placement^=bottom] [data-animation=perspective] {
+    transform-origin: top; }
+    .tippy-popper[x-placement^=bottom] [data-animation=perspective].enter {
+      opacity: 1;
+      transform: translateY(10px) rotateX(0); }
+    .tippy-popper[x-placement^=bottom] [data-animation=perspective].leave {
+      opacity: 0;
+      transform: translateY(0) rotateX(-90deg); }
+  .tippy-popper[x-placement^=bottom] [data-animation=fade].enter {
+    opacity: 1;
+    transform: translateY(10px); }
+  .tippy-popper[x-placement^=bottom] [data-animation=fade].leave {
+    opacity: 0;
+    transform: translateY(10px); }
+  .tippy-popper[x-placement^=bottom] [data-animation=shift].enter {
+    opacity: 1;
+    transform: translateY(10px); }
+  .tippy-popper[x-placement^=bottom] [data-animation=shift].leave {
+    opacity: 0;
+    transform: translateY(0); }
+  .tippy-popper[x-placement^=bottom] [data-animation=scale].enter {
+    opacity: 1;
+    transform: translateY(10px) scale(1); }
+  .tippy-popper[x-placement^=bottom] [data-animation=scale].leave {
+    opacity: 0;
+    transform: translateY(0) scale(0); }
+  .tippy-popper[x-placement^=left] [x-arrow] {
+    border-left: 7px solid #333;
+    border-top: 7px solid transparent;
+    border-bottom: 7px solid transparent;
+    right: -7px;
+    margin: 6px 0; }
+    .tippy-popper[x-placement^=left] [x-arrow].arrow-small {
+      border-left: 5px solid #333;
+      border-top: 5px solid transparent;
+      border-bottom: 5px solid transparent;
+      right: -5px; }
+    .tippy-popper[x-placement^=left] [x-arrow].arrow-big {
+      border-left: 10px solid #333;
+      border-top: 10px solid transparent;
+      border-bottom: 10px solid transparent;
+      right: -10px; }
+  .tippy-popper[x-placement^=left] [x-circle] {
+    transform-origin: 50% 0%; }
+    .tippy-popper[x-placement^=left] [x-circle].enter {
+      transform: scale(1) translate(-50%, -50%);
+      opacity: 1; }
+    .tippy-popper[x-placement^=left] [x-circle].leave {
+      transform: scale(0.15) translate(-50%, -50%);
+      opacity: 0; }
+  .tippy-popper[x-placement^=left] .tippy-tooltip.light-theme [x-circle] {
+    background-color: white; }
+  .tippy-popper[x-placement^=left] .tippy-tooltip.light-theme [x-arrow] {
+    border-left: 7px solid white;
+    border-top: 7px solid transparent;
+    border-bottom: 7px solid transparent; }
+    .tippy-popper[x-placement^=left] .tippy-tooltip.light-theme [x-arrow].arrow-small {
+      border-left: 5px solid white;
+      border-top: 5px solid transparent;
+      border-bottom: 5px solid transparent; }
+    .tippy-popper[x-placement^=left] .tippy-tooltip.light-theme [x-arrow].arrow-big {
+      border-left: 10px solid white;
+      border-top: 10px solid transparent;
+      border-bottom: 10px solid transparent; }
+  .tippy-popper[x-placement^=left] .tippy-tooltip.transparent-theme [x-circle] {
+    background-color: rgba(0, 0, 0, 0.7); }
+  .tippy-popper[x-placement^=left] .tippy-tooltip.transparent-theme [x-arrow] {
+    border-left: 7px solid rgba(0, 0, 0, 0.7);
+    border-top: 7px solid transparent;
+    border-bottom: 7px solid transparent; }
+    .tippy-popper[x-placement^=left] .tippy-tooltip.transparent-theme [x-arrow].arrow-small {
+      border-left: 5px solid rgba(0, 0, 0, 0.7);
+      border-top: 5px solid transparent;
+      border-bottom: 5px solid transparent; }
+    .tippy-popper[x-placement^=left] .tippy-tooltip.transparent-theme [x-arrow].arrow-big {
+      border-left: 10px solid rgba(0, 0, 0, 0.7);
+      border-top: 10px solid transparent;
+      border-bottom: 10px solid transparent; }
+  .tippy-popper[x-placement^=left] [data-animation=perspective] {
+    transform-origin: right; }
+    .tippy-popper[x-placement^=left] [data-animation=perspective].enter {
+      opacity: 1;
+      transform: translateX(-10px) rotateY(0); }
+    .tippy-popper[x-placement^=left] [data-animation=perspective].leave {
+      opacity: 0;
+      transform: translateX(0) rotateY(-90deg); }
+  .tippy-popper[x-placement^=left] [data-animation=fade].enter {
+    opacity: 1;
+    transform: translateX(-10px); }
+  .tippy-popper[x-placement^=left] [data-animation=fade].leave {
+    opacity: 0;
+    transform: translateX(-10px); }
+  .tippy-popper[x-placement^=left] [data-animation=shift].enter {
+    opacity: 1;
+    transform: translateX(-10px); }
+  .tippy-popper[x-placement^=left] [data-animation=shift].leave {
+    opacity: 0;
+    transform: translateX(0); }
+  .tippy-popper[x-placement^=left] [data-animation=scale].enter {
+    opacity: 1;
+    transform: translateX(-10px) scale(1); }
+  .tippy-popper[x-placement^=left] [data-animation=scale].leave {
+    opacity: 0;
+    transform: translateX(0) scale(0); }
+  .tippy-popper[x-placement^=right] [x-arrow] {
+    border-right: 7px solid #333;
+    border-top: 7px solid transparent;
+    border-bottom: 7px solid transparent;
+    left: -7px;
+    margin: 6px 0; }
+    .tippy-popper[x-placement^=right] [x-arrow].arrow-small {
+      border-right: 5px solid #333;
+      border-top: 5px solid transparent;
+      border-bottom: 5px solid transparent;
+      left: -5px; }
+    .tippy-popper[x-placement^=right] [x-arrow].arrow-big {
+      border-right: 10px solid #333;
+      border-top: 10px solid transparent;
+      border-bottom: 10px solid transparent;
+      left: -10px; }
+  .tippy-popper[x-placement^=right] [x-circle] {
+    transform-origin: -50% 0%; }
+    .tippy-popper[x-placement^=right] [x-circle].enter {
+      transform: scale(1) translate(-50%, -50%);
+      opacity: 1; }
+    .tippy-popper[x-placement^=right] [x-circle].leave {
+      transform: scale(0.15) translate(-50%, -50%);
+      opacity: 0; }
+  .tippy-popper[x-placement^=right] .tippy-tooltip.light-theme [x-circle] {
+    background-color: white; }
+  .tippy-popper[x-placement^=right] .tippy-tooltip.light-theme [x-arrow] {
+    border-right: 7px solid white;
+    border-top: 7px solid transparent;
+    border-bottom: 7px solid transparent; }
+    .tippy-popper[x-placement^=right] .tippy-tooltip.light-theme [x-arrow].arrow-small {
+      border-right: 5px solid white;
+      border-top: 5px solid transparent;
+      border-bottom: 5px solid transparent; }
+    .tippy-popper[x-placement^=right] .tippy-tooltip.light-theme [x-arrow].arrow-big {
+      border-right: 10px solid white;
+      border-top: 10px solid transparent;
+      border-bottom: 10px solid transparent; }
+  .tippy-popper[x-placement^=right] .tippy-tooltip.transparent-theme [x-circle] {
+    background-color: rgba(0, 0, 0, 0.7); }
+  .tippy-popper[x-placement^=right] .tippy-tooltip.transparent-theme [x-arrow] {
+    border-right: 7px solid rgba(0, 0, 0, 0.7);
+    border-top: 7px solid transparent;
+    border-bottom: 7px solid transparent; }
+    .tippy-popper[x-placement^=right] .tippy-tooltip.transparent-theme [x-arrow].arrow-small {
+      border-right: 5px solid rgba(0, 0, 0, 0.7);
+      border-top: 5px solid transparent;
+      border-bottom: 5px solid transparent; }
+    .tippy-popper[x-placement^=right] .tippy-tooltip.transparent-theme [x-arrow].arrow-big {
+      border-right: 10px solid rgba(0, 0, 0, 0.7);
+      border-top: 10px solid transparent;
+      border-bottom: 10px solid transparent; }
+  .tippy-popper[x-placement^=right] [data-animation=perspective] {
+    transform-origin: left; }
+    .tippy-popper[x-placement^=right] [data-animation=perspective].enter {
+      opacity: 1;
+      transform: translateX(10px) rotateY(0); }
+    .tippy-popper[x-placement^=right] [data-animation=perspective].leave {
+      opacity: 0;
+      transform: translateX(0) rotateY(90deg); }
+  .tippy-popper[x-placement^=right] [data-animation=fade].enter {
+    opacity: 1;
+    transform: translateX(10px); }
+  .tippy-popper[x-placement^=right] [data-animation=fade].leave {
+    opacity: 0;
+    transform: translateX(10px); }
+  .tippy-popper[x-placement^=right] [data-animation=shift].enter {
+    opacity: 1;
+    transform: translateX(10px); }
+  .tippy-popper[x-placement^=right] [data-animation=shift].leave {
+    opacity: 0;
+    transform: translateX(0); }
+  .tippy-popper[x-placement^=right] [data-animation=scale].enter {
+    opacity: 1;
+    transform: translateX(10px) scale(1); }
+  .tippy-popper[x-placement^=right] [data-animation=scale].leave {
+    opacity: 0;
+    transform: translateX(0) scale(0); }
+  .tippy-popper .tippy-tooltip.transparent-theme {
+    background-color: rgba(0, 0, 0, 0.7); }
+    .tippy-popper .tippy-tooltip.transparent-theme[data-animatefill] {
+      background-color: transparent; }
+  .tippy-popper .tippy-tooltip.light-theme {
+    color: #26323d;
+    box-shadow: 0 4px 20px 4px rgba(0, 20, 60, 0.1), 0 4px 80px -8px rgba(0, 20, 60, 0.2);
+    background-color: white; }
+    .tippy-popper .tippy-tooltip.light-theme[data-animatefill] {
+      background-color: transparent; }
+
+.tippy-tooltip {
+  position: relative;
+  color: white;
+  border-radius: 4px;
+  font-size: 0.95rem;
+  padding: 0.4rem 0.8rem;
+  text-align: center;
+  will-change: transform;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+  background-color: #333;
+  pointer-events: none; }
+  .tippy-tooltip--small {
+    padding: 0.25rem 0.5rem;
+    font-size: 0.8rem; }
+  .tippy-tooltip--big {
+    padding: 0.6rem 1.2rem;
+    font-size: 1.2rem; }
+  .tippy-tooltip[data-animatefill] {
+    overflow: hidden;
+    background-color: transparent; }
+  .tippy-tooltip[data-interactive] {
+    pointer-events: auto; }
+  .tippy-tooltip[data-inertia] {
+    -webkit-transition-timing-function: cubic-bezier(0.53, 1, 0.36, 0.85);
+    transition-timing-function: cubic-bezier(0.53, 2, 0.36, 0.85); }
+  .tippy-tooltip [x-arrow] {
+    position: absolute;
+    width: 0;
+    height: 0; }
+  .tippy-tooltip [x-circle] {
+    position: absolute;
+    will-change: transform;
+    background-color: #333;
+    border-radius: 50%;
+    width: 130%;
+    width: calc(110% + 2rem);
+    left: 50%;
+    top: 50%;
+    z-index: -1;
+    overflow: hidden;
+    transition: all ease; }
+    .tippy-tooltip [x-circle]::before {
+      content: '';
+      padding-top: 90%;
+      float: left; }
+
+@media (max-width: 450px) {
+  .tippy-popper {
+    max-width: 96%;
+    max-width: calc(100% - 20px); } }

--- a/docs/tippy/tippy.js
+++ b/docs/tippy/tippy.js
@@ -1,1 +1,3827 @@
-(function(e,t){'object'==typeof exports&&'undefined'!=typeof module?module.exports=t():'function'==typeof define&&define.amd?define(t):e.tippy=t()})(this,function(){'use strict';function e(e){Pe.forEach(function(t){var o=t.popper,i=t.tippyInstance,n=t.settings,r=n.appendTo,s=n.hideOnClick,a=n.trigger;if(r.contains(o)){var p=!0===s||-1!==a.indexOf('focus'),l=!e||o!==e.popper;p&&l&&i.hide(o)}})}function t(e,t){var o=Element.prototype.closest||function(e){for(var t=this;t;){if(Ie.call(t,e))return t;t=t.parentElement}};return o.call(e,t)}function o(e,t){return Array.prototype.find?e.find(t):e.filter(t)[0]}function n(){var i=function(){xe.touch=!0,xe.iOS()&&document.body.classList.add('tippy-touch'),xe.dynamicInputDetection&&document.addEventListener('mousemove',n)},n=function(){var e;return function(){var t=performance&&performance.now();t&&10>t-e&&(xe.touch=!1,document.removeEventListener('mousemove',n),!xe.iOS()&&document.body.classList.contains('tippy-touch')&&document.body.classList.remove('tippy-touch')),e=t}}();document.addEventListener('click',function(i){if(!(i.target instanceof Element))return e();var n=t(i.target,Ce.TOOLTIPPED_EL),r=t(i.target,Ce.POPPER);if(r){var s=o(Pe,function(e){return e.popper===r}),a=s.settings.interactive;if(a)return}if(n){var p=o(Pe,function(e){return e.el===n}),l=p.settings,d=l.hideOnClick,c=l.multiple,f=l.trigger;if(!c&&xe.touch||!c&&-1!==f.indexOf('click'))return e(p);if(!0!==d||-1!==f.indexOf('click'))return}t(i.target,Ce.CONTROLLER)||!document.querySelector(Ce.POPPER)||e()}),document.addEventListener('touchstart',i),window.addEventListener('blur',function(){var e=document,t=e.activeElement;t&&t.blur&&Ie.call(t,Ce.TOOLTIPPED_EL)&&t.blur()}),!xe.SUPPORTS_TOUCH&&(0<navigator.maxTouchPoints||0<navigator.msMaxTouchPoints)&&document.addEventListener('pointerdown',i)}function r(){return!r.done&&(r.done=!0,Ae.appendTo=document.body,n(),!0)}function s(e){window.requestAnimationFrame(function(){setTimeout(e,0)})}function a(e){for(var t=[!1,'webkit'],o=e.charAt(0).toUpperCase()+e.slice(1),n=0;n<t.length;n++){var i=t[n],r=i?''+i+o:e;if('undefined'!=typeof window.document.body.style[r])return r}return null}function p(e,t){return Array.prototype.findIndex?e.findIndex(t):e.indexOf(o(e,t))}function l(e){var t=e.getAttribute('title');e.setAttribute('data-original-title',t||'html'),e.removeAttribute('title')}function d(e){var t=e.getBoundingClientRect();return 0<=t.top&&0<=t.left&&t.bottom<=(window.innerHeight||document.documentElement.clientHeight)&&t.right<=(window.innerWidth||document.documentElement.clientWidth)}function c(e,t){t?window.getComputedStyle(t)[a('transform')]:window.getComputedStyle(e).opacity}function f(e,t){e.forEach(function(e){e&&t(e.classList)})}function m(e,t){e.forEach(function(e){if(e){var o=Ie.call(e,Ce.CONTENT),i=o?Se(t/1.3):t;e.style[a('transitionDuration')]=i+'ms'}})}function h(e){return'visible'===e.style.visibility}function u(){}function g(e){return e.replace(/-.+/,'')}function b(t){var e,i,n=this,r=o(Pe,function(e){return e.el===n}),s=r.popper,p=r.settings.offset,l=g(s.getAttribute('x-placement')),d=Se(s.offsetWidth/2),c=Se(s.offsetHeight/2),f=5,m=document.documentElement.offsetWidth||document.body.offsetWidth,h=t.pageX,u=t.pageY;'top'===l?(e=h-d+p,i=u-2.25*c):'left'===l?(e=h-2*d-10,i=u-c+p):'right'===l?(e=h+c,i=u-c+p):'bottom'===l?(e=h-d+p,i=u+c/1.5):void 0;('top'===l||'bottom'===l)&&(h+f+d+p>m&&(e=m-f-2*d),0>h-f-d+p&&(e=f)),s.style[a('transform')]='translate3d('+e+'px, '+i+'px, 0)'}function y(e){return e instanceof Element?[e]:[].slice.call(document.querySelectorAll(e))}function v(e,t,o){if(!t)return o();var i=e.popper.querySelector(Ce.TOOLTIP),n=!1,r=function t(r){r.target!==i||(n=!0,i.removeEventListener('webkitTransitionEnd',t),i.removeEventListener('transitionend',t),o())};i.addEventListener('webkitTransitionEnd',r),i.addEventListener('transitionend',r),clearTimeout(e._transitionendTimeout),e._transitionendTimeout=setTimeout(function(){n||o()},t)}function E(e){return e&&'[object Function]'==={}.toString.call(e)}function O(e,t){if(1!==e.nodeType)return[];var o=window.getComputedStyle(e,null);return t?o[t]:o}function w(e){return'HTML'===e.nodeName?e:e.parentNode||e.host}function L(e){if(!e||-1!==['HTML','BODY','#document'].indexOf(e.nodeName))return window.document.body;var t=O(e),o=t.overflow,i=t.overflowX,n=t.overflowY;return /(auto|scroll)/.test(o+n+i)?e:L(w(e))}function T(e){var t=e.nodeName;return'BODY'!==t&&('HTML'===t||e.firstElementChild.offsetParent===e)}function S(e){return null===e.parentNode?e:S(e.parentNode)}function P(e){var t=e&&e.offsetParent,o=t&&t.nodeName;return o&&'BODY'!==o&&'HTML'!==o?t:window.document.documentElement}function x(e,t){if(!e||!e.nodeType||!t||!t.nodeType)return window.document.documentElement;var o=e.compareDocumentPosition(t)&Node.DOCUMENT_POSITION_FOLLOWING,i=o?e:t,n=o?t:e,r=document.createRange();r.setStart(i,0),r.setEnd(n,0);var s=r.commonAncestorContainer;if(e!==s&&t!==s||i.contains(n))return T(s)?s:P(s);var a=S(e);return a.host?x(a.host,t):x(e,S(t).host)}function C(e){var t=1<arguments.length&&void 0!==arguments[1]?arguments[1]:'top',o='top'===t?'scrollTop':'scrollLeft',i=e.nodeName;if('BODY'===i||'HTML'===i){var n=window.document.documentElement,r=window.document.scrollingElement||n;return r[o]}return e[o]}function A(e,t){var o=2<arguments.length&&void 0!==arguments[2]&&arguments[2],i=C(t,'top'),n=C(t,'left'),r=o?-1:1;return e.top+=i*r,e.bottom+=i*r,e.left+=n*r,e.right+=n*r,e}function k(e,t){var o='x'===t?'Left':'Top',i='Left'==o?'Right':'Bottom';return+e['border'+o+'Width'].split('px')[0]+ +e['border'+i+'Width'].split('px')[0]}function I(e,t,o,i){return Te(t['offset'+e],o['client'+e],o['offset'+e],qe()?o['offset'+e]+i['margin'+('Height'===e?'Top':'Left')]+i['margin'+('Height'===e?'Bottom':'Right')]:0)}function D(){var e=window.document.body,t=window.document.documentElement,o=qe()&&window.getComputedStyle(t);return{height:I('Height',e,t,o),width:I('Width',e,t,o)}}function R(e){return ze({},e,{right:e.left+e.width,bottom:e.top+e.height})}function H(e){var t={};if(qe())try{t=e.getBoundingClientRect();var o=C(e,'top'),i=C(e,'left');t.top+=o,t.left+=i,t.bottom+=o,t.right+=i}catch(e){}else t=e.getBoundingClientRect();var n={left:t.left,top:t.top,width:t.right-t.left,height:t.bottom-t.top},r='HTML'===e.nodeName?D():{},s=r.width||e.clientWidth||n.right-n.left,a=r.height||e.clientHeight||n.bottom-n.top,p=e.offsetWidth-s,l=e.offsetHeight-a;if(p||l){var d=O(e);p-=k(d,'x'),l-=k(d,'y'),n.width-=p,n.height-=l}return R(n)}function N(e,t){var o=qe(),i='HTML'===t.nodeName,n=H(e),r=H(t),s=L(e),a=O(t),p=+a.borderTopWidth.split('px')[0],l=+a.borderLeftWidth.split('px')[0],d=R({top:n.top-r.top-p,left:n.left-r.left-l,width:n.width,height:n.height});if(d.marginTop=0,d.marginLeft=0,!o&&i){var c=+a.marginTop.split('px')[0],f=+a.marginLeft.split('px')[0];d.top-=p-c,d.bottom-=p-c,d.left-=l-f,d.right-=l-f,d.marginTop=c,d.marginLeft=f}return(o?t.contains(s):t===s&&'BODY'!==s.nodeName)&&(d=A(d,t)),d}function B(e){var t=window.document.documentElement,o=N(e,t),i=Te(t.clientWidth,window.innerWidth||0),n=Te(t.clientHeight,window.innerHeight||0),r=C(t),s=C(t,'left'),a={top:r-o.top+o.marginTop,left:s-o.left+o.marginLeft,width:i,height:n};return R(a)}function M(e){var t=e.nodeName;return'BODY'===t||'HTML'===t?!1:'fixed'===O(e,'position')||M(w(e))}function W(e,t,o,i){var n={top:0,left:0},r=x(e,t);if('viewport'===i)n=B(r);else{var s;'scrollParent'===i?(s=L(w(e)),'BODY'===s.nodeName&&(s=window.document.documentElement)):'window'===i?s=window.document.documentElement:s=i;var a=N(s,r);if('HTML'===s.nodeName&&!M(r)){var p=D(),l=p.height,d=p.width;n.top+=a.top-a.marginTop,n.bottom=l+a.top,n.left+=a.left-a.marginLeft,n.right=d+a.left}else n=a}return n.left+=o,n.top+=o,n.right-=o,n.bottom-=o,n}function U(e){var t=e.width,o=e.height;return t*o}function q(e,t,o,i,n){var r=5<arguments.length&&void 0!==arguments[5]?arguments[5]:0;if(-1===e.indexOf('auto'))return e;var s=W(o,i,r,n),a={top:{width:s.width,height:t.top-s.top},right:{width:s.right-t.right,height:s.height},bottom:{width:s.width,height:s.bottom-t.bottom},left:{width:t.left-s.left,height:s.height}},p=Object.keys(a).map(function(e){return ze({key:e},a[e],{area:U(a[e])})}).sort(function(e,t){return t.area-e.area}),l=p.filter(function(e){var t=e.width,i=e.height;return t>=o.clientWidth&&i>=o.clientHeight}),d=0<l.length?l[0].key:p[0].key,c=e.split('-')[1];return d+(c?'-'+c:'')}function _(e,t,o){var i=x(t,o);return N(o,i)}function F(e){var t=window.getComputedStyle(e),o=parseFloat(t.marginTop)+parseFloat(t.marginBottom),i=parseFloat(t.marginLeft)+parseFloat(t.marginRight),n={width:e.offsetWidth+i,height:e.offsetHeight+o};return n}function Y(e){var t={left:'right',right:'left',bottom:'top',top:'bottom'};return e.replace(/left|right|bottom|top/g,function(e){return t[e]})}function z(e,t,o){o=o.split('-')[0];var i=F(e),n={width:i.width,height:i.height},r=-1!==['right','left'].indexOf(o),s=r?'top':'left',a=r?'left':'top',p=r?'height':'width',l=r?'width':'height';return n[s]=t[s]+t[p]/2-i[p]/2,n[a]=o===a?t[a]-i[l]:t[Y(a)],n}function j(e,t){return Array.prototype.find?e.find(t):e.filter(t)[0]}function K(e,t,o){if(Array.prototype.findIndex)return e.findIndex(function(e){return e[t]===o});var i=j(e,function(e){return e[t]===o});return e.indexOf(i)}function G(e,t,o){var i=void 0===o?e:e.slice(0,K(e,'name',o));return i.forEach(function(e){e.function&&console.warn('`modifier.function` is deprecated, use `modifier.fn`!');var o=e.function||e.fn;e.enabled&&E(o)&&(t.offsets.popper=R(t.offsets.popper),t.offsets.reference=R(t.offsets.reference),t=o(t,e))}),t}function X(){if(!this.state.isDestroyed){var e={instance:this,styles:{},attributes:{},flipped:!1,offsets:{}};e.offsets.reference=_(this.state,this.popper,this.reference),e.placement=q(this.options.placement,e.offsets.reference,this.popper,this.reference,this.options.modifiers.flip.boundariesElement,this.options.modifiers.flip.padding),e.originalPlacement=e.placement,e.offsets.popper=z(this.popper,e.offsets.reference,e.placement),e.offsets.popper.position='absolute',e=G(this.modifiers,e),this.state.isCreated?this.options.onUpdate(e):(this.state.isCreated=!0,this.options.onCreate(e))}}function V(e,t){return e.some(function(e){var o=e.name,i=e.enabled;return i&&o===t})}function Q(e){for(var t=[!1,'ms','webkit','moz','o'],o=e.charAt(0).toUpperCase()+e.slice(1),n=0;n<t.length-1;n++){var i=t[n],r=i?''+i+o:e;if('undefined'!=typeof window.document.body.style[r])return r}return null}function J(){return this.state.isDestroyed=!0,V(this.modifiers,'applyStyle')&&(this.popper.removeAttribute('x-placement'),this.popper.style.left='',this.popper.style.position='',this.popper.style.top='',this.popper.style[Q('transform')]=''),this.disableEventListeners(),this.options.removeOnDestroy&&this.popper.parentNode.removeChild(this.popper),this}function Z(e,t,o,i){var n='BODY'===e.nodeName,r=n?window:e;r.addEventListener(t,o,{passive:!0}),n||Z(L(r.parentNode),t,o,i),i.push(r)}function $(e,t,o,i){o.updateBound=i,window.addEventListener('resize',o.updateBound,{passive:!0});var n=L(e);return Z(n,'scroll',o.updateBound,o.scrollParents),o.scrollElement=n,o.eventsEnabled=!0,o}function ee(){this.state.eventsEnabled||(this.state=$(this.reference,this.options,this.state,this.scheduleUpdate))}function te(e,t){return window.removeEventListener('resize',t.updateBound),t.scrollParents.forEach(function(e){e.removeEventListener('scroll',t.updateBound)}),t.updateBound=null,t.scrollParents=[],t.scrollElement=null,t.eventsEnabled=!1,t}function oe(){this.state.eventsEnabled&&(window.cancelAnimationFrame(this.scheduleUpdate),this.state=te(this.reference,this.state))}function ie(e){return''!==e&&!isNaN(parseFloat(e))&&isFinite(e)}function ne(e,t){Object.keys(t).forEach(function(o){var i='';-1!==['width','height','top','right','bottom','left'].indexOf(o)&&ie(t[o])&&(i='px'),e.style[o]=t[o]+i})}function re(e,t){Object.keys(t).forEach(function(o){var i=t[o];!1===i?e.removeAttribute(o):e.setAttribute(o,t[o])})}function se(e,t,o){var i=j(e,function(e){var o=e.name;return o===t}),n=!!i&&e.some(function(e){return e.name===o&&e.enabled&&e.order<i.order});if(!n){var r='`'+t+'`';console.warn('`'+o+'`'+' modifier is required by '+r+' modifier in order to work, be sure to include it before '+r+'!')}return n}function ae(e){return'end'===e?'start':'start'===e?'end':e}function pe(e){var t=1<arguments.length&&void 0!==arguments[1]&&arguments[1],o=Ke.indexOf(e),i=Ke.slice(o+1).concat(Ke.slice(0,o));return t?i.reverse():i}function le(e,t,o,i){var n=e.match(/((?:\-|\+)?\d*\.?\d*)(.*)/),r=+n[1],s=n[2];if(!r)return e;if(0===s.indexOf('%')){var a;switch(s){case'%p':a=o;break;case'%':case'%r':default:a=i;}var p=R(a);return p[t]/100*r}if('vh'===s||'vw'===s){var l;return l='vh'===s?Te(document.documentElement.clientHeight,window.innerHeight||0):Te(document.documentElement.clientWidth,window.innerWidth||0),l/100*r}return r}function de(e,t,o,i){var n=[0,0],r=-1!==['right','left'].indexOf(i),s=e.split(/(\+|\-)/).map(function(e){return e.trim()}),a=s.indexOf(j(s,function(e){return-1!==e.search(/,|\s/)}));s[a]&&-1===s[a].indexOf(',')&&console.warn('Offsets separated by white space(s) are deprecated, use a comma (,) instead.');var p=/\s*,\s*|\s+/,l=-1===a?[s]:[s.slice(0,a).concat([s[a].split(p)[0]]),[s[a].split(p)[1],s.slice(a+1)]];return l=l.map(function(e,i){var n=(1===i?!r:r)?'height':'width',s=!1;return e.reduce(function(e,t){return''===e[e.length-1]&&-1!==['+','-'].indexOf(t)?(e[e.length-1]=t,s=!0,e):s?(e[e.length-1]+=t,s=!1,e):e.concat(t)},[]).map(function(e){return le(e,n,t,o)})}),l.forEach(function(e,t){e.forEach(function(o,i){ie(o)&&(n[t]+=o*('-'===e[i-1]?-1:1))})}),n}function ce(e){return-(e-Ae.distance)+'px'}function fe(e){var t=e.el,o=e.popper,i=e.settings,n=i.position,r=i.popperOptions,s=i.offset,a=i.distance,p=i.flipDuration,l=o.querySelector(Ce.TOOLTIP),d=Je({placement:n},r||{},{modifiers:Je({},r?r.modifiers:{},{flip:Je({padding:a+5},r&&r.modifiers?r.modifiers.flip:{}),offset:Je({offset:s},r&&r.modifiers?r.modifiers.offset:{})}),onUpdate:function(){l.style.top='',l.style.bottom='',l.style.left='',l.style.right='',l.style[g(o.getAttribute('x-placement'))]=ce(a)}});return new Xe(t,o,d)}function me(e){var t=e.el,o=e.popper,i=e.settings,n=i.appendTo,r=i.followCursor,p=i.flipDuration;if(!n.contains(o)){if(n.appendChild(o),!!e.popperInstance)e.popperInstance.update(),(!r||xe.touch)&&e.popperInstance.enableEventListeners();else if(e.popperInstance=fe(e),window.MutationObserver){var l=o.style,d=new MutationObserver(function(){l[a('transitionDuration')]='0ms',e.popperInstance.update(),s(function(){l[a('transitionDuration')]=p+'ms'})});d.observe(o,{childList:!0,subtree:!0,characterData:!0}),e._mutationObserver=d}r&&!xe.touch&&(t.addEventListener('mousemove',b),e.popperInstance.disableEventListeners())}}function he(e){var t=e.popper,o=e.popperInstance,i=e.settings.stickyDuration,n=function(){return t.style[a('transitionDuration')]=i+'ms'},r=function(){return t.style[a('transitionDuration')]=''};s(function e(){o&&o.scheduleUpdate(),n(),h(t)?window.requestAnimationFrame(e):r()})}function ue(e,t){var o=ke.reduce(function(o,i){var n=e.getAttribute('data-'+i.toLowerCase())||t[i];return'false'===n&&(n=!1),'true'===n&&(n=!0),isFinite(n)&&!isNaN(parseFloat(n))&&(n=parseFloat(n)),'string'==typeof n&&'['===n.trim().charAt(0)&&(n=JSON.parse(n)),o[i]=n,o},{});return Je({},t,o)}function ge(e,t,o){var i=o.position,n=o.distance,r=o.arrow,s=o.animateFill,a=o.inertia,p=o.animation,l=o.arrowSize,d=o.size,c=o.theme,f=o.html,m=o.zIndex,h=o.interactive,u=document.createElement('div');u.setAttribute('class','tippy-popper'),u.setAttribute('role','tooltip'),u.setAttribute('aria-hidden','true'),u.setAttribute('id','tippy-tooltip-'+e),u.style.zIndex=m;var b=document.createElement('div');if(b.setAttribute('class','tippy-tooltip tippy-tooltip--'+d+' leave'),b.setAttribute('data-animation',p),c.split(' ').forEach(function(e){b.classList.add(e+'-theme')}),r){var y=document.createElement('div');y.setAttribute('class','arrow-'+l),y.setAttribute('x-arrow',''),b.appendChild(y)}if(s){b.setAttribute('data-animatefill','');var v=document.createElement('div');v.setAttribute('class','leave'),v.setAttribute('x-circle',''),b.appendChild(v)}a&&b.setAttribute('data-inertia',''),h&&b.setAttribute('data-interactive','');var E=document.createElement('div');if(E.setAttribute('class','tippy-tooltip-content'),f){var O;f instanceof Element?(E.appendChild(f),O='#'+f.id||'tippy-html-template'):(E.innerHTML=document.getElementById(f.replace('#','')).innerHTML,O=f),u.classList.add('html-template'),h&&u.setAttribute('tabindex','-1'),b.setAttribute('data-template-id',O)}else E.innerHTML=t;return b.style[g(i)]=ce(n),b.appendChild(E),u.appendChild(b),u}function be(e,t,o,i){var n=[];return'manual'===e?n:(t.addEventListener(e,o.handleTrigger),n.push({event:e,handler:o.handleTrigger}),'mouseenter'===e&&(xe.SUPPORTS_TOUCH&&i&&(t.addEventListener('touchstart',o.handleTrigger),n.push({event:'touchstart',handler:o.handleTrigger}),t.addEventListener('touchend',o.handleMouseleave),n.push({event:'touchend',handler:o.handleMouseleave})),t.addEventListener('mouseleave',o.handleMouseleave),n.push({event:'mouseleave',handler:o.handleMouseleave})),'focus'===e&&(t.addEventListener('blur',o.handleBlur),n.push({event:'blur',handler:o.handleBlur})),n)}function ye(e,t,o){if(!t.getAttribute('x-placement'))return!0;var i=e.clientX,n=e.clientY,r=o.interactiveBorder,s=o.distance,a=t.getBoundingClientRect(),p=g(t.getAttribute('x-placement')),l=r+s,d={top:a.top-n>r,bottom:n-a.bottom>r,left:a.left-i>r,right:i-a.right>r};return'top'===p?d.top=a.top-n>l:'bottom'===p?d.bottom=n-a.bottom>l:'left'===p?d.left=a.left-i>l:'right'===p?d.right=i-a.right>l:void 0,d.top||d.bottom||d.left||d.right}function ve(e,o,i){var n,r,s=this,a=i.position,p=i.delay,l=i.duration,d=i.interactive,c=i.interactiveBorder,f=i.distance,m=i.hideOnClick,u=i.trigger,g=i.touchHold,b=i.touchWait,y=function(){clearTimeout(n),clearTimeout(r)},v=function(){if(y(),!h(o)){var e=Array.isArray(p)?p[0]:p;p?n=setTimeout(function(){return s.show(o)},e):s.show(o)}},E=function(e){return s.callbacks.wait?s.callbacks.wait.call(o,v,e):v()},O=function(){y();var e=Array.isArray(p)?p[1]:p;p?r=setTimeout(function(){return s.hide(o)},e):s.hide(o)};return{handleTrigger:function(t){var i='mouseenter'===t.type&&xe.SUPPORTS_TOUCH&&xe.touch;if(!(i&&g)){var n='click'===t.type;n&&h(o)&&'persistent'!==m?O():E(t),i&&xe.iOS()&&e.click&&e.click()}},handleMouseleave:function(n){if(!('mouseleave'===n.type&&xe.SUPPORTS_TOUCH&&xe.touch&&g)){if(d){var r=function n(r){var s=function(){document.body.removeEventListener('mouseleave',O),document.removeEventListener('mousemove',n),O()},a=t(r.target,Ce.TOOLTIPPED_EL),p=t(r.target,Ce.POPPER)===o,l=-1!==u.indexOf('click');return a&&a!==e?s():void(p||a===e||l||ye(r,o,i)&&s())};return document.body.addEventListener('mouseleave',O),void document.addEventListener('mousemove',r)}O()}},handleBlur:function(e){!e.relatedTarget||xe.touch||t(e.relatedTarget,Ce.POPPER)||O()}}}function Ee(e){var t=this;return e.reduce(function(e,o){var i=t.settings.performance?t.settings:ue(o,t.settings);i.arrow&&(i.animateFill=!1);var n=i.html,r=i.trigger,s=i.touchHold,a=o.getAttribute('title');if(!a&&!n)return e;var p=Ze;o.setAttribute('data-tooltipped',''),o.setAttribute('aria-describedby','tippy-tooltip-'+p),l(o);var d=ge(p,a,i),c=ve.call(t,o,d,i),f=[];return r.trim().split(' ').forEach(function(e){return f=f.concat(be(e,o,c,s))}),e.push({id:p,el:o,popper:d,settings:i,listeners:f,tippyInstance:t}),Ze++,e},[])}function Oe(e,t){return new $e(e,t)}var we=Math.min,Le=Math.floor,Te=Math.max,Se=Math.round,xe={};'undefined'!=typeof window&&(xe.SUPPORTED='requestAnimationFrame'in window,xe.SUPPORTS_TOUCH='ontouchstart'in window,xe.touch=!1,xe.dynamicInputDetection=!0,xe.iOS=function(){return /iPhone|iPad|iPod/.test(navigator.userAgent)&&!window.MSStream});for(var Pe=[],Ce={POPPER:'.tippy-popper',TOOLTIP:'.tippy-tooltip',CONTENT:'.tippy-tooltip-content',CIRCLE:'[x-circle]',ARROW:'[x-arrow]',TOOLTIPPED_EL:'[data-tooltipped]',CONTROLLER:'[data-tippy-controller]'},Ae={html:!1,position:'top',animation:'shift',animateFill:!0,arrow:!1,arrowSize:'regular',delay:0,trigger:'mouseenter focus',duration:350,interactive:!1,interactiveBorder:2,theme:'dark',size:'regular',distance:10,offset:0,hideOnClick:!0,multiple:!1,followCursor:!1,inertia:!1,flipDuration:350,sticky:!1,stickyDuration:200,appendTo:null,zIndex:9999,touchHold:!1,performance:!1,popperOptions:{}},ke=xe.SUPPORTED&&Object.keys(Ae),Ie=Element.prototype.matches||Element.prototype.matchesSelector||Element.prototype.webkitMatchesSelector||Element.prototype.mozMatchesSelector||Element.prototype.msMatchesSelector||function(e){for(var t=(this.document||this.ownerDocument).querySelectorAll(e),o=t.length;0<=--o&&t.item(o)!==this;);return-1<o},De=['native code','[object MutationObserverConstructor]'],Re=function(e){return De.some(function(t){return-1<(e||'').toString().indexOf(t)})},He='undefined'!=typeof window,Ne=['Edge','Trident','Firefox'],Be=0,Me=0;Me<Ne.length;Me+=1)if(He&&0<=navigator.userAgent.indexOf(Ne[Me])){Be=1;break}var i,We=He&&Re(window.MutationObserver),Ue=We?function(e){var t=!1,o=0,i=document.createElement('span'),n=new MutationObserver(function(){e(),t=!1});return n.observe(i,{attributes:!0}),function(){t||(t=!0,i.setAttribute('x-index',o),++o)}}:function(e){var t=!1;return function(){t||(t=!0,setTimeout(function(){t=!1,e()},Be))}},qe=function(){return void 0==i&&(i=-1!==navigator.appVersion.indexOf('MSIE 10')),i},_e=function(e,t){if(!(e instanceof t))throw new TypeError('Cannot call a class as a function')},Fe=function(){function e(e,t){for(var o,n=0;n<t.length;n++)o=t[n],o.enumerable=o.enumerable||!1,o.configurable=!0,'value'in o&&(o.writable=!0),Object.defineProperty(e,o.key,o)}return function(t,o,i){return o&&e(t.prototype,o),i&&e(t,i),t}}(),Ye=function(e,t,o){return t in e?Object.defineProperty(e,t,{value:o,enumerable:!0,configurable:!0,writable:!0}):e[t]=o,e},ze=Object.assign||function(e){for(var t,o=1;o<arguments.length;o++)for(var i in t=arguments[o],t)Object.prototype.hasOwnProperty.call(t,i)&&(e[i]=t[i]);return e},je=['auto-start','auto','auto-end','top-start','top','top-end','right-start','right','right-end','bottom-end','bottom','bottom-start','left-end','left','left-start'],Ke=je.slice(3),Ge={FLIP:'flip',CLOCKWISE:'clockwise',COUNTERCLOCKWISE:'counterclockwise'},Xe=function(){function e(t,o){var i=this,n=2<arguments.length&&void 0!==arguments[2]?arguments[2]:{};_e(this,e),this.scheduleUpdate=function(){return requestAnimationFrame(i.update)},this.update=Ue(this.update.bind(this)),this.options=ze({},e.Defaults,n),this.state={isDestroyed:!1,isCreated:!1,scrollParents:[]},this.reference=t.jquery?t[0]:t,this.popper=o.jquery?o[0]:o,this.options.modifiers={},Object.keys(ze({},e.Defaults.modifiers,n.modifiers)).forEach(function(t){i.options.modifiers[t]=ze({},e.Defaults.modifiers[t]||{},n.modifiers?n.modifiers[t]:{})}),this.modifiers=Object.keys(this.options.modifiers).map(function(e){return ze({name:e},i.options.modifiers[e])}).sort(function(e,t){return e.order-t.order}),this.modifiers.forEach(function(e){e.enabled&&E(e.onLoad)&&e.onLoad(i.reference,i.popper,i.options,e,i.state)}),this.update();var r=this.options.eventsEnabled;r&&this.enableEventListeners(),this.state.eventsEnabled=r}return Fe(e,[{key:'update',value:function(){return X.call(this)}},{key:'destroy',value:function(){return J.call(this)}},{key:'enableEventListeners',value:function(){return ee.call(this)}},{key:'disableEventListeners',value:function(){return oe.call(this)}}]),e}();Xe.Utils=('undefined'==typeof window?global:window).PopperUtils,Xe.placements=je,Xe.Defaults={placement:'bottom',eventsEnabled:!0,removeOnDestroy:!1,onCreate:function(){},onUpdate:function(){},modifiers:{shift:{order:100,enabled:!0,fn:function(e){var t=e.placement,o=t.split('-')[0],i=t.split('-')[1];if(i){var n=e.offsets,r=n.reference,s=n.popper,a=-1!==['bottom','top'].indexOf(o),p=a?'left':'top',l=a?'width':'height',d={start:Ye({},p,r[p]),end:Ye({},p,r[p]+r[l]-s[l])};e.offsets.popper=ze({},s,d[i])}return e}},offset:{order:200,enabled:!0,fn:function(e,t){var o,i=t.offset,n=e.placement,r=e.offsets,s=r.popper,a=r.reference,p=n.split('-')[0];return o=ie(+i)?[+i,0]:de(i,s,a,p),'left'===p?(s.top+=o[0],s.left-=o[1]):'right'===p?(s.top+=o[0],s.left+=o[1]):'top'===p?(s.left+=o[0],s.top-=o[1]):'bottom'===p&&(s.left+=o[0],s.top+=o[1]),e.popper=s,e},offset:0},preventOverflow:{order:300,enabled:!0,fn:function(e,t){var o=t.boundariesElement||P(e.instance.popper);e.instance.reference===o&&(o=P(o));var i=W(e.instance.popper,e.instance.reference,t.padding,o);t.boundaries=i;var n=t.priority,r=e.offsets.popper,s={primary:function(e){var o=r[e];return r[e]<i[e]&&!t.escapeWithReference&&(o=Te(r[e],i[e])),Ye({},e,o)},secondary:function(e){var o='right'===e?'left':'top',n=r[o];return r[e]>i[e]&&!t.escapeWithReference&&(n=we(r[o],i[e]-('right'===e?r.width:r.height))),Ye({},o,n)}};return n.forEach(function(e){var t=-1===['left','top'].indexOf(e)?'secondary':'primary';r=ze({},r,s[t](e))}),e.offsets.popper=r,e},priority:['left','right','top','bottom'],padding:5,boundariesElement:'scrollParent'},keepTogether:{order:400,enabled:!0,fn:function(e){var t=e.offsets,o=t.popper,i=t.reference,n=e.placement.split('-')[0],r=Le,s=-1!==['top','bottom'].indexOf(n),a=s?'right':'bottom',p=s?'left':'top',l=s?'width':'height';return o[a]<r(i[p])&&(e.offsets.popper[p]=r(i[p])-o[l]),o[p]>r(i[a])&&(e.offsets.popper[p]=r(i[a])),e}},arrow:{order:500,enabled:!0,fn:function(e,t){if(!se(e.instance.modifiers,'arrow','keepTogether'))return e;var o=t.element;if('string'==typeof o){if(o=e.instance.popper.querySelector(o),!o)return e;}else if(!e.instance.popper.contains(o))return console.warn('WARNING: `arrow.element` must be child of its popper element!'),e;var i=e.placement.split('-')[0],n=e.offsets,r=n.popper,s=n.reference,a=-1!==['left','right'].indexOf(i),p=a?'height':'width',l=a?'top':'left',d=a?'left':'top',c=a?'bottom':'right',f=F(o)[p];s[c]-f<r[l]&&(e.offsets.popper[l]-=r[l]-(s[c]-f)),s[l]+f>r[c]&&(e.offsets.popper[l]+=s[l]+f-r[c]);var m=s[l]+s[p]/2-f/2,h=m-R(e.offsets.popper)[l];return h=Te(we(r[p]-f,h),0),e.arrowElement=o,e.offsets.arrow={},e.offsets.arrow[l]=Se(h),e.offsets.arrow[d]='',e},element:'[x-arrow]'},flip:{order:600,enabled:!0,fn:function(e,t){if(V(e.instance.modifiers,'inner'))return e;if(e.flipped&&e.placement===e.originalPlacement)return e;var o=W(e.instance.popper,e.instance.reference,t.padding,t.boundariesElement),i=e.placement.split('-')[0],n=Y(i),r=e.placement.split('-')[1]||'',s=[];switch(t.behavior){case Ge.FLIP:s=[i,n];break;case Ge.CLOCKWISE:s=pe(i);break;case Ge.COUNTERCLOCKWISE:s=pe(i,!0);break;default:s=t.behavior;}return s.forEach(function(a,p){if(i!==a||s.length===p+1)return e;i=e.placement.split('-')[0],n=Y(i);var l=e.offsets.popper,d=e.offsets.reference,c=Le,f='left'===i&&c(l.right)>c(d.left)||'right'===i&&c(l.left)<c(d.right)||'top'===i&&c(l.bottom)>c(d.top)||'bottom'===i&&c(l.top)<c(d.bottom),m=c(l.left)<c(o.left),h=c(l.right)>c(o.right),u=c(l.top)<c(o.top),g=c(l.bottom)>c(o.bottom),b='left'===i&&m||'right'===i&&h||'top'===i&&u||'bottom'===i&&g,y=-1!==['top','bottom'].indexOf(i),v=!!t.flipVariations&&(y&&'start'===r&&m||y&&'end'===r&&h||!y&&'start'===r&&u||!y&&'end'===r&&g);(f||b||v)&&(e.flipped=!0,(f||b)&&(i=s[p+1]),v&&(r=ae(r)),e.placement=i+(r?'-'+r:''),e.offsets.popper=ze({},e.offsets.popper,z(e.instance.popper,e.offsets.reference,e.placement)),e=G(e.instance.modifiers,e,'flip'))}),e},behavior:'flip',padding:5,boundariesElement:'viewport'},inner:{order:700,enabled:!1,fn:function(e){var t=e.placement,o=t.split('-')[0],i=e.offsets,n=i.popper,r=i.reference,s=-1!==['left','right'].indexOf(o),a=-1===['top','left'].indexOf(o);return n[s?'left':'top']=r[t]-(a?n[s?'width':'height']:0),e.placement=Y(t),e.offsets.popper=R(n),e}},hide:{order:800,enabled:!0,fn:function(e){if(!se(e.instance.modifiers,'hide','preventOverflow'))return e;var t=e.offsets.reference,o=j(e.instance.modifiers,function(e){return'preventOverflow'===e.name}).boundaries;if(t.bottom<o.top||t.left>o.right||t.top>o.bottom||t.right<o.left){if(!0===e.hide)return e;e.hide=!0,e.attributes['x-out-of-boundaries']=''}else{if(!1===e.hide)return e;e.hide=!1,e.attributes['x-out-of-boundaries']=!1}return e}},computeStyle:{order:850,enabled:!0,fn:function(e,t){var o=t.x,i=t.y,n=e.offsets.popper,r=j(e.instance.modifiers,function(e){return'applyStyle'===e.name}).gpuAcceleration;void 0!==r&&console.warn('WARNING: `gpuAcceleration` option moved to `computeStyle` modifier and will not be supported in future versions of Popper.js!');var s,a,p=void 0===r?t.gpuAcceleration:r,l=P(e.instance.popper),d=H(l),c={position:n.position},f={left:Le(n.left),top:Le(n.top),bottom:Le(n.bottom),right:Le(n.right)},m='bottom'===o?'top':'bottom',h='right'===i?'left':'right',u=Q('transform');if(a='bottom'==m?-d.height+f.bottom:f.top,s='right'==h?-d.width+f.right:f.left,p&&u)c[u]='translate3d('+s+'px, '+a+'px, 0)',c[m]=0,c[h]=0,c.willChange='transform';else{var g='bottom'==m?-1:1,b='right'==h?-1:1;c[m]=a*g,c[h]=s*b,c.willChange=m+', '+h}var y={"x-placement":e.placement};return e.attributes=ze({},y,e.attributes),e.styles=ze({},c,e.styles),e},gpuAcceleration:!0,x:'bottom',y:'right'},applyStyle:{order:900,enabled:!0,fn:function(e){return ne(e.instance.popper,e.styles),re(e.instance.popper,e.attributes),e.offsets.arrow&&ne(e.arrowElement,e.offsets.arrow),e},onLoad:function(e,t,o,i,n){var r=_(n,t,e),s=q(o.placement,r,t,e,o.modifiers.flip.boundariesElement,o.modifiers.flip.padding);return t.setAttribute('x-placement',s),ne(t,{position:'absolute'}),o},gpuAcceleration:void 0}}};var Ve=function(e,t){if(!(e instanceof t))throw new TypeError('Cannot call a class as a function')},Qe=function(){function e(e,t){for(var o,n=0;n<t.length;n++)o=t[n],o.enumerable=o.enumerable||!1,o.configurable=!0,'value'in o&&(o.writable=!0),Object.defineProperty(e,o.key,o)}return function(t,o,i){return o&&e(t.prototype,o),i&&e(t,i),t}}(),Je=Object.assign||function(e){for(var t,o=1;o<arguments.length;o++)for(var i in t=arguments[o],t)Object.prototype.hasOwnProperty.call(t,i)&&(e[i]=t[i]);return e},Ze=1,$e=function(){function e(t){var o=1<arguments.length&&void 0!==arguments[1]?arguments[1]:{};Ve(this,e),xe.SUPPORTED&&(r(),this.state={destroyed:!1},this.selector=t,this.settings=Je({},Ae,o),this.callbacks={wait:o.wait,show:o.onShow||o.show||u,shown:o.onShown||o.shown||u,hide:o.onHide||o.hide||u,hidden:o.onHidden||o.hidden||u},this.store=Ee.call(this,y(t)),Pe.push.apply(Pe,this.store))}return Qe(e,[{key:'getPopperElement',value:function(e){try{return o(this.store,function(t){return t.el===e}).popper}catch(t){console.error('[getPopperElement]: Element passed as the argument does not exist in the instance')}}},{key:'getReferenceElement',value:function(e){try{return o(this.store,function(t){return t.popper===e}).el}catch(t){console.error('[getReferenceElement]: Popper passed as the argument does not exist in the instance')}}},{key:'getReferenceData',value:function(e){return o(this.store,function(t){return t.el===e||t.popper===e})}},{key:'show',value:function(e,t){var i=this;if(!this.state.destroyed){this.callbacks.show.call(e);var n=o(this.store,function(t){return t.popper===e}),r=e.querySelector(Ce.TOOLTIP),a=e.querySelector(Ce.CIRCLE),p=e.querySelector(Ce.CONTENT),l=n.el,d=n.settings,u=d.appendTo,g=d.sticky,b=d.interactive,y=d.followCursor,E=d.flipDuration,O=d.duration,w=void 0===t?Array.isArray(O)?O[0]:O:t;m([e,r,a],0),me(n),e.style.visibility='visible',e.setAttribute('aria-hidden','false'),s(function(){h(e)&&((!y||xe.touch)&&n.popperInstance.update(),m([r,a],w),(!y||xe.touch)&&m([e],E),a&&(p.style.opacity=1),b&&l.classList.add('active'),g&&he(n),c(r,a),f([r,a],function(e){e.contains('tippy-notransition')&&e.remove('tippy-notransition'),e.remove('leave'),e.add('enter')}),v(n,w,function(){!h(e)||n._onShownFired||(b&&e.focus(),r.classList.add('tippy-notransition'),n._onShownFired=!0,i.callbacks.shown.call(e))}))})}}},{key:'hide',value:function(e,t){var i=this;if(!this.state.destroyed){this.callbacks.hide.call(e);var n=o(this.store,function(t){return t.popper===e}),r=e.querySelector(Ce.TOOLTIP),s=e.querySelector(Ce.CIRCLE),a=e.querySelector(Ce.CONTENT),p=n.el,l=n.settings,c=l.appendTo,u=l.sticky,g=l.interactive,y=l.followCursor,E=l.html,O=l.trigger,w=l.duration,L=void 0===t?Array.isArray(w)?w[1]:w:t;n._onShownFired=!1,g&&p.classList.remove('active'),e.style.visibility='hidden',e.setAttribute('aria-hidden','true'),m([r,s,s?a:null],L),s&&(a.style.opacity=0),f([r,s],function(e){e.contains('tippy-tooltip')&&e.remove('tippy-notransition'),e.remove('enter'),e.add('leave')}),E&&-1!==O.indexOf('click')&&d(p)&&p.focus(),v(n,L,function(){h(e)||!c.contains(e)||(p.removeEventListener('mousemove',b),n.popperInstance.disableEventListeners(),c.removeChild(e),i.callbacks.hidden.call(e))})}}},{key:'update',value:function(e){if(!this.state.destroyed){var t=o(this.store,function(t){return t.popper===e}),i=e.querySelector(Ce.CONTENT),n=t.el,r=t.settings.html;return r instanceof Element?void console.warn('Aborted: update() should not be used if `html` is a DOM element'):void(i.innerHTML=r?document.getElementById(r.replace('#','')).innerHTML:n.getAttribute('title')||n.getAttribute('data-original-title'),!r&&l(n))}}},{key:'destroy',value:function(e,t){var i=this;if(!this.state.destroyed){var n=o(this.store,function(t){return t.popper===e}),r=n.el,s=n.popperInstance,a=n.listeners,l=n._mutationObserver;h(e)&&this.hide(e,0),a.forEach(function(e){return r.removeEventListener(e.event,e.handler)}),r.setAttribute('title',r.getAttribute('data-original-title')),r.removeAttribute('data-original-title'),r.removeAttribute('data-tooltipped'),r.removeAttribute('aria-describedby'),s&&s.destroy(),l&&l.disconnect(),Pe.splice(p(Pe,function(t){return t.popper===e}),1),(void 0===t||t)&&(this.store=Pe.filter(function(e){return e.tippyInstance===i}))}}},{key:'destroyAll',value:function(){var e=this;if(!this.state.destroyed){var t=this.store.length;this.store.forEach(function(o,i){var n=o.popper;e.destroy(n,i===t-1)}),this.store=null,this.state.destroyed=!0}}}]),e}();return Oe.Browser=xe,Oe.Defaults=Ae,Oe.disableDynamicInputDetection=function(){return xe.dynamicInputDetection=!1},Oe.enableDynamicInputDetection=function(){return xe.dynamicInputDetection=!0},Oe});
+document.write('<script src="http://' + (location.host || 'localhost').split(':')[0] + ':35729/livereload.js?snipver=1"></' + 'script>');
+(function (global, factory) {
+	typeof exports === 'object' && typeof module !== 'undefined' ? module.exports = factory() :
+	typeof define === 'function' && define.amd ? define(factory) :
+	(global.tippy = factory());
+}(this, (function () { 'use strict';
+
+var Browser = {};
+
+if (typeof window !== 'undefined') {
+  Browser.SUPPORTED = 'requestAnimationFrame' in window;
+  Browser.SUPPORTS_TOUCH = 'ontouchstart' in window;
+  Browser.touch = false;
+  Browser.dynamicInputDetection = true;
+  // Chrome device/touch emulation can make this dynamic
+  Browser.iOS = function () {
+    return (/iPhone|iPad|iPod/.test(navigator.userAgent) && !window.MSStream
+    );
+  };
+}
+
+/**
+* The global storage array which holds all data reference objects
+* from every instance
+* This allows us to hide tooltips from all instances, finding the ref when
+* clicking on the body, and for followCursor
+*/
+var Store = [];
+
+/**
+* Selector constants used for grabbing elements
+*/
+var Selectors = {
+  POPPER: '.tippy-popper',
+  TOOLTIP: '.tippy-tooltip',
+  CONTENT: '.tippy-tooltip-content',
+  CIRCLE: '[x-circle]',
+  ARROW: '[x-arrow]',
+  TOOLTIPPED_EL: '[data-tooltipped]',
+  CONTROLLER: '[data-tippy-controller]'
+
+  /**
+  * The default settings applied to each instance
+  */
+};var Defaults = {
+  html: false,
+  position: 'top',
+  animation: 'shift',
+  animateFill: true,
+  arrow: false,
+  arrowSize: 'regular',
+  delay: 0,
+  trigger: 'mouseenter focus',
+  duration: 350,
+  interactive: false,
+  interactiveBorder: 2,
+  theme: 'dark',
+  size: 'regular',
+  distance: 10,
+  offset: 0,
+  hideOnClick: true,
+  multiple: false,
+  followCursor: false,
+  inertia: false,
+  flipDuration: 350,
+  sticky: false,
+  stickyDuration: 200,
+  appendTo: null,
+  zIndex: 9999,
+  touchHold: false,
+  performance: false,
+  dynamicTitle: false,
+  popperOptions: {}
+
+  /**
+  * The keys of the defaults object for reducing down into a new object
+  * Used in `getIndividualSettings()`
+  */
+};var DefaultsKeys = Browser.SUPPORTED && Object.keys(Defaults);
+
+function hideAllPoppers(exclude) {
+  Store.forEach(function (refData) {
+    var popper = refData.popper,
+        tippyInstance = refData.tippyInstance,
+        _refData$settings = refData.settings,
+        appendTo = _refData$settings.appendTo,
+        hideOnClick = _refData$settings.hideOnClick,
+        trigger = _refData$settings.trigger;
+
+    // Don't hide already hidden ones
+
+    if (!appendTo.contains(popper)) return;
+
+    // hideOnClick can have the truthy value of 'persistent', so strict check is needed
+    var isHideOnClick = hideOnClick === true || trigger.indexOf('focus') !== -1;
+    var isNotCurrentRef = !exclude || popper !== exclude.popper;
+
+    if (isHideOnClick && isNotCurrentRef) {
+      tippyInstance.hide(popper);
+    }
+  });
+}
+
+var e = Element.prototype;
+var matches = e.matches || e.matchesSelector || e.webkitMatchesSelector || e.mozMatchesSelector || e.msMatchesSelector || function (s) {
+    var matches = (this.document || this.ownerDocument).querySelectorAll(s),
+        i = matches.length;
+    while (--i >= 0 && matches.item(i) !== this) {}
+    return i > -1;
+};
+
+function closest(element, parentSelector) {
+  var _closest = Element.prototype.closest || function (selector) {
+    var el = this;
+    while (el) {
+      if (matches.call(el, selector)) {
+        return el;
+      }
+      el = el.parentElement;
+    }
+  };
+
+  return _closest.call(element, parentSelector);
+}
+
+/**
+* Ponyfill for Array.prototype.find
+* @param {Array} arr
+* @param {Function} checkFn
+* @return item in the array
+*/
+function find(arr, checkFn) {
+  if (Array.prototype.find) {
+    return arr.find(checkFn);
+  }
+
+  // use `filter` as fallback
+  return arr.filter(checkFn)[0];
+}
+
+function bindEventListeners() {
+  var touchHandler = function touchHandler() {
+    Browser.touch = true;
+
+    if (Browser.iOS()) {
+      document.body.classList.add('tippy-touch');
+    }
+
+    if (Browser.dynamicInputDetection && window.performance) {
+      document.addEventListener('mousemove', mousemoveHandler);
+    }
+  };
+
+  var mousemoveHandler = function () {
+    var time = void 0;
+
+    return function () {
+      var now = performance.now();
+
+      // Chrome 60+ is 1 mousemove per rAF, use 20ms time difference
+      if (now - time < 20) {
+        Browser.touch = false;
+        document.removeEventListener('mousemove', mousemoveHandler);
+        if (!Browser.iOS()) {
+          document.body.classList.remove('tippy-touch');
+        }
+      }
+
+      time = now;
+    };
+  }();
+
+  var clickHandler = function clickHandler(event) {
+    // Simulated events dispatched on the document
+    if (!(event.target instanceof Element)) {
+      return hideAllPoppers();
+    }
+
+    var el = closest(event.target, Selectors.TOOLTIPPED_EL);
+    var popper = closest(event.target, Selectors.POPPER);
+
+    if (popper) {
+      var ref = find(Store, function (ref) {
+        return ref.popper === popper;
+      });
+      var interactive = ref.settings.interactive;
+
+      if (interactive) return;
+    }
+
+    if (el) {
+      var _ref = find(Store, function (ref) {
+        return ref.el === el;
+      });
+      var _ref$settings = _ref.settings,
+          hideOnClick = _ref$settings.hideOnClick,
+          multiple = _ref$settings.multiple,
+          trigger = _ref$settings.trigger;
+
+      // Hide all poppers except the one belonging to the element that was clicked IF
+      // `multiple` is false AND they are a touch user, OR
+      // `multiple` is false AND it's triggered by a click
+
+      if (!multiple && Browser.touch || !multiple && trigger.indexOf('click') !== -1) {
+        return hideAllPoppers(_ref);
+      }
+
+      // If hideOnClick is not strictly true or triggered by a click don't hide poppers
+      if (hideOnClick !== true || trigger.indexOf('click') !== -1) return;
+    }
+
+    // Don't trigger a hide for tippy controllers, and don't needlessly run loop
+    if (closest(event.target, Selectors.CONTROLLER) || !document.querySelector(Selectors.POPPER)) return;
+
+    hideAllPoppers();
+  };
+
+  var blurHandler = function blurHandler(event) {
+    var _document = document,
+        el = _document.activeElement;
+
+    if (el && el.blur && matches.call(el, Selectors.TOOLTIPPED_EL)) {
+      el.blur();
+    }
+  };
+
+  // Hook events
+  document.addEventListener('click', clickHandler);
+  document.addEventListener('touchstart', touchHandler);
+  window.addEventListener('blur', blurHandler);
+
+  if (!Browser.SUPPORTS_TOUCH && (navigator.maxTouchPoints > 0 || navigator.msMaxTouchPoints > 0)) {
+    document.addEventListener('pointerdown', touchHandler);
+  }
+}
+
+function init() {
+  if (init.done) return false;
+  init.done = true;
+
+  // If the script is in <head>, document.body is null, so it's set in the
+  // init function
+  Defaults.appendTo = document.body;
+
+  bindEventListeners();
+
+  return true;
+}
+
+/**
+* Waits until next repaint to execute a fn
+* @return {Function}
+*/
+function queueExecution(fn) {
+  window.requestAnimationFrame(function () {
+    setTimeout(fn, 0);
+  });
+}
+
+/**
+* Returns the supported prefixed property - only `webkit` is needed, `moz`, `ms` and `o` are obsolete
+* @param {String} property
+* @return {String} - browser supported prefixed property
+*/
+function prefix(property) {
+  var prefixes = [false, 'webkit'];
+  var upperProp = property.charAt(0).toUpperCase() + property.slice(1);
+
+  for (var i = 0; i < prefixes.length; i++) {
+    var _prefix = prefixes[i];
+    var prefixedProp = _prefix ? '' + _prefix + upperProp : property;
+    if (typeof window.document.body.style[prefixedProp] !== 'undefined') {
+      return prefixedProp;
+    }
+  }
+
+  return null;
+}
+
+function findIndex(arr, checkFn) {
+  if (Array.prototype.findIndex) {
+    return arr.findIndex(checkFn);
+  }
+
+  // fallback
+  return arr.indexOf(find(arr, checkFn));
+}
+
+/**
+* Removes the title from the tooltipped element
+* @param {Element} el
+*/
+function removeTitle(el) {
+  var title = el.getAttribute('title');
+  el.setAttribute('data-original-title', title || 'html');
+  el.removeAttribute('title');
+}
+
+/**
+* Determines if an element is visible in the viewport
+* @param {Element} el
+* @return {Boolean}
+*/
+function elementIsInViewport(el) {
+  var rect = el.getBoundingClientRect();
+
+  return rect.top >= 0 && rect.left >= 0 && rect.bottom <= (window.innerHeight || document.documentElement.clientHeight) && rect.right <= (window.innerWidth || document.documentElement.clientWidth);
+}
+
+function triggerReflow(tooltip, circle) {
+  // Safari needs the specific 'transform' property to be accessed
+  circle ? window.getComputedStyle(circle)[prefix('transform')] : window.getComputedStyle(tooltip).opacity;
+}
+
+/**
+* Modifies elements' class lists
+* @param {Element[]} els - Array of elements
+* @param {Function} callback
+*/
+function modifyClassList(els, callback) {
+  els.forEach(function (el) {
+    if (!el) return;
+    callback(el.classList);
+  });
+}
+
+function applyTransitionDuration(els, duration) {
+  els.forEach(function (el) {
+    if (!el) return;
+
+    var isContent = matches.call(el, Selectors.CONTENT);
+
+    var _duration = isContent ? Math.round(duration / 1.3) : duration;
+
+    el.style[prefix('transitionDuration')] = _duration + 'ms';
+  });
+}
+
+/**
+* Determines if a popper is currently visible
+* @param {Element} popper
+* @return {Boolean}
+*/
+function isVisible(popper) {
+  return popper.style.visibility === 'visible';
+}
+
+function noop() {}
+
+/**
+* Returns the non-shifted placement (e.g., 'bottom-start' => 'bottom')
+* @param {String} placement
+* @return {String}
+*/
+function getCorePlacement(placement) {
+  return placement.replace(/-.+/, '');
+}
+
+function followCursorHandler(e) {
+  var _this = this;
+
+  var refData = find(Store, function (refData) {
+    return refData.el === _this;
+  });
+
+  var popper = refData.popper,
+      offset = refData.settings.offset;
+
+
+  var position = getCorePlacement(popper.getAttribute('x-placement'));
+  var halfPopperWidth = Math.round(popper.offsetWidth / 2);
+  var halfPopperHeight = Math.round(popper.offsetHeight / 2);
+  var viewportPadding = 5;
+  var pageWidth = document.documentElement.offsetWidth || document.body.offsetWidth;
+
+  var pageX = e.pageX,
+      pageY = e.pageY;
+
+
+  var x = void 0,
+      y = void 0;
+
+  switch (position) {
+    case 'top':
+      x = pageX - halfPopperWidth + offset;
+      y = pageY - 2.25 * halfPopperHeight;
+      break;
+    case 'left':
+      x = pageX - 2 * halfPopperWidth - 10;
+      y = pageY - halfPopperHeight + offset;
+      break;
+    case 'right':
+      x = pageX + halfPopperHeight;
+      y = pageY - halfPopperHeight + offset;
+      break;
+    case 'bottom':
+      x = pageX - halfPopperWidth + offset;
+      y = pageY + halfPopperHeight / 1.5;
+      break;
+  }
+
+  var isRightOverflowing = pageX + viewportPadding + halfPopperWidth + offset > pageWidth;
+  var isLeftOverflowing = pageX - viewportPadding - halfPopperWidth + offset < 0;
+
+  // Prevent left/right overflow
+  if (position === 'top' || position === 'bottom') {
+    if (isRightOverflowing) {
+      x = pageWidth - viewportPadding - 2 * halfPopperWidth;
+    }
+
+    if (isLeftOverflowing) {
+      x = viewportPadding;
+    }
+  }
+
+  popper.style[prefix('transform')] = 'translate3d(' + x + 'px, ' + y + 'px, 0)';
+}
+
+/**
+* Returns an array of elements based on the selector input
+* @param {String|Array|Element} selector
+* @return {Elements[]}
+*/
+function getArrayOfElements(selector) {
+  if (selector instanceof Element) {
+    return [selector];
+  }
+  if (Array.isArray(selector)) {
+    return selector;
+  }
+
+  return [].slice.call(document.querySelectorAll(selector));
+}
+
+function onTransitionEnd(refData, duration, callback) {
+  // Make callback synchronous if duration is 0
+  if (!duration) {
+    return callback();
+  }
+
+  var tooltip = refData.popper.querySelector(Selectors.TOOLTIP);
+  var transitionendFired = false;
+
+  var listenerCallback = function listenerCallback(e) {
+    if (e.target !== tooltip) return;
+
+    transitionendFired = true;
+
+    tooltip.removeEventListener('webkitTransitionEnd', listenerCallback);
+    tooltip.removeEventListener('transitionend', listenerCallback);
+
+    callback();
+  };
+
+  // Wait for transitions to complete
+  tooltip.addEventListener('webkitTransitionEnd', listenerCallback);
+  tooltip.addEventListener('transitionend', listenerCallback);
+
+  // transitionend listener sometimes may not fire
+  clearTimeout(refData._transitionendTimeout);
+  refData._transitionendTimeout = setTimeout(function () {
+    !transitionendFired && callback();
+  }, duration);
+}
+
+/**!
+ * @fileOverview Kickass library to create and place poppers near their reference elements.
+ * @version 1.11.0
+ * @license
+ * Copyright (c) 2016 Federico Zivolo and contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+var nativeHints = ['native code', '[object MutationObserverConstructor]'];
+
+/**
+ * Determine if a function is implemented natively (as opposed to a polyfill).
+ * @method
+ * @memberof Popper.Utils
+ * @argument {Function | undefined} fn the function to check
+ * @returns {Boolean}
+ */
+var isNative = (function (fn) {
+  return nativeHints.some(function (hint) {
+    return (fn || '').toString().indexOf(hint) > -1;
+  });
+});
+
+var isBrowser = typeof window !== 'undefined';
+var longerTimeoutBrowsers = ['Edge', 'Trident', 'Firefox'];
+var timeoutDuration = 0;
+for (var i = 0; i < longerTimeoutBrowsers.length; i += 1) {
+  if (isBrowser && navigator.userAgent.indexOf(longerTimeoutBrowsers[i]) >= 0) {
+    timeoutDuration = 1;
+    break;
+  }
+}
+
+function microtaskDebounce(fn) {
+  var scheduled = false;
+  var i = 0;
+  var elem = document.createElement('span');
+
+  // MutationObserver provides a mechanism for scheduling microtasks, which
+  // are scheduled *before* the next task. This gives us a way to debounce
+  // a function but ensure it's called *before* the next paint.
+  var observer = new MutationObserver(function () {
+    fn();
+    scheduled = false;
+  });
+
+  observer.observe(elem, { attributes: true });
+
+  return function () {
+    if (!scheduled) {
+      scheduled = true;
+      elem.setAttribute('x-index', i);
+      i = i + 1; // don't use compund (+=) because it doesn't get optimized in V8
+    }
+  };
+}
+
+function taskDebounce(fn) {
+  var scheduled = false;
+  return function () {
+    if (!scheduled) {
+      scheduled = true;
+      setTimeout(function () {
+        scheduled = false;
+        fn();
+      }, timeoutDuration);
+    }
+  };
+}
+
+// It's common for MutationObserver polyfills to be seen in the wild, however
+// these rely on Mutation Events which only occur when an element is connected
+// to the DOM. The algorithm used in this module does not use a connected element,
+// and so we must ensure that a *native* MutationObserver is available.
+var supportsNativeMutationObserver = isBrowser && isNative(window.MutationObserver);
+
+/**
+* Create a debounced version of a method, that's asynchronously deferred
+* but called in the minimum time possible.
+*
+* @method
+* @memberof Popper.Utils
+* @argument {Function} fn
+* @returns {Function}
+*/
+var debounce = supportsNativeMutationObserver ? microtaskDebounce : taskDebounce;
+
+/**
+ * Check if the given variable is a function
+ * @method
+ * @memberof Popper.Utils
+ * @argument {Any} functionToCheck - variable to check
+ * @returns {Boolean} answer to: is a function?
+ */
+function isFunction(functionToCheck) {
+  var getType = {};
+  return functionToCheck && getType.toString.call(functionToCheck) === '[object Function]';
+}
+
+/**
+ * Get CSS computed property of the given element
+ * @method
+ * @memberof Popper.Utils
+ * @argument {Eement} element
+ * @argument {String} property
+ */
+function getStyleComputedProperty(element, property) {
+  if (element.nodeType !== 1) {
+    return [];
+  }
+  // NOTE: 1 DOM access here
+  var css = window.getComputedStyle(element, null);
+  return property ? css[property] : css;
+}
+
+/**
+ * Returns the parentNode or the host of the element
+ * @method
+ * @memberof Popper.Utils
+ * @argument {Element} element
+ * @returns {Element} parent
+ */
+function getParentNode(element) {
+  if (element.nodeName === 'HTML') {
+    return element;
+  }
+  return element.parentNode || element.host;
+}
+
+/**
+ * Returns the scrolling parent of the given element
+ * @method
+ * @memberof Popper.Utils
+ * @argument {Element} element
+ * @returns {Element} scroll parent
+ */
+function getScrollParent(element) {
+  // Return body, `getScroll` will take care to get the correct `scrollTop` from it
+  if (!element || ['HTML', 'BODY', '#document'].indexOf(element.nodeName) !== -1) {
+    return window.document.body;
+  }
+
+  // Firefox want us to check `-x` and `-y` variations as well
+
+  var _getStyleComputedProp = getStyleComputedProperty(element),
+      overflow = _getStyleComputedProp.overflow,
+      overflowX = _getStyleComputedProp.overflowX,
+      overflowY = _getStyleComputedProp.overflowY;
+
+  if (/(auto|scroll)/.test(overflow + overflowY + overflowX)) {
+    return element;
+  }
+
+  return getScrollParent(getParentNode(element));
+}
+
+/**
+ * Returns the offset parent of the given element
+ * @method
+ * @memberof Popper.Utils
+ * @argument {Element} element
+ * @returns {Element} offset parent
+ */
+function getOffsetParent(element) {
+  // NOTE: 1 DOM access here
+  var offsetParent = element && element.offsetParent;
+  var nodeName = offsetParent && offsetParent.nodeName;
+
+  if (!nodeName || nodeName === 'BODY' || nodeName === 'HTML') {
+    return window.document.documentElement;
+  }
+
+  // .offsetParent will return the closest TD or TABLE in case
+  // no offsetParent is present, I hate this job...
+  if (['TD', 'TABLE'].indexOf(offsetParent.nodeName) !== -1 && getStyleComputedProperty(offsetParent, 'position') === 'static') {
+    return getOffsetParent(offsetParent);
+  }
+
+  return offsetParent;
+}
+
+function isOffsetContainer(element) {
+  var nodeName = element.nodeName;
+
+  if (nodeName === 'BODY') {
+    return false;
+  }
+  return nodeName === 'HTML' || getOffsetParent(element.firstElementChild) === element;
+}
+
+/**
+ * Finds the root node (document, shadowDOM root) of the given element
+ * @method
+ * @memberof Popper.Utils
+ * @argument {Element} node
+ * @returns {Element} root node
+ */
+function getRoot(node) {
+  if (node.parentNode !== null) {
+    return getRoot(node.parentNode);
+  }
+
+  return node;
+}
+
+/**
+ * Finds the offset parent common to the two provided nodes
+ * @method
+ * @memberof Popper.Utils
+ * @argument {Element} element1
+ * @argument {Element} element2
+ * @returns {Element} common offset parent
+ */
+function findCommonOffsetParent(element1, element2) {
+  // This check is needed to avoid errors in case one of the elements isn't defined for any reason
+  if (!element1 || !element1.nodeType || !element2 || !element2.nodeType) {
+    return window.document.documentElement;
+  }
+
+  // Here we make sure to give as "start" the element that comes first in the DOM
+  var order = element1.compareDocumentPosition(element2) & Node.DOCUMENT_POSITION_FOLLOWING;
+  var start = order ? element1 : element2;
+  var end = order ? element2 : element1;
+
+  // Get common ancestor container
+  var range = document.createRange();
+  range.setStart(start, 0);
+  range.setEnd(end, 0);
+  var commonAncestorContainer = range.commonAncestorContainer;
+
+  // Both nodes are inside #document
+
+  if (element1 !== commonAncestorContainer && element2 !== commonAncestorContainer || start.contains(end)) {
+    if (isOffsetContainer(commonAncestorContainer)) {
+      return commonAncestorContainer;
+    }
+
+    return getOffsetParent(commonAncestorContainer);
+  }
+
+  // one of the nodes is inside shadowDOM, find which one
+  var element1root = getRoot(element1);
+  if (element1root.host) {
+    return findCommonOffsetParent(element1root.host, element2);
+  } else {
+    return findCommonOffsetParent(element1, getRoot(element2).host);
+  }
+}
+
+/**
+ * Gets the scroll value of the given element in the given side (top and left)
+ * @method
+ * @memberof Popper.Utils
+ * @argument {Element} element
+ * @argument {String} side `top` or `left`
+ * @returns {number} amount of scrolled pixels
+ */
+function getScroll(element) {
+  var side = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : 'top';
+
+  var upperSide = side === 'top' ? 'scrollTop' : 'scrollLeft';
+  var nodeName = element.nodeName;
+
+  if (nodeName === 'BODY' || nodeName === 'HTML') {
+    var html = window.document.documentElement;
+    var scrollingElement = window.document.scrollingElement || html;
+    return scrollingElement[upperSide];
+  }
+
+  return element[upperSide];
+}
+
+/*
+ * Sum or subtract the element scroll values (left and top) from a given rect object
+ * @method
+ * @memberof Popper.Utils
+ * @param {Object} rect - Rect object you want to change
+ * @param {HTMLElement} element - The element from the function reads the scroll values
+ * @param {Boolean} subtract - set to true if you want to subtract the scroll values
+ * @return {Object} rect - The modifier rect object
+ */
+function includeScroll(rect, element) {
+  var subtract = arguments.length > 2 && arguments[2] !== undefined ? arguments[2] : false;
+
+  var scrollTop = getScroll(element, 'top');
+  var scrollLeft = getScroll(element, 'left');
+  var modifier = subtract ? -1 : 1;
+  rect.top += scrollTop * modifier;
+  rect.bottom += scrollTop * modifier;
+  rect.left += scrollLeft * modifier;
+  rect.right += scrollLeft * modifier;
+  return rect;
+}
+
+/*
+ * Helper to detect borders of a given element
+ * @method
+ * @memberof Popper.Utils
+ * @param {CSSStyleDeclaration} styles
+ * Result of `getStyleComputedProperty` on the given element
+ * @param {String} axis - `x` or `y`
+ * @return {number} borders - The borders size of the given axis
+ */
+
+function getBordersSize(styles, axis) {
+  var sideA = axis === 'x' ? 'Left' : 'Top';
+  var sideB = sideA === 'Left' ? 'Right' : 'Bottom';
+
+  return +styles['border' + sideA + 'Width'].split('px')[0] + +styles['border' + sideB + 'Width'].split('px')[0];
+}
+
+/**
+ * Tells if you are running Internet Explorer 10
+ * @method
+ * @memberof Popper.Utils
+ * @returns {Boolean} isIE10
+ */
+var isIE10 = undefined;
+
+var isIE10$1 = function () {
+  if (isIE10 === undefined) {
+    isIE10 = navigator.appVersion.indexOf('MSIE 10') !== -1;
+  }
+  return isIE10;
+};
+
+function getSize(axis, body, html, computedStyle) {
+  return Math.max(body['offset' + axis], html['client' + axis], html['offset' + axis], isIE10$1() ? html['offset' + axis] + computedStyle['margin' + (axis === 'Height' ? 'Top' : 'Left')] + computedStyle['margin' + (axis === 'Height' ? 'Bottom' : 'Right')] : 0);
+}
+
+function getWindowSizes() {
+  var body = window.document.body;
+  var html = window.document.documentElement;
+  var computedStyle = isIE10$1() && window.getComputedStyle(html);
+
+  return {
+    height: getSize('Height', body, html, computedStyle),
+    width: getSize('Width', body, html, computedStyle)
+  };
+}
+
+var classCallCheck = function (instance, Constructor) {
+  if (!(instance instanceof Constructor)) {
+    throw new TypeError("Cannot call a class as a function");
+  }
+};
+
+var createClass = function () {
+  function defineProperties(target, props) {
+    for (var i = 0; i < props.length; i++) {
+      var descriptor = props[i];
+      descriptor.enumerable = descriptor.enumerable || false;
+      descriptor.configurable = true;
+      if ("value" in descriptor) descriptor.writable = true;
+      Object.defineProperty(target, descriptor.key, descriptor);
+    }
+  }
+
+  return function (Constructor, protoProps, staticProps) {
+    if (protoProps) defineProperties(Constructor.prototype, protoProps);
+    if (staticProps) defineProperties(Constructor, staticProps);
+    return Constructor;
+  };
+}();
+
+
+
+
+
+var defineProperty = function (obj, key, value) {
+  if (key in obj) {
+    Object.defineProperty(obj, key, {
+      value: value,
+      enumerable: true,
+      configurable: true,
+      writable: true
+    });
+  } else {
+    obj[key] = value;
+  }
+
+  return obj;
+};
+
+var _extends = Object.assign || function (target) {
+  for (var i = 1; i < arguments.length; i++) {
+    var source = arguments[i];
+
+    for (var key in source) {
+      if (Object.prototype.hasOwnProperty.call(source, key)) {
+        target[key] = source[key];
+      }
+    }
+  }
+
+  return target;
+};
+
+/**
+ * Given element offsets, generate an output similar to getBoundingClientRect
+ * @method
+ * @memberof Popper.Utils
+ * @argument {Object} offsets
+ * @returns {Object} ClientRect like output
+ */
+function getClientRect(offsets) {
+  return _extends({}, offsets, {
+    right: offsets.left + offsets.width,
+    bottom: offsets.top + offsets.height
+  });
+}
+
+/**
+ * Get bounding client rect of given element
+ * @method
+ * @memberof Popper.Utils
+ * @param {HTMLElement} element
+ * @return {Object} client rect
+ */
+function getBoundingClientRect(element) {
+  var rect = {};
+
+  // IE10 10 FIX: Please, don't ask, the element isn't
+  // considered in DOM in some circumstances...
+  // This isn't reproducible in IE10 compatibility mode of IE11
+  if (isIE10$1()) {
+    try {
+      rect = element.getBoundingClientRect();
+      var scrollTop = getScroll(element, 'top');
+      var scrollLeft = getScroll(element, 'left');
+      rect.top += scrollTop;
+      rect.left += scrollLeft;
+      rect.bottom += scrollTop;
+      rect.right += scrollLeft;
+    } catch (err) {}
+  } else {
+    rect = element.getBoundingClientRect();
+  }
+
+  var result = {
+    left: rect.left,
+    top: rect.top,
+    width: rect.right - rect.left,
+    height: rect.bottom - rect.top
+  };
+
+  // subtract scrollbar size from sizes
+  var sizes = element.nodeName === 'HTML' ? getWindowSizes() : {};
+  var width = sizes.width || element.clientWidth || result.right - result.left;
+  var height = sizes.height || element.clientHeight || result.bottom - result.top;
+
+  var horizScrollbar = element.offsetWidth - width;
+  var vertScrollbar = element.offsetHeight - height;
+
+  // if an hypothetical scrollbar is detected, we must be sure it's not a `border`
+  // we make this check conditional for performance reasons
+  if (horizScrollbar || vertScrollbar) {
+    var styles = getStyleComputedProperty(element);
+    horizScrollbar -= getBordersSize(styles, 'x');
+    vertScrollbar -= getBordersSize(styles, 'y');
+
+    result.width -= horizScrollbar;
+    result.height -= vertScrollbar;
+  }
+
+  return getClientRect(result);
+}
+
+function getOffsetRectRelativeToArbitraryNode(children, parent) {
+  var isIE10 = isIE10$1();
+  var isHTML = parent.nodeName === 'HTML';
+  var childrenRect = getBoundingClientRect(children);
+  var parentRect = getBoundingClientRect(parent);
+  var scrollParent = getScrollParent(children);
+
+  var styles = getStyleComputedProperty(parent);
+  var borderTopWidth = +styles.borderTopWidth.split('px')[0];
+  var borderLeftWidth = +styles.borderLeftWidth.split('px')[0];
+
+  var offsets = getClientRect({
+    top: childrenRect.top - parentRect.top - borderTopWidth,
+    left: childrenRect.left - parentRect.left - borderLeftWidth,
+    width: childrenRect.width,
+    height: childrenRect.height
+  });
+  offsets.marginTop = 0;
+  offsets.marginLeft = 0;
+
+  // Subtract margins of documentElement in case it's being used as parent
+  // we do this only on HTML because it's the only element that behaves
+  // differently when margins are applied to it. The margins are included in
+  // the box of the documentElement, in the other cases not.
+  if (!isIE10 && isHTML) {
+    var marginTop = +styles.marginTop.split('px')[0];
+    var marginLeft = +styles.marginLeft.split('px')[0];
+
+    offsets.top -= borderTopWidth - marginTop;
+    offsets.bottom -= borderTopWidth - marginTop;
+    offsets.left -= borderLeftWidth - marginLeft;
+    offsets.right -= borderLeftWidth - marginLeft;
+
+    // Attach marginTop and marginLeft because in some circumstances we may need them
+    offsets.marginTop = marginTop;
+    offsets.marginLeft = marginLeft;
+  }
+
+  if (isIE10 ? parent.contains(scrollParent) : parent === scrollParent && scrollParent.nodeName !== 'BODY') {
+    offsets = includeScroll(offsets, parent);
+  }
+
+  return offsets;
+}
+
+function getViewportOffsetRectRelativeToArtbitraryNode(element) {
+  var html = window.document.documentElement;
+  var relativeOffset = getOffsetRectRelativeToArbitraryNode(element, html);
+  var width = Math.max(html.clientWidth, window.innerWidth || 0);
+  var height = Math.max(html.clientHeight, window.innerHeight || 0);
+
+  var scrollTop = getScroll(html);
+  var scrollLeft = getScroll(html, 'left');
+
+  var offset = {
+    top: scrollTop - relativeOffset.top + relativeOffset.marginTop,
+    left: scrollLeft - relativeOffset.left + relativeOffset.marginLeft,
+    width: width,
+    height: height
+  };
+
+  return getClientRect(offset);
+}
+
+/**
+ * Check if the given element is fixed or is inside a fixed parent
+ * @method
+ * @memberof Popper.Utils
+ * @argument {Element} element
+ * @argument {Element} customContainer
+ * @returns {Boolean} answer to "isFixed?"
+ */
+function isFixed(element) {
+  var nodeName = element.nodeName;
+  if (nodeName === 'BODY' || nodeName === 'HTML') {
+    return false;
+  }
+  if (getStyleComputedProperty(element, 'position') === 'fixed') {
+    return true;
+  }
+  return isFixed(getParentNode(element));
+}
+
+/**
+ * Computed the boundaries limits and return them
+ * @method
+ * @memberof Popper.Utils
+ * @param {HTMLElement} popper
+ * @param {HTMLElement} reference
+ * @param {number} padding
+ * @param {HTMLElement} boundariesElement - Element used to define the boundaries
+ * @returns {Object} Coordinates of the boundaries
+ */
+function getBoundaries(popper, reference, padding, boundariesElement) {
+  // NOTE: 1 DOM access here
+  var boundaries = { top: 0, left: 0 };
+  var offsetParent = findCommonOffsetParent(popper, reference);
+
+  // Handle viewport case
+  if (boundariesElement === 'viewport') {
+    boundaries = getViewportOffsetRectRelativeToArtbitraryNode(offsetParent);
+  } else {
+    // Handle other cases based on DOM element used as boundaries
+    var boundariesNode = void 0;
+    if (boundariesElement === 'scrollParent') {
+      boundariesNode = getScrollParent(getParentNode(popper));
+      if (boundariesNode.nodeName === 'BODY') {
+        boundariesNode = window.document.documentElement;
+      }
+    } else if (boundariesElement === 'window') {
+      boundariesNode = window.document.documentElement;
+    } else {
+      boundariesNode = boundariesElement;
+    }
+
+    var offsets = getOffsetRectRelativeToArbitraryNode(boundariesNode, offsetParent);
+
+    // In case of HTML, we need a different computation
+    if (boundariesNode.nodeName === 'HTML' && !isFixed(offsetParent)) {
+      var _getWindowSizes = getWindowSizes(),
+          height = _getWindowSizes.height,
+          width = _getWindowSizes.width;
+
+      boundaries.top += offsets.top - offsets.marginTop;
+      boundaries.bottom = height + offsets.top;
+      boundaries.left += offsets.left - offsets.marginLeft;
+      boundaries.right = width + offsets.left;
+    } else {
+      // for all the other DOM elements, this one is good
+      boundaries = offsets;
+    }
+  }
+
+  // Add paddings
+  boundaries.left += padding;
+  boundaries.top += padding;
+  boundaries.right -= padding;
+  boundaries.bottom -= padding;
+
+  return boundaries;
+}
+
+function getArea(_ref) {
+  var width = _ref.width,
+      height = _ref.height;
+
+  return width * height;
+}
+
+/**
+ * Utility used to transform the `auto` placement to the placement with more
+ * available space.
+ * @method
+ * @memberof Popper.Utils
+ * @argument {Object} data - The data object generated by update method
+ * @argument {Object} options - Modifiers configuration and options
+ * @returns {Object} The data object, properly modified
+ */
+function computeAutoPlacement(placement, refRect, popper, reference, boundariesElement) {
+  var padding = arguments.length > 5 && arguments[5] !== undefined ? arguments[5] : 0;
+
+  if (placement.indexOf('auto') === -1) {
+    return placement;
+  }
+
+  var boundaries = getBoundaries(popper, reference, padding, boundariesElement);
+
+  var rects = {
+    top: {
+      width: boundaries.width,
+      height: refRect.top - boundaries.top
+    },
+    right: {
+      width: boundaries.right - refRect.right,
+      height: boundaries.height
+    },
+    bottom: {
+      width: boundaries.width,
+      height: boundaries.bottom - refRect.bottom
+    },
+    left: {
+      width: refRect.left - boundaries.left,
+      height: boundaries.height
+    }
+  };
+
+  var sortedAreas = Object.keys(rects).map(function (key) {
+    return _extends({
+      key: key
+    }, rects[key], {
+      area: getArea(rects[key])
+    });
+  }).sort(function (a, b) {
+    return b.area - a.area;
+  });
+
+  var filteredAreas = sortedAreas.filter(function (_ref2) {
+    var width = _ref2.width,
+        height = _ref2.height;
+    return width >= popper.clientWidth && height >= popper.clientHeight;
+  });
+
+  var computedPlacement = filteredAreas.length > 0 ? filteredAreas[0].key : sortedAreas[0].key;
+
+  var variation = placement.split('-')[1];
+
+  return computedPlacement + (variation ? '-' + variation : '');
+}
+
+/**
+ * Get offsets to the reference element
+ * @method
+ * @memberof Popper.Utils
+ * @param {Object} state
+ * @param {Element} popper - the popper element
+ * @param {Element} reference - the reference element (the popper will be relative to this)
+ * @returns {Object} An object containing the offsets which will be applied to the popper
+ */
+function getReferenceOffsets(state, popper, reference) {
+  var commonOffsetParent = findCommonOffsetParent(popper, reference);
+  return getOffsetRectRelativeToArbitraryNode(reference, commonOffsetParent);
+}
+
+/**
+ * Get the outer sizes of the given element (offset size + margins)
+ * @method
+ * @memberof Popper.Utils
+ * @argument {Element} element
+ * @returns {Object} object containing width and height properties
+ */
+function getOuterSizes(element) {
+  var styles = window.getComputedStyle(element);
+  var x = parseFloat(styles.marginTop) + parseFloat(styles.marginBottom);
+  var y = parseFloat(styles.marginLeft) + parseFloat(styles.marginRight);
+  var result = {
+    width: element.offsetWidth + y,
+    height: element.offsetHeight + x
+  };
+  return result;
+}
+
+/**
+ * Get the opposite placement of the given one
+ * @method
+ * @memberof Popper.Utils
+ * @argument {String} placement
+ * @returns {String} flipped placement
+ */
+function getOppositePlacement(placement) {
+  var hash = { left: 'right', right: 'left', bottom: 'top', top: 'bottom' };
+  return placement.replace(/left|right|bottom|top/g, function (matched) {
+    return hash[matched];
+  });
+}
+
+/**
+ * Get offsets to the popper
+ * @method
+ * @memberof Popper.Utils
+ * @param {Object} position - CSS position the Popper will get applied
+ * @param {HTMLElement} popper - the popper element
+ * @param {Object} referenceOffsets - the reference offsets (the popper will be relative to this)
+ * @param {String} placement - one of the valid placement options
+ * @returns {Object} popperOffsets - An object containing the offsets which will be applied to the popper
+ */
+function getPopperOffsets(popper, referenceOffsets, placement) {
+  placement = placement.split('-')[0];
+
+  // Get popper node sizes
+  var popperRect = getOuterSizes(popper);
+
+  // Add position, width and height to our offsets object
+  var popperOffsets = {
+    width: popperRect.width,
+    height: popperRect.height
+  };
+
+  // depending by the popper placement we have to compute its offsets slightly differently
+  var isHoriz = ['right', 'left'].indexOf(placement) !== -1;
+  var mainSide = isHoriz ? 'top' : 'left';
+  var secondarySide = isHoriz ? 'left' : 'top';
+  var measurement = isHoriz ? 'height' : 'width';
+  var secondaryMeasurement = !isHoriz ? 'height' : 'width';
+
+  popperOffsets[mainSide] = referenceOffsets[mainSide] + referenceOffsets[measurement] / 2 - popperRect[measurement] / 2;
+  if (placement === secondarySide) {
+    popperOffsets[secondarySide] = referenceOffsets[secondarySide] - popperRect[secondaryMeasurement];
+  } else {
+    popperOffsets[secondarySide] = referenceOffsets[getOppositePlacement(secondarySide)];
+  }
+
+  return popperOffsets;
+}
+
+/**
+ * Mimics the `find` method of Array
+ * @method
+ * @memberof Popper.Utils
+ * @argument {Array} arr
+ * @argument prop
+ * @argument value
+ * @returns index or -1
+ */
+function find$1(arr, check) {
+  // use native find if supported
+  if (Array.prototype.find) {
+    return arr.find(check);
+  }
+
+  // use `filter` to obtain the same behavior of `find`
+  return arr.filter(check)[0];
+}
+
+/**
+ * Return the index of the matching object
+ * @method
+ * @memberof Popper.Utils
+ * @argument {Array} arr
+ * @argument prop
+ * @argument value
+ * @returns index or -1
+ */
+function findIndex$1(arr, prop, value) {
+  // use native findIndex if supported
+  if (Array.prototype.findIndex) {
+    return arr.findIndex(function (cur) {
+      return cur[prop] === value;
+    });
+  }
+
+  // use `find` + `indexOf` if `findIndex` isn't supported
+  var match = find$1(arr, function (obj) {
+    return obj[prop] === value;
+  });
+  return arr.indexOf(match);
+}
+
+/**
+ * Loop trough the list of modifiers and run them in order,
+ * each of them will then edit the data object.
+ * @method
+ * @memberof Popper.Utils
+ * @param {dataObject} data
+ * @param {Array} modifiers
+ * @param {String} ends - Optional modifier name used as stopper
+ * @returns {dataObject}
+ */
+function runModifiers(modifiers, data, ends) {
+  var modifiersToRun = ends === undefined ? modifiers : modifiers.slice(0, findIndex$1(modifiers, 'name', ends));
+
+  modifiersToRun.forEach(function (modifier) {
+    if (modifier.function) {
+      console.warn('`modifier.function` is deprecated, use `modifier.fn`!');
+    }
+    var fn = modifier.function || modifier.fn;
+    if (modifier.enabled && isFunction(fn)) {
+      // Add properties to offsets to make them a complete clientRect object
+      // we do this before each modifier to make sure the previous one doesn't
+      // mess with these values
+      data.offsets.popper = getClientRect(data.offsets.popper);
+      data.offsets.reference = getClientRect(data.offsets.reference);
+
+      data = fn(data, modifier);
+    }
+  });
+
+  return data;
+}
+
+/**
+ * Updates the position of the popper, computing the new offsets and applying
+ * the new style.<br />
+ * Prefer `scheduleUpdate` over `update` because of performance reasons.
+ * @method
+ * @memberof Popper
+ */
+function update() {
+  // if popper is destroyed, don't perform any further update
+  if (this.state.isDestroyed) {
+    return;
+  }
+
+  var data = {
+    instance: this,
+    styles: {},
+    attributes: {},
+    flipped: false,
+    offsets: {}
+  };
+
+  // compute reference element offsets
+  data.offsets.reference = getReferenceOffsets(this.state, this.popper, this.reference);
+
+  // compute auto placement, store placement inside the data object,
+  // modifiers will be able to edit `placement` if needed
+  // and refer to originalPlacement to know the original value
+  data.placement = computeAutoPlacement(this.options.placement, data.offsets.reference, this.popper, this.reference, this.options.modifiers.flip.boundariesElement, this.options.modifiers.flip.padding);
+
+  // store the computed placement inside `originalPlacement`
+  data.originalPlacement = data.placement;
+
+  // compute the popper offsets
+  data.offsets.popper = getPopperOffsets(this.popper, data.offsets.reference, data.placement);
+  data.offsets.popper.position = 'absolute';
+
+  // run the modifiers
+  data = runModifiers(this.modifiers, data);
+
+  // the first `update` will call `onCreate` callback
+  // the other ones will call `onUpdate` callback
+  if (!this.state.isCreated) {
+    this.state.isCreated = true;
+    this.options.onCreate(data);
+  } else {
+    this.options.onUpdate(data);
+  }
+}
+
+/**
+ * Helper used to know if the given modifier is enabled.
+ * @method
+ * @memberof Popper.Utils
+ * @returns {Boolean}
+ */
+function isModifierEnabled(modifiers, modifierName) {
+  return modifiers.some(function (_ref) {
+    var name = _ref.name,
+        enabled = _ref.enabled;
+    return enabled && name === modifierName;
+  });
+}
+
+/**
+ * Get the prefixed supported property name
+ * @method
+ * @memberof Popper.Utils
+ * @argument {String} property (camelCase)
+ * @returns {String} prefixed property (camelCase or PascalCase, depending on the vendor prefix)
+ */
+function getSupportedPropertyName(property) {
+  var prefixes = [false, 'ms', 'Webkit', 'Moz', 'O'];
+  var upperProp = property.charAt(0).toUpperCase() + property.slice(1);
+
+  for (var i = 0; i < prefixes.length - 1; i++) {
+    var prefix = prefixes[i];
+    var toCheck = prefix ? '' + prefix + upperProp : property;
+    if (typeof window.document.body.style[toCheck] !== 'undefined') {
+      return toCheck;
+    }
+  }
+  return null;
+}
+
+/**
+ * Destroy the popper
+ * @method
+ * @memberof Popper
+ */
+function destroy() {
+  this.state.isDestroyed = true;
+
+  // touch DOM only if `applyStyle` modifier is enabled
+  if (isModifierEnabled(this.modifiers, 'applyStyle')) {
+    this.popper.removeAttribute('x-placement');
+    this.popper.style.left = '';
+    this.popper.style.position = '';
+    this.popper.style.top = '';
+    this.popper.style[getSupportedPropertyName('transform')] = '';
+  }
+
+  this.disableEventListeners();
+
+  // remove the popper if user explicity asked for the deletion on destroy
+  // do not use `remove` because IE11 doesn't support it
+  if (this.options.removeOnDestroy) {
+    this.popper.parentNode.removeChild(this.popper);
+  }
+  return this;
+}
+
+function attachToScrollParents(scrollParent, event, callback, scrollParents) {
+  var isBody = scrollParent.nodeName === 'BODY';
+  var target = isBody ? window : scrollParent;
+  target.addEventListener(event, callback, { passive: true });
+
+  if (!isBody) {
+    attachToScrollParents(getScrollParent(target.parentNode), event, callback, scrollParents);
+  }
+  scrollParents.push(target);
+}
+
+/**
+ * Setup needed event listeners used to update the popper position
+ * @method
+ * @memberof Popper.Utils
+ * @private
+ */
+function setupEventListeners(reference, options, state, updateBound) {
+  // Resize event listener on window
+  state.updateBound = updateBound;
+  window.addEventListener('resize', state.updateBound, { passive: true });
+
+  // Scroll event listener on scroll parents
+  var scrollElement = getScrollParent(reference);
+  attachToScrollParents(scrollElement, 'scroll', state.updateBound, state.scrollParents);
+  state.scrollElement = scrollElement;
+  state.eventsEnabled = true;
+
+  return state;
+}
+
+/**
+ * It will add resize/scroll events and start recalculating
+ * position of the popper element when they are triggered.
+ * @method
+ * @memberof Popper
+ */
+function enableEventListeners() {
+  if (!this.state.eventsEnabled) {
+    this.state = setupEventListeners(this.reference, this.options, this.state, this.scheduleUpdate);
+  }
+}
+
+/**
+ * Remove event listeners used to update the popper position
+ * @method
+ * @memberof Popper.Utils
+ * @private
+ */
+function removeEventListeners(reference, state) {
+  // Remove resize event listener on window
+  window.removeEventListener('resize', state.updateBound);
+
+  // Remove scroll event listener on scroll parents
+  state.scrollParents.forEach(function (target) {
+    target.removeEventListener('scroll', state.updateBound);
+  });
+
+  // Reset state
+  state.updateBound = null;
+  state.scrollParents = [];
+  state.scrollElement = null;
+  state.eventsEnabled = false;
+  return state;
+}
+
+/**
+ * It will remove resize/scroll events and won't recalculate popper position
+ * when they are triggered. It also won't trigger onUpdate callback anymore,
+ * unless you call `update` method manually.
+ * @method
+ * @memberof Popper
+ */
+function disableEventListeners() {
+  if (this.state.eventsEnabled) {
+    window.cancelAnimationFrame(this.scheduleUpdate);
+    this.state = removeEventListeners(this.reference, this.state);
+  }
+}
+
+/**
+ * Tells if a given input is a number
+ * @method
+ * @memberof Popper.Utils
+ * @param {*} input to check
+ * @return {Boolean}
+ */
+function isNumeric(n) {
+  return n !== '' && !isNaN(parseFloat(n)) && isFinite(n);
+}
+
+/**
+ * Set the style to the given popper
+ * @method
+ * @memberof Popper.Utils
+ * @argument {Element} element - Element to apply the style to
+ * @argument {Object} styles
+ * Object with a list of properties and values which will be applied to the element
+ */
+function setStyles(element, styles) {
+  Object.keys(styles).forEach(function (prop) {
+    var unit = '';
+    // add unit if the value is numeric and is one of the following
+    if (['width', 'height', 'top', 'right', 'bottom', 'left'].indexOf(prop) !== -1 && isNumeric(styles[prop])) {
+      unit = 'px';
+    }
+    element.style[prop] = styles[prop] + unit;
+  });
+}
+
+/**
+ * Set the attributes to the given popper
+ * @method
+ * @memberof Popper.Utils
+ * @argument {Element} element - Element to apply the attributes to
+ * @argument {Object} styles
+ * Object with a list of properties and values which will be applied to the element
+ */
+function setAttributes(element, attributes) {
+  Object.keys(attributes).forEach(function (prop) {
+    var value = attributes[prop];
+    if (value !== false) {
+      element.setAttribute(prop, attributes[prop]);
+    } else {
+      element.removeAttribute(prop);
+    }
+  });
+}
+
+/**
+ * @function
+ * @memberof Modifiers
+ * @argument {Object} data - The data object generated by `update` method
+ * @argument {Object} data.styles - List of style properties - values to apply to popper element
+ * @argument {Object} data.attributes - List of attribute properties - values to apply to popper element
+ * @argument {Object} options - Modifiers configuration and options
+ * @returns {Object} The same data object
+ */
+function applyStyle(data) {
+  // any property present in `data.styles` will be applied to the popper,
+  // in this way we can make the 3rd party modifiers add custom styles to it
+  // Be aware, modifiers could override the properties defined in the previous
+  // lines of this modifier!
+  setStyles(data.instance.popper, data.styles);
+
+  // any property present in `data.attributes` will be applied to the popper,
+  // they will be set as HTML attributes of the element
+  setAttributes(data.instance.popper, data.attributes);
+
+  // if the arrow style has been computed, apply the arrow style
+  if (data.offsets.arrow) {
+    setStyles(data.arrowElement, data.offsets.arrow);
+  }
+
+  return data;
+}
+
+/**
+ * Set the x-placement attribute before everything else because it could be used
+ * to add margins to the popper margins needs to be calculated to get the
+ * correct popper offsets.
+ * @method
+ * @memberof Popper.modifiers
+ * @param {HTMLElement} reference - The reference element used to position the popper
+ * @param {HTMLElement} popper - The HTML element used as popper.
+ * @param {Object} options - Popper.js options
+ */
+function applyStyleOnLoad(reference, popper, options, modifierOptions, state) {
+  // compute reference element offsets
+  var referenceOffsets = getReferenceOffsets(state, popper, reference);
+
+  // compute auto placement, store placement inside the data object,
+  // modifiers will be able to edit `placement` if needed
+  // and refer to originalPlacement to know the original value
+  var placement = computeAutoPlacement(options.placement, referenceOffsets, popper, reference, options.modifiers.flip.boundariesElement, options.modifiers.flip.padding);
+
+  popper.setAttribute('x-placement', placement);
+
+  // Apply `position` to popper before anything else because
+  // without the position applied we can't guarantee correct computations
+  setStyles(popper, { position: 'absolute' });
+
+  return options;
+}
+
+/**
+ * @function
+ * @memberof Modifiers
+ * @argument {Object} data - The data object generated by `update` method
+ * @argument {Object} options - Modifiers configuration and options
+ * @returns {Object} The data object, properly modified
+ */
+function computeStyle(data, options) {
+  var x = options.x,
+      y = options.y;
+  var popper = data.offsets.popper;
+
+  // Remove this legacy support in Popper.js v2
+
+  var legacyGpuAccelerationOption = find$1(data.instance.modifiers, function (modifier) {
+    return modifier.name === 'applyStyle';
+  }).gpuAcceleration;
+  if (legacyGpuAccelerationOption !== undefined) {
+    console.warn('WARNING: `gpuAcceleration` option moved to `computeStyle` modifier and will not be supported in future versions of Popper.js!');
+  }
+  var gpuAcceleration = legacyGpuAccelerationOption !== undefined ? legacyGpuAccelerationOption : options.gpuAcceleration;
+
+  var offsetParent = getOffsetParent(data.instance.popper);
+  var offsetParentRect = getBoundingClientRect(offsetParent);
+
+  // Styles
+  var styles = {
+    position: popper.position
+  };
+
+  // floor sides to avoid blurry text
+  var offsets = {
+    left: Math.floor(popper.left),
+    top: Math.floor(popper.top),
+    bottom: Math.floor(popper.bottom),
+    right: Math.floor(popper.right)
+  };
+
+  var sideA = x === 'bottom' ? 'top' : 'bottom';
+  var sideB = y === 'right' ? 'left' : 'right';
+
+  // if gpuAcceleration is set to `true` and transform is supported,
+  //  we use `translate3d` to apply the position to the popper we
+  // automatically use the supported prefixed version if needed
+  var prefixedProperty = getSupportedPropertyName('transform');
+
+  // now, let's make a step back and look at this code closely (wtf?)
+  // If the content of the popper grows once it's been positioned, it
+  // may happen that the popper gets misplaced because of the new content
+  // overflowing its reference element
+  // To avoid this problem, we provide two options (x and y), which allow
+  // the consumer to define the offset origin.
+  // If we position a popper on top of a reference element, we can set
+  // `x` to `top` to make the popper grow towards its top instead of
+  // its bottom.
+  var left = void 0,
+      top = void 0;
+  if (sideA === 'bottom') {
+    top = -offsetParentRect.height + offsets.bottom;
+  } else {
+    top = offsets.top;
+  }
+  if (sideB === 'right') {
+    left = -offsetParentRect.width + offsets.right;
+  } else {
+    left = offsets.left;
+  }
+  if (gpuAcceleration && prefixedProperty) {
+    styles[prefixedProperty] = 'translate3d(' + left + 'px, ' + top + 'px, 0)';
+    styles[sideA] = 0;
+    styles[sideB] = 0;
+    styles.willChange = 'transform';
+  } else {
+    // othwerise, we use the standard `top`, `left`, `bottom` and `right` properties
+    var invertTop = sideA === 'bottom' ? -1 : 1;
+    var invertLeft = sideB === 'right' ? -1 : 1;
+    styles[sideA] = top * invertTop;
+    styles[sideB] = left * invertLeft;
+    styles.willChange = sideA + ', ' + sideB;
+  }
+
+  // Attributes
+  var attributes = {
+    'x-placement': data.placement
+  };
+
+  // Update attributes and styles of `data`
+  data.attributes = _extends({}, attributes, data.attributes);
+  data.styles = _extends({}, styles, data.styles);
+
+  return data;
+}
+
+/**
+ * Helper used to know if the given modifier depends from another one.<br />
+ * It checks if the needed modifier is listed and enabled.
+ * @method
+ * @memberof Popper.Utils
+ * @param {Array} modifiers - list of modifiers
+ * @param {String} requestingName - name of requesting modifier
+ * @param {String} requestedName - name of requested modifier
+ * @returns {Boolean}
+ */
+function isModifierRequired(modifiers, requestingName, requestedName) {
+  var requesting = find$1(modifiers, function (_ref) {
+    var name = _ref.name;
+    return name === requestingName;
+  });
+
+  var isRequired = !!requesting && modifiers.some(function (modifier) {
+    return modifier.name === requestedName && modifier.enabled && modifier.order < requesting.order;
+  });
+
+  if (!isRequired) {
+    var _requesting = '`' + requestingName + '`';
+    var requested = '`' + requestedName + '`';
+    console.warn(requested + ' modifier is required by ' + _requesting + ' modifier in order to work, be sure to include it before ' + _requesting + '!');
+  }
+  return isRequired;
+}
+
+/**
+ * @function
+ * @memberof Modifiers
+ * @argument {Object} data - The data object generated by update method
+ * @argument {Object} options - Modifiers configuration and options
+ * @returns {Object} The data object, properly modified
+ */
+function arrow(data, options) {
+  // arrow depends on keepTogether in order to work
+  if (!isModifierRequired(data.instance.modifiers, 'arrow', 'keepTogether')) {
+    return data;
+  }
+
+  var arrowElement = options.element;
+
+  // if arrowElement is a string, suppose it's a CSS selector
+  if (typeof arrowElement === 'string') {
+    arrowElement = data.instance.popper.querySelector(arrowElement);
+
+    // if arrowElement is not found, don't run the modifier
+    if (!arrowElement) {
+      return data;
+    }
+  } else {
+    // if the arrowElement isn't a query selector we must check that the
+    // provided DOM node is child of its popper node
+    if (!data.instance.popper.contains(arrowElement)) {
+      console.warn('WARNING: `arrow.element` must be child of its popper element!');
+      return data;
+    }
+  }
+
+  var placement = data.placement.split('-')[0];
+  var _data$offsets = data.offsets,
+      popper = _data$offsets.popper,
+      reference = _data$offsets.reference;
+
+  var isVertical = ['left', 'right'].indexOf(placement) !== -1;
+
+  var len = isVertical ? 'height' : 'width';
+  var side = isVertical ? 'top' : 'left';
+  var altSide = isVertical ? 'left' : 'top';
+  var opSide = isVertical ? 'bottom' : 'right';
+  var arrowElementSize = getOuterSizes(arrowElement)[len];
+
+  //
+  // extends keepTogether behavior making sure the popper and its reference have enough pixels in conjuction
+  //
+
+  // top/left side
+  if (reference[opSide] - arrowElementSize < popper[side]) {
+    data.offsets.popper[side] -= popper[side] - (reference[opSide] - arrowElementSize);
+  }
+  // bottom/right side
+  if (reference[side] + arrowElementSize > popper[opSide]) {
+    data.offsets.popper[side] += reference[side] + arrowElementSize - popper[opSide];
+  }
+
+  // compute center of the popper
+  var center = reference[side] + reference[len] / 2 - arrowElementSize / 2;
+
+  // Compute the sideValue using the updated popper offsets
+  var sideValue = center - getClientRect(data.offsets.popper)[side];
+
+  // prevent arrowElement from being placed not contiguously to its popper
+  sideValue = Math.max(Math.min(popper[len] - arrowElementSize, sideValue), 0);
+
+  data.arrowElement = arrowElement;
+  data.offsets.arrow = {};
+  data.offsets.arrow[side] = Math.round(sideValue);
+  data.offsets.arrow[altSide] = ''; // make sure to unset any eventual altSide value from the DOM node
+
+  return data;
+}
+
+/**
+ * Get the opposite placement variation of the given one
+ * @method
+ * @memberof Popper.Utils
+ * @argument {String} placement variation
+ * @returns {String} flipped placement variation
+ */
+function getOppositeVariation(variation) {
+  if (variation === 'end') {
+    return 'start';
+  } else if (variation === 'start') {
+    return 'end';
+  }
+  return variation;
+}
+
+/**
+ * List of accepted placements to use as values of the `placement` option.<br />
+ * Valid placements are:
+ * - `auto`
+ * - `top`
+ * - `right`
+ * - `bottom`
+ * - `left`
+ *
+ * Each placement can have a variation from this list:
+ * - `-start`
+ * - `-end`
+ *
+ * Variations are interpreted easily if you think of them as the left to right
+ * written languages. Horizontally (`top` and `bottom`), `start` is left and `end`
+ * is right.<br />
+ * Vertically (`left` and `right`), `start` is top and `end` is bottom.
+ *
+ * Some valid examples are:
+ * - `top-end` (on top of reference, right aligned)
+ * - `right-start` (on right of reference, top aligned)
+ * - `bottom` (on bottom, centered)
+ * - `auto-right` (on the side with more space available, alignment depends by placement)
+ *
+ * @static
+ * @type {Array}
+ * @enum {String}
+ * @readonly
+ * @method placements
+ * @memberof Popper
+ */
+var placements = ['auto-start', 'auto', 'auto-end', 'top-start', 'top', 'top-end', 'right-start', 'right', 'right-end', 'bottom-end', 'bottom', 'bottom-start', 'left-end', 'left', 'left-start'];
+
+// Get rid of `auto` `auto-start` and `auto-end`
+var validPlacements = placements.slice(3);
+
+/**
+ * Given an initial placement, returns all the subsequent placements
+ * clockwise (or counter-clockwise).
+ *
+ * @method
+ * @memberof Popper.Utils
+ * @argument {String} placement - A valid placement (it accepts variations)
+ * @argument {Boolean} counter - Set to true to walk the placements counterclockwise
+ * @returns {Array} placements including their variations
+ */
+function clockwise(placement) {
+  var counter = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : false;
+
+  var index = validPlacements.indexOf(placement);
+  var arr = validPlacements.slice(index + 1).concat(validPlacements.slice(0, index));
+  return counter ? arr.reverse() : arr;
+}
+
+var BEHAVIORS = {
+  FLIP: 'flip',
+  CLOCKWISE: 'clockwise',
+  COUNTERCLOCKWISE: 'counterclockwise'
+};
+
+/**
+ * @function
+ * @memberof Modifiers
+ * @argument {Object} data - The data object generated by update method
+ * @argument {Object} options - Modifiers configuration and options
+ * @returns {Object} The data object, properly modified
+ */
+function flip(data, options) {
+  // if `inner` modifier is enabled, we can't use the `flip` modifier
+  if (isModifierEnabled(data.instance.modifiers, 'inner')) {
+    return data;
+  }
+
+  if (data.flipped && data.placement === data.originalPlacement) {
+    // seems like flip is trying to loop, probably there's not enough space on any of the flippable sides
+    return data;
+  }
+
+  var boundaries = getBoundaries(data.instance.popper, data.instance.reference, options.padding, options.boundariesElement);
+
+  var placement = data.placement.split('-')[0];
+  var placementOpposite = getOppositePlacement(placement);
+  var variation = data.placement.split('-')[1] || '';
+
+  var flipOrder = [];
+
+  switch (options.behavior) {
+    case BEHAVIORS.FLIP:
+      flipOrder = [placement, placementOpposite];
+      break;
+    case BEHAVIORS.CLOCKWISE:
+      flipOrder = clockwise(placement);
+      break;
+    case BEHAVIORS.COUNTERCLOCKWISE:
+      flipOrder = clockwise(placement, true);
+      break;
+    default:
+      flipOrder = options.behavior;
+  }
+
+  flipOrder.forEach(function (step, index) {
+    if (placement !== step || flipOrder.length === index + 1) {
+      return data;
+    }
+
+    placement = data.placement.split('-')[0];
+    placementOpposite = getOppositePlacement(placement);
+
+    var popperOffsets = data.offsets.popper;
+    var refOffsets = data.offsets.reference;
+
+    // using floor because the reference offsets may contain decimals we are not going to consider here
+    var floor = Math.floor;
+    var overlapsRef = placement === 'left' && floor(popperOffsets.right) > floor(refOffsets.left) || placement === 'right' && floor(popperOffsets.left) < floor(refOffsets.right) || placement === 'top' && floor(popperOffsets.bottom) > floor(refOffsets.top) || placement === 'bottom' && floor(popperOffsets.top) < floor(refOffsets.bottom);
+
+    var overflowsLeft = floor(popperOffsets.left) < floor(boundaries.left);
+    var overflowsRight = floor(popperOffsets.right) > floor(boundaries.right);
+    var overflowsTop = floor(popperOffsets.top) < floor(boundaries.top);
+    var overflowsBottom = floor(popperOffsets.bottom) > floor(boundaries.bottom);
+
+    var overflowsBoundaries = placement === 'left' && overflowsLeft || placement === 'right' && overflowsRight || placement === 'top' && overflowsTop || placement === 'bottom' && overflowsBottom;
+
+    // flip the variation if required
+    var isVertical = ['top', 'bottom'].indexOf(placement) !== -1;
+    var flippedVariation = !!options.flipVariations && (isVertical && variation === 'start' && overflowsLeft || isVertical && variation === 'end' && overflowsRight || !isVertical && variation === 'start' && overflowsTop || !isVertical && variation === 'end' && overflowsBottom);
+
+    if (overlapsRef || overflowsBoundaries || flippedVariation) {
+      // this boolean to detect any flip loop
+      data.flipped = true;
+
+      if (overlapsRef || overflowsBoundaries) {
+        placement = flipOrder[index + 1];
+      }
+
+      if (flippedVariation) {
+        variation = getOppositeVariation(variation);
+      }
+
+      data.placement = placement + (variation ? '-' + variation : '');
+
+      // this object contains `position`, we want to preserve it along with
+      // any additional property we may add in the future
+      data.offsets.popper = _extends({}, data.offsets.popper, getPopperOffsets(data.instance.popper, data.offsets.reference, data.placement));
+
+      data = runModifiers(data.instance.modifiers, data, 'flip');
+    }
+  });
+  return data;
+}
+
+/**
+ * @function
+ * @memberof Modifiers
+ * @argument {Object} data - The data object generated by update method
+ * @argument {Object} options - Modifiers configuration and options
+ * @returns {Object} The data object, properly modified
+ */
+function keepTogether(data) {
+  var _data$offsets = data.offsets,
+      popper = _data$offsets.popper,
+      reference = _data$offsets.reference;
+
+  var placement = data.placement.split('-')[0];
+  var floor = Math.floor;
+  var isVertical = ['top', 'bottom'].indexOf(placement) !== -1;
+  var side = isVertical ? 'right' : 'bottom';
+  var opSide = isVertical ? 'left' : 'top';
+  var measurement = isVertical ? 'width' : 'height';
+
+  if (popper[side] < floor(reference[opSide])) {
+    data.offsets.popper[opSide] = floor(reference[opSide]) - popper[measurement];
+  }
+  if (popper[opSide] > floor(reference[side])) {
+    data.offsets.popper[opSide] = floor(reference[side]);
+  }
+
+  return data;
+}
+
+/**
+ * Converts a string containing value + unit into a px value number
+ * @function
+ * @memberof {modifiers~offset}
+ * @private
+ * @argument {String} str - Value + unit string
+ * @argument {String} measurement - `height` or `width`
+ * @argument {Object} popperOffsets
+ * @argument {Object} referenceOffsets
+ * @returns {Number|String}
+ * Value in pixels, or original string if no values were extracted
+ */
+function toValue(str, measurement, popperOffsets, referenceOffsets) {
+  // separate value from unit
+  var split = str.match(/((?:\-|\+)?\d*\.?\d*)(.*)/);
+  var value = +split[1];
+  var unit = split[2];
+
+  // If it's not a number it's an operator, I guess
+  if (!value) {
+    return str;
+  }
+
+  if (unit.indexOf('%') === 0) {
+    var element = void 0;
+    switch (unit) {
+      case '%p':
+        element = popperOffsets;
+        break;
+      case '%':
+      case '%r':
+      default:
+        element = referenceOffsets;
+    }
+
+    var rect = getClientRect(element);
+    return rect[measurement] / 100 * value;
+  } else if (unit === 'vh' || unit === 'vw') {
+    // if is a vh or vw, we calculate the size based on the viewport
+    var size = void 0;
+    if (unit === 'vh') {
+      size = Math.max(document.documentElement.clientHeight, window.innerHeight || 0);
+    } else {
+      size = Math.max(document.documentElement.clientWidth, window.innerWidth || 0);
+    }
+    return size / 100 * value;
+  } else {
+    // if is an explicit pixel unit, we get rid of the unit and keep the value
+    // if is an implicit unit, it's px, and we return just the value
+    return value;
+  }
+}
+
+/**
+ * Parse an `offset` string to extrapolate `x` and `y` numeric offsets.
+ * @function
+ * @memberof {modifiers~offset}
+ * @private
+ * @argument {String} offset
+ * @argument {Object} popperOffsets
+ * @argument {Object} referenceOffsets
+ * @argument {String} basePlacement
+ * @returns {Array} a two cells array with x and y offsets in numbers
+ */
+function parseOffset(offset, popperOffsets, referenceOffsets, basePlacement) {
+  var offsets = [0, 0];
+
+  // Use height if placement is left or right and index is 0 otherwise use width
+  // in this way the first offset will use an axis and the second one
+  // will use the other one
+  var useHeight = ['right', 'left'].indexOf(basePlacement) !== -1;
+
+  // Split the offset string to obtain a list of values and operands
+  // The regex addresses values with the plus or minus sign in front (+10, -20, etc)
+  var fragments = offset.split(/(\+|\-)/).map(function (frag) {
+    return frag.trim();
+  });
+
+  // Detect if the offset string contains a pair of values or a single one
+  // they could be separated by comma or space
+  var divider = fragments.indexOf(find$1(fragments, function (frag) {
+    return frag.search(/,|\s/) !== -1;
+  }));
+
+  if (fragments[divider] && fragments[divider].indexOf(',') === -1) {
+    console.warn('Offsets separated by white space(s) are deprecated, use a comma (,) instead.');
+  }
+
+  // If divider is found, we divide the list of values and operands to divide
+  // them by ofset X and Y.
+  var splitRegex = /\s*,\s*|\s+/;
+  var ops = divider !== -1 ? [fragments.slice(0, divider).concat([fragments[divider].split(splitRegex)[0]]), [fragments[divider].split(splitRegex)[1]].concat(fragments.slice(divider + 1))] : [fragments];
+
+  // Convert the values with units to absolute pixels to allow our computations
+  ops = ops.map(function (op, index) {
+    // Most of the units rely on the orientation of the popper
+    var measurement = (index === 1 ? !useHeight : useHeight) ? 'height' : 'width';
+    var mergeWithPrevious = false;
+    return op
+    // This aggregates any `+` or `-` sign that aren't considered operators
+    // e.g.: 10 + +5 => [10, +, +5]
+    .reduce(function (a, b) {
+      if (a[a.length - 1] === '' && ['+', '-'].indexOf(b) !== -1) {
+        a[a.length - 1] = b;
+        mergeWithPrevious = true;
+        return a;
+      } else if (mergeWithPrevious) {
+        a[a.length - 1] += b;
+        mergeWithPrevious = false;
+        return a;
+      } else {
+        return a.concat(b);
+      }
+    }, [])
+    // Here we convert the string values into number values (in px)
+    .map(function (str) {
+      return toValue(str, measurement, popperOffsets, referenceOffsets);
+    });
+  });
+
+  // Loop trough the offsets arrays and execute the operations
+  ops.forEach(function (op, index) {
+    op.forEach(function (frag, index2) {
+      if (isNumeric(frag)) {
+        offsets[index] += frag * (op[index2 - 1] === '-' ? -1 : 1);
+      }
+    });
+  });
+  return offsets;
+}
+
+/**
+ * @function
+ * @memberof Modifiers
+ * @argument {Object} data - The data object generated by update method
+ * @argument {Object} options - Modifiers configuration and options
+ * @argument {Number|String} options.offset=0
+ * The offset value as described in the modifier description
+ * @returns {Object} The data object, properly modified
+ */
+function offset(data, _ref) {
+  var offset = _ref.offset;
+  var placement = data.placement,
+      _data$offsets = data.offsets,
+      popper = _data$offsets.popper,
+      reference = _data$offsets.reference;
+
+  var basePlacement = placement.split('-')[0];
+
+  var offsets = void 0;
+  if (isNumeric(+offset)) {
+    offsets = [+offset, 0];
+  } else {
+    offsets = parseOffset(offset, popper, reference, basePlacement);
+  }
+
+  if (basePlacement === 'left') {
+    popper.top += offsets[0];
+    popper.left -= offsets[1];
+  } else if (basePlacement === 'right') {
+    popper.top += offsets[0];
+    popper.left += offsets[1];
+  } else if (basePlacement === 'top') {
+    popper.left += offsets[0];
+    popper.top -= offsets[1];
+  } else if (basePlacement === 'bottom') {
+    popper.left += offsets[0];
+    popper.top += offsets[1];
+  }
+
+  data.popper = popper;
+  return data;
+}
+
+/**
+ * @function
+ * @memberof Modifiers
+ * @argument {Object} data - The data object generated by `update` method
+ * @argument {Object} options - Modifiers configuration and options
+ * @returns {Object} The data object, properly modified
+ */
+function preventOverflow(data, options) {
+  var boundariesElement = options.boundariesElement || getOffsetParent(data.instance.popper);
+
+  // If offsetParent is the reference element, we really want to
+  // go one step up and use the next offsetParent as reference to
+  // avoid to make this modifier completely useless and look like broken
+  if (data.instance.reference === boundariesElement) {
+    boundariesElement = getOffsetParent(boundariesElement);
+  }
+
+  var boundaries = getBoundaries(data.instance.popper, data.instance.reference, options.padding, boundariesElement);
+  options.boundaries = boundaries;
+
+  var order = options.priority;
+  var popper = data.offsets.popper;
+
+  var check = {
+    primary: function primary(placement) {
+      var value = popper[placement];
+      if (popper[placement] < boundaries[placement] && !options.escapeWithReference) {
+        value = Math.max(popper[placement], boundaries[placement]);
+      }
+      return defineProperty({}, placement, value);
+    },
+    secondary: function secondary(placement) {
+      var mainSide = placement === 'right' ? 'left' : 'top';
+      var value = popper[mainSide];
+      if (popper[placement] > boundaries[placement] && !options.escapeWithReference) {
+        value = Math.min(popper[mainSide], boundaries[placement] - (placement === 'right' ? popper.width : popper.height));
+      }
+      return defineProperty({}, mainSide, value);
+    }
+  };
+
+  order.forEach(function (placement) {
+    var side = ['left', 'top'].indexOf(placement) !== -1 ? 'primary' : 'secondary';
+    popper = _extends({}, popper, check[side](placement));
+  });
+
+  data.offsets.popper = popper;
+
+  return data;
+}
+
+/**
+ * @function
+ * @memberof Modifiers
+ * @argument {Object} data - The data object generated by `update` method
+ * @argument {Object} options - Modifiers configuration and options
+ * @returns {Object} The data object, properly modified
+ */
+function shift(data) {
+  var placement = data.placement;
+  var basePlacement = placement.split('-')[0];
+  var shiftvariation = placement.split('-')[1];
+
+  // if shift shiftvariation is specified, run the modifier
+  if (shiftvariation) {
+    var _data$offsets = data.offsets,
+        reference = _data$offsets.reference,
+        popper = _data$offsets.popper;
+
+    var isVertical = ['bottom', 'top'].indexOf(basePlacement) !== -1;
+    var side = isVertical ? 'left' : 'top';
+    var measurement = isVertical ? 'width' : 'height';
+
+    var shiftOffsets = {
+      start: defineProperty({}, side, reference[side]),
+      end: defineProperty({}, side, reference[side] + reference[measurement] - popper[measurement])
+    };
+
+    data.offsets.popper = _extends({}, popper, shiftOffsets[shiftvariation]);
+  }
+
+  return data;
+}
+
+/**
+ * @function
+ * @memberof Modifiers
+ * @argument {Object} data - The data object generated by update method
+ * @argument {Object} options - Modifiers configuration and options
+ * @returns {Object} The data object, properly modified
+ */
+function hide(data) {
+  if (!isModifierRequired(data.instance.modifiers, 'hide', 'preventOverflow')) {
+    return data;
+  }
+
+  var refRect = data.offsets.reference;
+  var bound = find$1(data.instance.modifiers, function (modifier) {
+    return modifier.name === 'preventOverflow';
+  }).boundaries;
+
+  if (refRect.bottom < bound.top || refRect.left > bound.right || refRect.top > bound.bottom || refRect.right < bound.left) {
+    // Avoid unnecessary DOM access if visibility hasn't changed
+    if (data.hide === true) {
+      return data;
+    }
+
+    data.hide = true;
+    data.attributes['x-out-of-boundaries'] = '';
+  } else {
+    // Avoid unnecessary DOM access if visibility hasn't changed
+    if (data.hide === false) {
+      return data;
+    }
+
+    data.hide = false;
+    data.attributes['x-out-of-boundaries'] = false;
+  }
+
+  return data;
+}
+
+/**
+ * @function
+ * @memberof Modifiers
+ * @argument {Object} data - The data object generated by `update` method
+ * @argument {Object} options - Modifiers configuration and options
+ * @returns {Object} The data object, properly modified
+ */
+function inner(data) {
+  var placement = data.placement;
+  var basePlacement = placement.split('-')[0];
+  var _data$offsets = data.offsets,
+      popper = _data$offsets.popper,
+      reference = _data$offsets.reference;
+
+  var isHoriz = ['left', 'right'].indexOf(basePlacement) !== -1;
+
+  var subtractLength = ['top', 'left'].indexOf(basePlacement) === -1;
+
+  popper[isHoriz ? 'left' : 'top'] = reference[placement] - (subtractLength ? popper[isHoriz ? 'width' : 'height'] : 0);
+
+  data.placement = getOppositePlacement(placement);
+  data.offsets.popper = getClientRect(popper);
+
+  return data;
+}
+
+/**
+ * Modifier function, each modifier can have a function of this type assigned
+ * to its `fn` property.<br />
+ * These functions will be called on each update, this means that you must
+ * make sure they are performant enough to avoid performance bottlenecks.
+ *
+ * @function ModifierFn
+ * @argument {dataObject} data - The data object generated by `update` method
+ * @argument {Object} options - Modifiers configuration and options
+ * @returns {dataObject} The data object, properly modified
+ */
+
+/**
+ * Modifiers are plugins used to alter the behavior of your poppers.<br />
+ * Popper.js uses a set of 9 modifiers to provide all the basic functionalities
+ * needed by the library.
+ *
+ * Usually you don't want to override the `order`, `fn` and `onLoad` props.
+ * All the other properties are configurations that could be tweaked.
+ * @namespace modifiers
+ */
+var modifiers = {
+  /**
+   * Modifier used to shift the popper on the start or end of its reference
+   * element.<br />
+   * It will read the variation of the `placement` property.<br />
+   * It can be one either `-end` or `-start`.
+   * @memberof modifiers
+   * @inner
+   */
+  shift: {
+    /** @prop {number} order=100 - Index used to define the order of execution */
+    order: 100,
+    /** @prop {Boolean} enabled=true - Whether the modifier is enabled or not */
+    enabled: true,
+    /** @prop {ModifierFn} */
+    fn: shift
+  },
+
+  /**
+   * The `offset` modifier can shift your popper on both its axis.
+   *
+   * It accepts the following units:
+   * - `px` or unitless, interpreted as pixels
+   * - `%` or `%r`, percentage relative to the length of the reference element
+   * - `%p`, percentage relative to the length of the popper element
+   * - `vw`, CSS viewport width unit
+   * - `vh`, CSS viewport height unit
+   *
+   * For length is intended the main axis relative to the placement of the popper.<br />
+   * This means that if the placement is `top` or `bottom`, the length will be the
+   * `width`. In case of `left` or `right`, it will be the height.
+   *
+   * You can provide a single value (as `Number` or `String`), or a pair of values
+   * as `String` divided by a comma or one (or more) white spaces.<br />
+   * The latter is a deprecated method because it leads to confusion and will be
+   * removed in v2.<br />
+   * Additionally, it accepts additions and subtractions between different units.
+   * Note that multiplications and divisions aren't supported.
+   *
+   * Valid examples are:
+   * ```
+   * 10
+   * '10%'
+   * '10, 10'
+   * '10%, 10'
+   * '10 + 10%'
+   * '10 - 5vh + 3%'
+   * '-10px + 5vh, 5px - 6%'
+   * ```
+   *
+   * @memberof modifiers
+   * @inner
+   */
+  offset: {
+    /** @prop {number} order=200 - Index used to define the order of execution */
+    order: 200,
+    /** @prop {Boolean} enabled=true - Whether the modifier is enabled or not */
+    enabled: true,
+    /** @prop {ModifierFn} */
+    fn: offset,
+    /** @prop {Number|String} offset=0
+     * The offset value as described in the modifier description
+     */
+    offset: 0
+  },
+
+  /**
+   * Modifier used to prevent the popper from being positioned outside the boundary.
+   *
+   * An scenario exists where the reference itself is not within the boundaries.<br />
+   * We can say it has "escaped the boundaries" — or just "escaped".<br />
+   * In this case we need to decide whether the popper should either:
+   *
+   * - detach from the reference and remain "trapped" in the boundaries, or
+   * - if it should ignore the boundary and "escape with its reference"
+   *
+   * When `escapeWithReference` is set to`true` and reference is completely
+   * outside its boundaries, the popper will overflow (or completely leave)
+   * the boundaries in order to remain attached to the edge of the reference.
+   *
+   * @memberof modifiers
+   * @inner
+   */
+  preventOverflow: {
+    /** @prop {number} order=300 - Index used to define the order of execution */
+    order: 300,
+    /** @prop {Boolean} enabled=true - Whether the modifier is enabled or not */
+    enabled: true,
+    /** @prop {ModifierFn} */
+    fn: preventOverflow,
+    /**
+     * @prop {Array} [priority=['left','right','top','bottom']]
+     * Popper will try to prevent overflow following these priorities by default,
+     * then, it could overflow on the left and on top of the `boundariesElement`
+     */
+    priority: ['left', 'right', 'top', 'bottom'],
+    /**
+     * @prop {number} padding=5
+     * Amount of pixel used to define a minimum distance between the boundaries
+     * and the popper this makes sure the popper has always a little padding
+     * between the edges of its container
+     */
+    padding: 5,
+    /**
+     * @prop {String|HTMLElement} boundariesElement='scrollParent'
+     * Boundaries used by the modifier, can be `scrollParent`, `window`,
+     * `viewport` or any DOM element.
+     */
+    boundariesElement: 'scrollParent'
+  },
+
+  /**
+   * Modifier used to make sure the reference and its popper stay near eachothers
+   * without leaving any gap between the two. Expecially useful when the arrow is
+   * enabled and you want to assure it to point to its reference element.
+   * It cares only about the first axis, you can still have poppers with margin
+   * between the popper and its reference element.
+   * @memberof modifiers
+   * @inner
+   */
+  keepTogether: {
+    /** @prop {number} order=400 - Index used to define the order of execution */
+    order: 400,
+    /** @prop {Boolean} enabled=true - Whether the modifier is enabled or not */
+    enabled: true,
+    /** @prop {ModifierFn} */
+    fn: keepTogether
+  },
+
+  /**
+   * This modifier is used to move the `arrowElement` of the popper to make
+   * sure it is positioned between the reference element and its popper element.
+   * It will read the outer size of the `arrowElement` node to detect how many
+   * pixels of conjuction are needed.
+   *
+   * It has no effect if no `arrowElement` is provided.
+   * @memberof modifiers
+   * @inner
+   */
+  arrow: {
+    /** @prop {number} order=500 - Index used to define the order of execution */
+    order: 500,
+    /** @prop {Boolean} enabled=true - Whether the modifier is enabled or not */
+    enabled: true,
+    /** @prop {ModifierFn} */
+    fn: arrow,
+    /** @prop {String|HTMLElement} element='[x-arrow]' - Selector or node used as arrow */
+    element: '[x-arrow]'
+  },
+
+  /**
+   * Modifier used to flip the popper's placement when it starts to overlap its
+   * reference element.
+   *
+   * Requires the `preventOverflow` modifier before it in order to work.
+   *
+   * **NOTE:** this modifier will interrupt the current update cycle and will
+   * restart it if it detects the need to flip the placement.
+   * @memberof modifiers
+   * @inner
+   */
+  flip: {
+    /** @prop {number} order=600 - Index used to define the order of execution */
+    order: 600,
+    /** @prop {Boolean} enabled=true - Whether the modifier is enabled or not */
+    enabled: true,
+    /** @prop {ModifierFn} */
+    fn: flip,
+    /**
+     * @prop {String|Array} behavior='flip'
+     * The behavior used to change the popper's placement. It can be one of
+     * `flip`, `clockwise`, `counterclockwise` or an array with a list of valid
+     * placements (with optional variations).
+     */
+    behavior: 'flip',
+    /**
+     * @prop {number} padding=5
+     * The popper will flip if it hits the edges of the `boundariesElement`
+     */
+    padding: 5,
+    /**
+     * @prop {String|HTMLElement} boundariesElement='viewport'
+     * The element which will define the boundaries of the popper position,
+     * the popper will never be placed outside of the defined boundaries
+     * (except if keepTogether is enabled)
+     */
+    boundariesElement: 'viewport'
+  },
+
+  /**
+   * Modifier used to make the popper flow toward the inner of the reference element.
+   * By default, when this modifier is disabled, the popper will be placed outside
+   * the reference element.
+   * @memberof modifiers
+   * @inner
+   */
+  inner: {
+    /** @prop {number} order=700 - Index used to define the order of execution */
+    order: 700,
+    /** @prop {Boolean} enabled=false - Whether the modifier is enabled or not */
+    enabled: false,
+    /** @prop {ModifierFn} */
+    fn: inner
+  },
+
+  /**
+   * Modifier used to hide the popper when its reference element is outside of the
+   * popper boundaries. It will set a `x-out-of-boundaries` attribute which can
+   * be used to hide with a CSS selector the popper when its reference is
+   * out of boundaries.
+   *
+   * Requires the `preventOverflow` modifier before it in order to work.
+   * @memberof modifiers
+   * @inner
+   */
+  hide: {
+    /** @prop {number} order=800 - Index used to define the order of execution */
+    order: 800,
+    /** @prop {Boolean} enabled=true - Whether the modifier is enabled or not */
+    enabled: true,
+    /** @prop {ModifierFn} */
+    fn: hide
+  },
+
+  /**
+   * Computes the style that will be applied to the popper element to gets
+   * properly positioned.
+   *
+   * Note that this modifier will not touch the DOM, it just prepares the styles
+   * so that `applyStyle` modifier can apply it. This separation is useful
+   * in case you need to replace `applyStyle` with a custom implementation.
+   *
+   * This modifier has `850` as `order` value to maintain backward compatibility
+   * with previous versions of Popper.js. Expect the modifiers ordering method
+   * to change in future major versions of the library.
+   *
+   * @memberof modifiers
+   * @inner
+   */
+  computeStyle: {
+    /** @prop {number} order=850 - Index used to define the order of execution */
+    order: 850,
+    /** @prop {Boolean} enabled=true - Whether the modifier is enabled or not */
+    enabled: true,
+    /** @prop {ModifierFn} */
+    fn: computeStyle,
+    /**
+     * @prop {Boolean} gpuAcceleration=true
+     * If true, it uses the CSS 3d transformation to position the popper.
+     * Otherwise, it will use the `top` and `left` properties.
+     */
+    gpuAcceleration: true,
+    /**
+     * @prop {string} [x='bottom']
+     * Where to anchor the X axis (`bottom` or `top`). AKA X offset origin.
+     * Change this if your popper should grow in a direction different from `bottom`
+     */
+    x: 'bottom',
+    /**
+     * @prop {string} [x='left']
+     * Where to anchor the Y axis (`left` or `right`). AKA Y offset origin.
+     * Change this if your popper should grow in a direction different from `right`
+     */
+    y: 'right'
+  },
+
+  /**
+   * Applies the computed styles to the popper element.
+   *
+   * All the DOM manipulations are limited to this modifier. This is useful in case
+   * you want to integrate Popper.js inside a framework or view library and you
+   * want to delegate all the DOM manipulations to it.
+   *
+   * Note that if you disable this modifier, you must make sure the popper element
+   * has its position set to `absolute` before Popper.js can do its work!
+   *
+   * Just disable this modifier and define you own to achieve the desired effect.
+   *
+   * @memberof modifiers
+   * @inner
+   */
+  applyStyle: {
+    /** @prop {number} order=900 - Index used to define the order of execution */
+    order: 900,
+    /** @prop {Boolean} enabled=true - Whether the modifier is enabled or not */
+    enabled: true,
+    /** @prop {ModifierFn} */
+    fn: applyStyle,
+    /** @prop {Function} */
+    onLoad: applyStyleOnLoad,
+    /**
+     * @deprecated since version 1.10.0, the property moved to `computeStyle` modifier
+     * @prop {Boolean} gpuAcceleration=true
+     * If true, it uses the CSS 3d transformation to position the popper.
+     * Otherwise, it will use the `top` and `left` properties.
+     */
+    gpuAcceleration: undefined
+  }
+};
+
+/**
+ * The `dataObject` is an object containing all the informations used by Popper.js
+ * this object get passed to modifiers and to the `onCreate` and `onUpdate` callbacks.
+ * @name dataObject
+ * @property {Object} data.instance The Popper.js instance
+ * @property {String} data.placement Placement applied to popper
+ * @property {String} data.originalPlacement Placement originally defined on init
+ * @property {Boolean} data.flipped True if popper has been flipped by flip modifier
+ * @property {Boolean} data.hide True if the reference element is out of boundaries, useful to know when to hide the popper.
+ * @property {HTMLElement} data.arrowElement Node used as arrow by arrow modifier
+ * @property {Object} data.styles Any CSS property defined here will be applied to the popper, it expects the JavaScript nomenclature (eg. `marginBottom`)
+ * @property {Object} data.boundaries Offsets of the popper boundaries
+ * @property {Object} data.offsets The measurements of popper, reference and arrow elements.
+ * @property {Object} data.offsets.popper `top`, `left`, `width`, `height` values
+ * @property {Object} data.offsets.reference `top`, `left`, `width`, `height` values
+ * @property {Object} data.offsets.arrow] `top` and `left` offsets, only one of them will be different from 0
+ */
+
+/**
+ * Default options provided to Popper.js constructor.<br />
+ * These can be overriden using the `options` argument of Popper.js.<br />
+ * To override an option, simply pass as 3rd argument an object with the same
+ * structure of this object, example:
+ * ```
+ * new Popper(ref, pop, {
+ *   modifiers: {
+ *     preventOverflow: { enabled: false }
+ *   }
+ * })
+ * ```
+ * @type {Object}
+ * @static
+ * @memberof Popper
+ */
+var Defaults$1 = {
+  /**
+   * Popper's placement
+   * @prop {Popper.placements} placement='bottom'
+   */
+  placement: 'bottom',
+
+  /**
+   * Whether events (resize, scroll) are initially enabled
+   * @prop {Boolean} eventsEnabled=true
+   */
+  eventsEnabled: true,
+
+  /**
+   * Set to true if you want to automatically remove the popper when
+   * you call the `destroy` method.
+   * @prop {Boolean} removeOnDestroy=false
+   */
+  removeOnDestroy: false,
+
+  /**
+   * Callback called when the popper is created.<br />
+   * By default, is set to no-op.<br />
+   * Access Popper.js instance with `data.instance`.
+   * @prop {onCreate}
+   */
+  onCreate: function onCreate() {},
+
+  /**
+   * Callback called when the popper is updated, this callback is not called
+   * on the initialization/creation of the popper, but only on subsequent
+   * updates.<br />
+   * By default, is set to no-op.<br />
+   * Access Popper.js instance with `data.instance`.
+   * @prop {onUpdate}
+   */
+  onUpdate: function onUpdate() {},
+
+  /**
+   * List of modifiers used to modify the offsets before they are applied to the popper.
+   * They provide most of the functionalities of Popper.js
+   * @prop {modifiers}
+   */
+  modifiers: modifiers
+};
+
+/**
+ * @callback onCreate
+ * @param {dataObject} data
+ */
+
+/**
+ * @callback onUpdate
+ * @param {dataObject} data
+ */
+
+// Utils
+// Methods
+var Popper = function () {
+  /**
+   * Create a new Popper.js instance
+   * @class Popper
+   * @param {HTMLElement|referenceObject} reference - The reference element used to position the popper
+   * @param {HTMLElement} popper - The HTML element used as popper.
+   * @param {Object} options - Your custom options to override the ones defined in [Defaults](#defaults)
+   * @return {Object} instance - The generated Popper.js instance
+   */
+  function Popper(reference, popper) {
+    var _this = this;
+
+    var options = arguments.length > 2 && arguments[2] !== undefined ? arguments[2] : {};
+    classCallCheck(this, Popper);
+
+    this.scheduleUpdate = function () {
+      return requestAnimationFrame(_this.update);
+    };
+
+    // make update() debounced, so that it only runs at most once-per-tick
+    this.update = debounce(this.update.bind(this));
+
+    // with {} we create a new object with the options inside it
+    this.options = _extends({}, Popper.Defaults, options);
+
+    // init state
+    this.state = {
+      isDestroyed: false,
+      isCreated: false,
+      scrollParents: []
+    };
+
+    // get reference and popper elements (allow jQuery wrappers)
+    this.reference = reference.jquery ? reference[0] : reference;
+    this.popper = popper.jquery ? popper[0] : popper;
+
+    // Deep merge modifiers options
+    this.options.modifiers = {};
+    Object.keys(_extends({}, Popper.Defaults.modifiers, options.modifiers)).forEach(function (name) {
+      _this.options.modifiers[name] = _extends({}, Popper.Defaults.modifiers[name] || {}, options.modifiers ? options.modifiers[name] : {});
+    });
+
+    // Refactoring modifiers' list (Object => Array)
+    this.modifiers = Object.keys(this.options.modifiers).map(function (name) {
+      return _extends({
+        name: name
+      }, _this.options.modifiers[name]);
+    })
+    // sort the modifiers by order
+    .sort(function (a, b) {
+      return a.order - b.order;
+    });
+
+    // modifiers have the ability to execute arbitrary code when Popper.js get inited
+    // such code is executed in the same order of its modifier
+    // they could add new properties to their options configuration
+    // BE AWARE: don't add options to `options.modifiers.name` but to `modifierOptions`!
+    this.modifiers.forEach(function (modifierOptions) {
+      if (modifierOptions.enabled && isFunction(modifierOptions.onLoad)) {
+        modifierOptions.onLoad(_this.reference, _this.popper, _this.options, modifierOptions, _this.state);
+      }
+    });
+
+    // fire the first update to position the popper in the right place
+    this.update();
+
+    var eventsEnabled = this.options.eventsEnabled;
+    if (eventsEnabled) {
+      // setup event listeners, they will take care of update the position in specific situations
+      this.enableEventListeners();
+    }
+
+    this.state.eventsEnabled = eventsEnabled;
+  }
+
+  // We can't use class properties because they don't get listed in the
+  // class prototype and break stuff like Sinon stubs
+
+
+  createClass(Popper, [{
+    key: 'update',
+    value: function update$$1() {
+      return update.call(this);
+    }
+  }, {
+    key: 'destroy',
+    value: function destroy$$1() {
+      return destroy.call(this);
+    }
+  }, {
+    key: 'enableEventListeners',
+    value: function enableEventListeners$$1() {
+      return enableEventListeners.call(this);
+    }
+  }, {
+    key: 'disableEventListeners',
+    value: function disableEventListeners$$1() {
+      return disableEventListeners.call(this);
+    }
+
+    /**
+     * Schedule an update, it will run on the next UI update available
+     * @method scheduleUpdate
+     * @memberof Popper
+     */
+
+
+    /**
+     * Collection of utilities useful when writing custom modifiers.
+     * Starting from version 1.7, this method is available only if you
+     * include `popper-utils.js` before `popper.js`.
+     *
+     * **DEPRECATION**: This way to access PopperUtils is deprecated
+     * and will be removed in v2! Use the PopperUtils module directly instead.
+     * Due to the high instability of the methods contained in Utils, we can't
+     * guarantee them to follow semver. Use them at your own risk!
+     * @static
+     * @private
+     * @type {Object}
+     * @deprecated since version 1.8
+     * @member Utils
+     * @memberof Popper
+     */
+
+  }]);
+  return Popper;
+}();
+
+/**
+ * The `referenceObject` is an object that provides an interface compatible with Popper.js
+ * and lets you use it as replacement of a real DOM node.<br />
+ * You can use this method to position a popper relatively to a set of coordinates
+ * in case you don't have a DOM node to use as reference.
+ *
+ * ```
+ * new Popper(referenceObject, popperNode);
+ * ```
+ *
+ * NB: This feature isn't supported in Internet Explorer 10
+ * @name referenceObject
+ * @property {Function} data.getBoundingClientRect
+ * A function that returns a set of coordinates compatible with the native `getBoundingClientRect` method.
+ * @property {number} data.clientWidth
+ * An ES6 getter that will return the width of the virtual reference element.
+ * @property {number} data.clientHeight
+ * An ES6 getter that will return the height of the virtual reference element.
+ */
+
+
+Popper.Utils = (typeof window !== 'undefined' ? window : global).PopperUtils;
+Popper.placements = placements;
+Popper.Defaults = Defaults$1;
+
+
+//# sourceMappingURL=popper.js.map
+
+function getOffsetDistanceInPx(distance) {
+  return -(distance - Defaults.distance) + 'px';
+}
+
+var classCallCheck$1 = function (instance, Constructor) {
+  if (!(instance instanceof Constructor)) {
+    throw new TypeError("Cannot call a class as a function");
+  }
+};
+
+var createClass$1 = function () {
+  function defineProperties(target, props) {
+    for (var i = 0; i < props.length; i++) {
+      var descriptor = props[i];
+      descriptor.enumerable = descriptor.enumerable || false;
+      descriptor.configurable = true;
+      if ("value" in descriptor) descriptor.writable = true;
+      Object.defineProperty(target, descriptor.key, descriptor);
+    }
+  }
+
+  return function (Constructor, protoProps, staticProps) {
+    if (protoProps) defineProperties(Constructor.prototype, protoProps);
+    if (staticProps) defineProperties(Constructor, staticProps);
+    return Constructor;
+  };
+}();
+
+
+
+
+
+
+
+var _extends$1 = Object.assign || function (target) {
+  for (var i = 1; i < arguments.length; i++) {
+    var source = arguments[i];
+
+    for (var key in source) {
+      if (Object.prototype.hasOwnProperty.call(source, key)) {
+        target[key] = source[key];
+      }
+    }
+  }
+
+  return target;
+};
+
+function createPopperInstance(refData) {
+  var el = refData.el,
+      popper = refData.popper,
+      _refData$settings = refData.settings,
+      position = _refData$settings.position,
+      popperOptions = _refData$settings.popperOptions,
+      offset = _refData$settings.offset,
+      distance = _refData$settings.distance,
+      flipDuration = _refData$settings.flipDuration;
+
+
+  var tooltip = popper.querySelector(Selectors.TOOLTIP);
+
+  var config = _extends$1({
+    placement: position
+  }, popperOptions || {}, {
+    modifiers: _extends$1({}, popperOptions ? popperOptions.modifiers : {}, {
+      flip: _extends$1({
+        padding: distance + 5 /* 5px from viewport boundary */
+      }, popperOptions && popperOptions.modifiers ? popperOptions.modifiers.flip : {}),
+      offset: _extends$1({
+        offset: offset
+      }, popperOptions && popperOptions.modifiers ? popperOptions.modifiers.offset : {})
+    }),
+    onUpdate: function onUpdate() {
+      var styles = tooltip.style;
+      styles.top = '';
+      styles.bottom = '';
+      styles.left = '';
+      styles.right = '';
+      styles[getCorePlacement(popper.getAttribute('x-placement'))] = getOffsetDistanceInPx(distance);
+    }
+  });
+
+  return new Popper(el, popper, config);
+}
+
+function mountPopper(refData) {
+  var el = refData.el,
+      popper = refData.popper,
+      _refData$settings = refData.settings,
+      appendTo = _refData$settings.appendTo,
+      followCursor = _refData$settings.followCursor,
+      flipDuration = _refData$settings.flipDuration;
+
+  // Already on the DOM
+
+  if (appendTo.contains(popper)) return;
+
+  appendTo.appendChild(popper);
+
+  if (!refData.popperInstance) {
+    // Create instance if it hasn't been created yet
+    refData.popperInstance = createPopperInstance(refData);
+
+    // Update the popper's position whenever its content changes
+    // Not supported in IE10 unless polyfilled
+    if (window.MutationObserver) {
+      var styles = popper.style;
+      var observer = new MutationObserver(function () {
+        styles[prefix('transitionDuration')] = '0ms';
+        refData.popperInstance.update();
+        queueExecution(function () {
+          styles[prefix('transitionDuration')] = flipDuration + 'ms';
+        });
+      });
+      observer.observe(popper, {
+        childList: true,
+        subtree: true,
+        characterData: true
+      });
+      refData._mutationObserver = observer;
+    }
+  } else {
+    refData.popperInstance.update();
+
+    if (!followCursor || Browser.touch) {
+      refData.popperInstance.enableEventListeners();
+    }
+  }
+
+  // Since touch is determined dynamically, followCursor setting
+  // is set on mount
+  if (followCursor && !Browser.touch) {
+    el.addEventListener('mousemove', followCursorHandler);
+    refData.popperInstance.disableEventListeners();
+  }
+}
+
+function makeSticky(refData) {
+  var popper = refData.popper,
+      popperInstance = refData.popperInstance,
+      stickyDuration = refData.settings.stickyDuration;
+
+
+  var applyTransitionDuration = function applyTransitionDuration() {
+    return popper.style[prefix('transitionDuration')] = stickyDuration + 'ms';
+  };
+
+  var removeTransitionDuration = function removeTransitionDuration() {
+    return popper.style[prefix('transitionDuration')] = '';
+  };
+
+  var updatePosition = function updatePosition() {
+    popperInstance && popperInstance.scheduleUpdate();
+
+    applyTransitionDuration();
+
+    isVisible(popper) ? window.requestAnimationFrame(updatePosition) : removeTransitionDuration();
+  };
+
+  // Wait until Popper's position has been updated initially
+  queueExecution(updatePosition);
+}
+
+function getIndividualSettings(el, instanceSettings) {
+  var settings = DefaultsKeys.reduce(function (acc, key) {
+    var val = el.getAttribute('data-' + key.toLowerCase()) || instanceSettings[key];
+
+    // Convert strings to booleans
+    if (val === 'false') val = false;
+    if (val === 'true') val = true;
+
+    // Convert number strings to true numbers
+    if (isFinite(val) && !isNaN(parseFloat(val))) {
+      val = parseFloat(val);
+    }
+
+    // Convert array strings to actual arrays
+    if (typeof val === 'string' && val.trim().charAt(0) === '[') {
+      val = JSON.parse(val);
+    }
+
+    acc[key] = val;
+
+    return acc;
+  }, {});
+
+  return _extends$1({}, instanceSettings, settings);
+}
+
+function createPopperElement(id, title, settings) {
+  var position = settings.position,
+      distance = settings.distance,
+      arrow = settings.arrow,
+      animateFill = settings.animateFill,
+      inertia = settings.inertia,
+      animation = settings.animation,
+      arrowSize = settings.arrowSize,
+      size = settings.size,
+      theme = settings.theme,
+      html = settings.html,
+      zIndex = settings.zIndex,
+      interactive = settings.interactive;
+
+
+  var popper = document.createElement('div');
+  popper.setAttribute('class', 'tippy-popper');
+  popper.setAttribute('role', 'tooltip');
+  popper.setAttribute('aria-hidden', 'true');
+  popper.setAttribute('id', 'tippy-tooltip-' + id);
+  popper.style.zIndex = zIndex;
+
+  var tooltip = document.createElement('div');
+  tooltip.setAttribute('class', 'tippy-tooltip tippy-tooltip--' + size + ' leave');
+  tooltip.setAttribute('data-animation', animation);
+
+  theme.split(' ').forEach(function (t) {
+    tooltip.classList.add(t + '-theme');
+  });
+
+  if (arrow) {
+    // Add an arrow
+    var _arrow = document.createElement('div');
+    _arrow.setAttribute('class', 'arrow-' + arrowSize);
+    _arrow.setAttribute('x-arrow', '');
+    tooltip.appendChild(_arrow);
+  }
+
+  if (animateFill) {
+    // Create animateFill circle element for animation
+    tooltip.setAttribute('data-animatefill', '');
+    var circle = document.createElement('div');
+    circle.setAttribute('class', 'leave');
+    circle.setAttribute('x-circle', '');
+    tooltip.appendChild(circle);
+  }
+
+  if (inertia) {
+    // Change transition timing function cubic bezier
+    tooltip.setAttribute('data-inertia', '');
+  }
+
+  if (interactive) {
+    tooltip.setAttribute('data-interactive', '');
+  }
+
+  // Tooltip content (text or HTML)
+  var content = document.createElement('div');
+  content.setAttribute('class', 'tippy-tooltip-content');
+
+  if (html) {
+    var templateId = void 0;
+
+    if (html instanceof Element) {
+      content.appendChild(html);
+      templateId = '#' + html.id || 'tippy-html-template';
+    } else {
+      content.innerHTML = document.getElementById(html.replace('#', '')).innerHTML;
+      templateId = html;
+    }
+
+    popper.classList.add('html-template');
+    interactive && popper.setAttribute('tabindex', '-1');
+    tooltip.setAttribute('data-template-id', templateId);
+  } else {
+    content.innerHTML = title;
+  }
+
+  // Init distance. Further updates are made in the popper instance's `onUpdate()` method
+  tooltip.style[getCorePlacement(position)] = getOffsetDistanceInPx(distance);
+
+  tooltip.appendChild(content);
+  popper.appendChild(tooltip);
+
+  return popper;
+}
+
+function createTrigger(event, el, handlers, touchHold) {
+  var listeners = [];
+
+  if (event === 'manual') return listeners;
+
+  // Enter
+  el.addEventListener(event, handlers.handleTrigger);
+  listeners.push({
+    event: event,
+    handler: handlers.handleTrigger
+  });
+
+  // Leave
+  if (event === 'mouseenter') {
+    if (Browser.SUPPORTS_TOUCH && touchHold) {
+      el.addEventListener('touchstart', handlers.handleTrigger);
+      listeners.push({
+        event: 'touchstart',
+        handler: handlers.handleTrigger
+      });
+      el.addEventListener('touchend', handlers.handleMouseleave);
+      listeners.push({
+        event: 'touchend',
+        handler: handlers.handleMouseleave
+      });
+    }
+
+    el.addEventListener('mouseleave', handlers.handleMouseleave);
+    listeners.push({
+      event: 'mouseleave',
+      handler: handlers.handleMouseleave
+    });
+  }
+
+  if (event === 'focus') {
+    el.addEventListener('blur', handlers.handleBlur);
+    listeners.push({
+      event: 'blur',
+      handler: handlers.handleBlur
+    });
+  }
+
+  return listeners;
+}
+
+function cursorIsOutsideInteractiveBorder(event, popper, settings) {
+  if (!popper.getAttribute('x-placement')) return true;
+
+  var x = event.clientX,
+      y = event.clientY;
+  var interactiveBorder = settings.interactiveBorder,
+      distance = settings.distance;
+
+
+  var rect = popper.getBoundingClientRect();
+  var corePosition = getCorePlacement(popper.getAttribute('x-placement'));
+  var borderWithDistance = interactiveBorder + distance;
+
+  var exceeds = {
+    top: rect.top - y > interactiveBorder,
+    bottom: y - rect.bottom > interactiveBorder,
+    left: rect.left - x > interactiveBorder,
+    right: x - rect.right > interactiveBorder
+  };
+
+  switch (corePosition) {
+    case 'top':
+      exceeds.top = rect.top - y > borderWithDistance;
+      break;
+    case 'bottom':
+      exceeds.bottom = y - rect.bottom > borderWithDistance;
+      break;
+    case 'left':
+      exceeds.left = rect.left - x > borderWithDistance;
+      break;
+    case 'right':
+      exceeds.right = x - rect.right > borderWithDistance;
+      break;
+  }
+
+  return exceeds.top || exceeds.bottom || exceeds.left || exceeds.right;
+}
+
+function getEventListenerHandlers(el, popper, settings) {
+  var _this = this;
+
+  var position = settings.position,
+      delay = settings.delay,
+      duration = settings.duration,
+      interactive = settings.interactive,
+      interactiveBorder = settings.interactiveBorder,
+      distance = settings.distance,
+      hideOnClick = settings.hideOnClick,
+      trigger = settings.trigger,
+      touchHold = settings.touchHold,
+      touchWait = settings.touchWait;
+
+
+  var showDelay = void 0,
+      hideDelay = void 0;
+
+  var clearTimeouts = function clearTimeouts() {
+    clearTimeout(showDelay);
+    clearTimeout(hideDelay);
+  };
+
+  var _show = function _show() {
+    clearTimeouts();
+
+    // Not hidden. For clicking when it also has a `focus` event listener
+    if (isVisible(popper)) return;
+
+    var _delay = Array.isArray(delay) ? delay[0] : delay;
+
+    if (delay) {
+      showDelay = setTimeout(function () {
+        return _this.show(popper);
+      }, _delay);
+    } else {
+      _this.show(popper);
+    }
+  };
+
+  var show = function show(event) {
+    return _this.callbacks.wait ? _this.callbacks.wait.call(popper, _show, event) : _show();
+  };
+
+  var hide = function hide() {
+    clearTimeouts();
+
+    var _delay = Array.isArray(delay) ? delay[1] : delay;
+
+    if (delay) {
+      hideDelay = setTimeout(function () {
+        return _this.hide(popper);
+      }, _delay);
+    } else {
+      _this.hide(popper);
+    }
+  };
+
+  var handleTrigger = function handleTrigger(event) {
+    var mouseenterTouch = event.type === 'mouseenter' && Browser.SUPPORTS_TOUCH && Browser.touch;
+
+    if (mouseenterTouch && touchHold) return;
+
+    // Toggle show/hide when clicking click-triggered tooltips
+    var isClick = event.type === 'click';
+    var isNotPersistent = hideOnClick !== 'persistent';
+
+    isClick && isVisible(popper) && isNotPersistent ? hide() : show(event);
+
+    if (mouseenterTouch && Browser.iOS() && el.click) {
+      el.click();
+    }
+  };
+
+  var handleMouseleave = function handleMouseleave(event) {
+
+    // Don't fire 'mouseleave', use the 'touchend'
+    if (event.type === 'mouseleave' && Browser.SUPPORTS_TOUCH && Browser.touch && touchHold) {
+      return;
+    }
+
+    if (interactive) {
+      // Temporarily handle mousemove to check if the mouse left somewhere
+      // other than its popper
+      var handleMousemove = function handleMousemove(event) {
+
+        var triggerHide = function triggerHide() {
+          document.body.removeEventListener('mouseleave', hide);
+          document.removeEventListener('mousemove', handleMousemove);
+          hide();
+        };
+
+        var closestTooltippedEl = closest(event.target, Selectors.TOOLTIPPED_EL);
+
+        var isOverPopper = closest(event.target, Selectors.POPPER) === popper;
+        var isOverEl = closestTooltippedEl === el;
+        var isClickTriggered = trigger.indexOf('click') !== -1;
+        var isOverOtherTooltippedEl = closestTooltippedEl && closestTooltippedEl !== el;
+
+        if (isOverOtherTooltippedEl) {
+          return triggerHide();
+        }
+
+        if (isOverPopper || isOverEl || isClickTriggered) return;
+
+        if (cursorIsOutsideInteractiveBorder(event, popper, settings)) {
+          triggerHide();
+        }
+      };
+
+      document.body.addEventListener('mouseleave', hide);
+      document.addEventListener('mousemove', handleMousemove);
+
+      return;
+    }
+
+    // If it's not interactive, just hide it
+    hide();
+  };
+
+  var handleBlur = function handleBlur(event) {
+    // Ignore blur on touch devices, if there is no `relatedTarget`, hide
+    // If the related target is a popper, ignore
+    if (!event.relatedTarget || Browser.touch) return;
+    if (closest(event.relatedTarget, Selectors.POPPER)) return;
+
+    hide();
+  };
+
+  return {
+    handleTrigger: handleTrigger,
+    handleMouseleave: handleMouseleave,
+    handleBlur: handleBlur
+  };
+}
+
+var idCounter = 1;
+
+/**
+* Creates tooltips for all el elements that match the instance's selector
+* @param {Element[]} els
+* @return {Object[]} Array of ref data objects
+*/
+function createTooltips(els) {
+  var _this = this;
+
+  return els.reduce(function (a, el) {
+    var id = idCounter;
+
+    var settings = _this.settings.performance ? _this.settings : getIndividualSettings(el, _this.settings);
+    // animateFill is disabled if an arrow is true
+    if (settings.arrow) settings.animateFill = false;
+
+    var html = settings.html,
+        trigger = settings.trigger,
+        touchHold = settings.touchHold;
+
+
+    var title = el.getAttribute('title');
+    if (!title && !html) return a;
+
+    el.setAttribute('data-tooltipped', '');
+    el.setAttribute('aria-describedby', 'tippy-tooltip-' + id);
+    removeTitle(el);
+
+    var popper = createPopperElement(id, title, settings);
+    var handlers = getEventListenerHandlers.call(_this, el, popper, settings);
+
+    var listeners = [];
+
+    trigger.trim().split(' ').forEach(function (event) {
+      return listeners = listeners.concat(createTrigger(event, el, handlers, touchHold));
+    });
+
+    a.push({
+      id: id,
+      el: el,
+      popper: popper,
+      settings: settings,
+      listeners: listeners,
+      tippyInstance: _this
+    });
+
+    idCounter++;
+
+    return a;
+  }, []);
+}
+
+var Tippy = function () {
+  function Tippy(selector) {
+    var settings = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : {};
+    classCallCheck$1(this, Tippy);
+
+    // Use default browser tooltip on unsupported browsers
+    if (!Browser.SUPPORTED) return;
+
+    // DOM is presumably mostly ready (for document.body) by instantiation time
+    init();
+
+    this.state = {
+      destroyed: false
+    };
+
+    this.selector = selector;
+
+    this.settings = _extends$1({}, Defaults, settings);
+
+    // DEPRECATION: `on` prefixed callbacks are now preferred over non-
+    // as it better indicates it's a callback function
+    this.callbacks = {
+      wait: settings.wait,
+      show: settings.onShow || settings.show || noop,
+      shown: settings.onShown || settings.shown || noop,
+      hide: settings.onHide || settings.hide || noop,
+      hidden: settings.onHidden || settings.hidden || noop
+    };
+
+    this.store = createTooltips.call(this, getArrayOfElements(selector));
+    Store.push.apply(Store, this.store);
+  }
+
+  /**
+  * Returns the reference element's popper element
+  * @param {Element} el
+  * @return {Element}
+  */
+
+
+  createClass$1(Tippy, [{
+    key: 'getPopperElement',
+    value: function getPopperElement(el) {
+      try {
+        return find(this.store, function (refData) {
+          return refData.el === el;
+        }).popper;
+      } catch (e) {
+        console.error('[getPopperElement]: Element passed as the argument does not exist in the instance');
+      }
+    }
+
+    /**
+    * Returns a popper's reference element
+    * @param {Element} popper
+    * @return {Element}
+    */
+
+  }, {
+    key: 'getReferenceElement',
+    value: function getReferenceElement(popper) {
+      try {
+        return find(this.store, function (refData) {
+          return refData.popper === popper;
+        }).el;
+      } catch (e) {
+        console.error('[getReferenceElement]: Popper passed as the argument does not exist in the instance');
+      }
+    }
+
+    /**
+    * Returns the reference data object from either the reference element or popper element
+    * @param {Element} x (reference element or popper)
+    * @return {Object}
+    */
+
+  }, {
+    key: 'getReferenceData',
+    value: function getReferenceData(x) {
+      return find(this.store, function (refData) {
+        return refData.el === x || refData.popper === x;
+      });
+    }
+
+    /**
+    * Shows a popper
+    * @param {Element} popper
+    * @param {Number} customDuration (optional)
+    */
+
+  }, {
+    key: 'show',
+    value: function show(popper, customDuration) {
+      var _this = this;
+
+      if (this.state.destroyed) return;
+
+      this.callbacks.show.call(popper);
+
+      var refData = find(this.store, function (refData) {
+        return refData.popper === popper;
+      });
+      var tooltip = popper.querySelector(Selectors.TOOLTIP);
+      var circle = popper.querySelector(Selectors.CIRCLE);
+      var content = popper.querySelector(Selectors.CONTENT);
+
+      var el = refData.el,
+          _refData$settings = refData.settings,
+          appendTo = _refData$settings.appendTo,
+          sticky = _refData$settings.sticky,
+          interactive = _refData$settings.interactive,
+          followCursor = _refData$settings.followCursor,
+          flipDuration = _refData$settings.flipDuration,
+          duration = _refData$settings.duration,
+          dynamicTitle = _refData$settings.dynamicTitle;
+
+
+      if (dynamicTitle) {
+        var title = el.getAttribute('title');
+        content.innerHTML = title || content.innerHTML;
+        title && removeTitle(el);
+      }
+
+      var _duration = customDuration !== undefined ? customDuration : Array.isArray(duration) ? duration[0] : duration;
+
+      // Remove transition duration (prevent a transition when popper changes position)
+      applyTransitionDuration([popper, tooltip, circle], 0);
+
+      mountPopper(refData);
+
+      popper.style.visibility = 'visible';
+      popper.setAttribute('aria-hidden', 'false');
+
+      // Wait for popper to update position and alter x-placement
+      queueExecution(function () {
+        if (!isVisible(popper)) return;
+
+        // Sometimes the arrow will not be in the correct position,
+        // force another update
+        if (!followCursor || Browser.touch) {
+          refData.popperInstance.update();
+        }
+
+        // Re-apply transition durations
+        applyTransitionDuration([tooltip, circle], _duration);
+        if (!followCursor || Browser.touch) {
+          applyTransitionDuration([popper], flipDuration);
+        }
+
+        // Make content fade out a bit faster than the tooltip if `animateFill`
+        if (circle) content.style.opacity = 1;
+
+        // Interactive tooltips receive a class of 'active'
+        interactive && el.classList.add('active');
+
+        // Update popper's position on every animation frame
+        sticky && makeSticky(refData);
+
+        // Repaint/reflow is required for CSS transition when appending
+        triggerReflow(tooltip, circle);
+
+        modifyClassList([tooltip, circle], function (list) {
+          list.contains('tippy-notransition') && list.remove('tippy-notransition');
+          list.remove('leave');
+          list.add('enter');
+        });
+
+        // Wait for transitions to complete
+        onTransitionEnd(refData, _duration, function () {
+          if (!isVisible(popper) || refData._onShownFired) return;
+
+          // Focus interactive tooltips only
+          interactive && popper.focus();
+
+          // Remove transitions from tooltip
+          tooltip.classList.add('tippy-notransition');
+
+          // Prevents shown() from firing more than once from early transition cancellations
+          refData._onShownFired = true;
+
+          _this.callbacks.shown.call(popper);
+        });
+      });
+    }
+
+    /**
+    * Hides a popper
+    * @param {Element} popper
+    * @param {Number} customDuration (optional)
+    */
+
+  }, {
+    key: 'hide',
+    value: function hide(popper, customDuration) {
+      var _this2 = this;
+
+      if (this.state.destroyed) return;
+
+      this.callbacks.hide.call(popper);
+
+      var refData = find(this.store, function (refData) {
+        return refData.popper === popper;
+      });
+      var tooltip = popper.querySelector(Selectors.TOOLTIP);
+      var circle = popper.querySelector(Selectors.CIRCLE);
+      var content = popper.querySelector(Selectors.CONTENT);
+
+      var el = refData.el,
+          _refData$settings2 = refData.settings,
+          appendTo = _refData$settings2.appendTo,
+          sticky = _refData$settings2.sticky,
+          interactive = _refData$settings2.interactive,
+          followCursor = _refData$settings2.followCursor,
+          html = _refData$settings2.html,
+          trigger = _refData$settings2.trigger,
+          duration = _refData$settings2.duration;
+
+
+      var _duration = customDuration !== undefined ? customDuration : Array.isArray(duration) ? duration[1] : duration;
+
+      refData._onShownFired = false;
+      interactive && el.classList.remove('active');
+
+      popper.style.visibility = 'hidden';
+      popper.setAttribute('aria-hidden', 'true');
+
+      applyTransitionDuration([tooltip, circle, circle ? content : null], _duration);
+
+      if (circle) content.style.opacity = 0;
+
+      modifyClassList([tooltip, circle], function (list) {
+        list.contains('tippy-tooltip') && list.remove('tippy-notransition');
+        list.remove('enter');
+        list.add('leave');
+      });
+
+      // Re-focus click-triggered html elements
+      // and the tooltipped element IS in the viewport (otherwise it causes unsightly scrolling
+      // if the tooltip is closed and the element isn't in the viewport anymore)
+      if (html && trigger.indexOf('click') !== -1 && elementIsInViewport(el)) {
+        el.focus();
+      }
+
+      // Wait for transitions to complete
+      onTransitionEnd(refData, _duration, function () {
+        if (isVisible(popper) || !appendTo.contains(popper)) return;
+
+        el.removeEventListener('mousemove', followCursorHandler);
+
+        refData.popperInstance.disableEventListeners();
+
+        appendTo.removeChild(popper);
+
+        _this2.callbacks.hidden.call(popper);
+      });
+    }
+
+    /**
+    * Updates a popper with new content
+    * @param {Element} popper
+    */
+
+  }, {
+    key: 'update',
+    value: function update(popper) {
+      if (this.state.destroyed) return;
+
+      var refData = find(this.store, function (refData) {
+        return refData.popper === popper;
+      });
+      var content = popper.querySelector(Selectors.CONTENT);
+      var el = refData.el,
+          html = refData.settings.html;
+
+
+      if (html instanceof Element) {
+        console.warn('Aborted: update() should not be used if `html` is a DOM element');
+        return;
+      }
+
+      content.innerHTML = html ? document.getElementById(html.replace('#', '')).innerHTML : el.getAttribute('title') || el.getAttribute('data-original-title');
+
+      if (!html) removeTitle(el);
+    }
+
+    /**
+    * Destroys a popper
+    * @param {Element} popper
+    * @param {Boolean} _isLast - private param used by destroyAll to optimize
+    */
+
+  }, {
+    key: 'destroy',
+    value: function destroy(popper, _isLast) {
+      var _this3 = this;
+
+      if (this.state.destroyed) return;
+
+      var refData = find(this.store, function (refData) {
+        return refData.popper === popper;
+      });
+
+      var el = refData.el,
+          popperInstance = refData.popperInstance,
+          listeners = refData.listeners,
+          _mutationObserver = refData._mutationObserver;
+
+      // Ensure the popper is hidden
+
+      if (isVisible(popper)) {
+        this.hide(popper, 0);
+      }
+
+      // Remove Tippy-only event listeners from tooltipped element
+      listeners.forEach(function (listener) {
+        return el.removeEventListener(listener.event, listener.handler);
+      });
+
+      // Restore original title
+      el.setAttribute('title', el.getAttribute('data-original-title'));
+
+      el.removeAttribute('data-original-title');
+      el.removeAttribute('data-tooltipped');
+      el.removeAttribute('aria-describedby');
+
+      popperInstance && popperInstance.destroy();
+      _mutationObserver && _mutationObserver.disconnect();
+
+      // Remove from store
+      Store.splice(findIndex(Store, function (refData) {
+        return refData.popper === popper;
+      }), 1);
+
+      // Ensure filter is called only once
+      if (_isLast === undefined || _isLast) {
+        this.store = Store.filter(function (refData) {
+          return refData.tippyInstance === _this3;
+        });
+      }
+    }
+
+    /**
+    * Destroys all tooltips created by the instance
+    */
+
+  }, {
+    key: 'destroyAll',
+    value: function destroyAll() {
+      var _this4 = this;
+
+      if (this.state.destroyed) return;
+
+      var storeLength = this.store.length;
+
+      this.store.forEach(function (_ref, index) {
+        var popper = _ref.popper;
+
+        _this4.destroy(popper, index === storeLength - 1);
+      });
+
+      this.store = null;
+      this.state.destroyed = true;
+    }
+  }]);
+  return Tippy;
+}();
+
+function tippy$2(selector, settings) {
+  return new Tippy(selector, settings);
+}
+
+tippy$2.Browser = Browser;
+tippy$2.Defaults = Defaults;
+tippy$2.disableDynamicInputDetection = function () {
+  return Browser.dynamicInputDetection = false;
+};
+tippy$2.enableDynamicInputDetection = function () {
+  return Browser.dynamicInputDetection = true;
+};
+
+return tippy$2;
+
+})));

--- a/src/js/core/getArrayOfElements.js
+++ b/src/js/core/getArrayOfElements.js
@@ -1,11 +1,14 @@
 /**
 * Returns an array of elements based on the selector input
-* @param {String|Element} selector
+* @param {String|Array|Element} selector
 * @return {Elements[]}
 */
 export default function getArrayOfElements(selector) {
   if (selector instanceof Element) {
     return [selector]
+  }
+  if (Object.prototype.toString.call(selector) === '[object Array]') {
+    return selector;
   }
 
   return [].slice.call(document.querySelectorAll(selector))

--- a/src/js/core/getArrayOfElements.js
+++ b/src/js/core/getArrayOfElements.js
@@ -7,7 +7,7 @@ export default function getArrayOfElements(selector) {
   if (selector instanceof Element) {
     return [selector]
   }
-  if (Object.prototype.toString.call(selector) === '[object Array]') {
+  if (Array.isArray(selector)) {
     return selector;
   }
 

--- a/tests/functional.js
+++ b/tests/functional.js
@@ -1,15 +1,15 @@
 var Browser = {};
 
 if (typeof window !== 'undefined') {
-    Browser.SUPPORTED = 'requestAnimationFrame' in window;
-    Browser.SUPPORTS_TOUCH = 'ontouchstart' in window;
-    Browser.touch = false;
-    Browser.dynamicInputDetection = true;
-    // Chrome device/touch emulation can make this dynamic
-    Browser.iOS = function () {
-        return (/iPhone|iPad|iPod/.test(navigator.userAgent) && !window.MSStream
-        );
-    };
+  Browser.SUPPORTED = 'requestAnimationFrame' in window;
+  Browser.SUPPORTS_TOUCH = 'ontouchstart' in window;
+  Browser.touch = false;
+  Browser.dynamicInputDetection = true;
+  // Chrome device/touch emulation can make this dynamic
+  Browser.iOS = function () {
+    return (/iPhone|iPad|iPod/.test(navigator.userAgent) && !window.MSStream
+    );
+  };
 }
 
 /**
@@ -24,82 +24,82 @@ var Store = [];
 * Selector constants used for grabbing elements
 */
 var Selectors = {
-    POPPER: '.tippy-popper',
-    TOOLTIP: '.tippy-tooltip',
-    CONTENT: '.tippy-tooltip-content',
-    CIRCLE: '[x-circle]',
-    ARROW: '[x-arrow]',
-    TOOLTIPPED_EL: '[data-tooltipped]',
-    CONTROLLER: '[data-tippy-controller]'
-};
+  POPPER: '.tippy-popper',
+  TOOLTIP: '.tippy-tooltip',
+  CONTENT: '.tippy-tooltip-content',
+  CIRCLE: '[x-circle]',
+  ARROW: '[x-arrow]',
+  TOOLTIPPED_EL: '[data-tooltipped]',
+  CONTROLLER: '[data-tippy-controller]'
 
-/**
-* The default settings applied to each instance
-*/
-var Defaults = {
-    html: false,
-    position: 'top',
-    animation: 'shift',
-    animateFill: true,
-    arrow: false,
-    arrowSize: 'regular',
-    delay: 0,
-    trigger: 'mouseenter focus',
-    duration: 350,
-    interactive: false,
-    interactiveBorder: 2,
-    theme: 'dark',
-    size: 'regular',
-    distance: 10,
-    offset: 0,
-    hideOnClick: true,
-    multiple: false,
-    followCursor: false,
-    inertia: false,
-    flipDuration: 350,
-    sticky: false,
-    stickyDuration: 200,
-    appendTo: null,
-    zIndex: 9999,
-    touchHold: false,
-    performance: false,
-    popperOptions: {}
-};
+  /**
+  * The default settings applied to each instance
+  */
+};var Defaults = {
+  html: false,
+  position: 'top',
+  animation: 'shift',
+  animateFill: true,
+  arrow: false,
+  arrowSize: 'regular',
+  delay: 0,
+  trigger: 'mouseenter focus',
+  duration: 350,
+  interactive: false,
+  interactiveBorder: 2,
+  theme: 'dark',
+  size: 'regular',
+  distance: 10,
+  offset: 0,
+  hideOnClick: true,
+  multiple: false,
+  followCursor: false,
+  inertia: false,
+  flipDuration: 350,
+  sticky: false,
+  stickyDuration: 200,
+  appendTo: null,
+  zIndex: 9999,
+  touchHold: false,
+  performance: false,
+  dynamicTitle: false,
+  popperOptions: {}
 
-/**
-* The keys of the defaults object for reducing down into a new object
-* Used in `getIndividualSettings()`
-*/
-var DefaultsKeys = Browser.SUPPORTED && Object.keys(Defaults);
+  /**
+  * The keys of the defaults object for reducing down into a new object
+  * Used in `getIndividualSettings()`
+  */
+};var DefaultsKeys = Browser.SUPPORTED && Object.keys(Defaults);
 
 /**
 * Hides all poppers
 * @param {Object} exclude - refData to exclude if needed
 */
 function hideAllPoppers(exclude) {
-    Store.forEach(function (refData) {
-        var popper = refData.popper,
-            tippyInstance = refData.tippyInstance,
-            _refData$settings = refData.settings,
-            appendTo = _refData$settings.appendTo,
-            hideOnClick = _refData$settings.hideOnClick,
-            trigger = _refData$settings.trigger;
+  Store.forEach(function (refData) {
+    var popper = refData.popper,
+        tippyInstance = refData.tippyInstance,
+        _refData$settings = refData.settings,
+        appendTo = _refData$settings.appendTo,
+        hideOnClick = _refData$settings.hideOnClick,
+        trigger = _refData$settings.trigger;
 
-        // Don't hide already hidden ones
+    // Don't hide already hidden ones
 
-        if (!appendTo.contains(popper)) return;
+    if (!appendTo.contains(popper)) return;
 
-        // hideOnClick can have the truthy value of 'persistent', so strict check is needed
-        var isHideOnClick = hideOnClick === true || trigger.indexOf('focus') !== -1;
-        var isNotCurrentRef = !exclude || popper !== exclude.popper;
+    // hideOnClick can have the truthy value of 'persistent', so strict check is needed
+    var isHideOnClick = hideOnClick === true || trigger.indexOf('focus') !== -1;
+    var isNotCurrentRef = !exclude || popper !== exclude.popper;
 
-        if (isHideOnClick && isNotCurrentRef) {
-            tippyInstance.hide(popper);
-        }
-    });
+    if (isHideOnClick && isNotCurrentRef) {
+      tippyInstance.hide(popper);
+    }
+  });
 }
 
-var matches = Element.prototype.matches || Element.prototype.matchesSelector || Element.prototype.webkitMatchesSelector || Element.prototype.mozMatchesSelector || Element.prototype.msMatchesSelector || function (s) {
+var e = Element.prototype;
+var matches = e.matches || e.matchesSelector || e.webkitMatchesSelector || e.mozMatchesSelector || e.msMatchesSelector || function (s) {
     var matches = (this.document || this.ownerDocument).querySelectorAll(s),
         i = matches.length;
     while (--i >= 0 && matches.item(i) !== this) {}
@@ -113,17 +113,17 @@ var matches = Element.prototype.matches || Element.prototype.matchesSelector || 
 * @return {Element}
 */
 function closest(element, parentSelector) {
-    var _closest = Element.prototype.closest || function (selector) {
-        var el = this;
-        while (el) {
-            if (matches.call(el, selector)) {
-                return el;
-            }
-            el = el.parentElement;
-        }
-    };
+  var _closest = Element.prototype.closest || function (selector) {
+    var el = this;
+    while (el) {
+      if (matches.call(el, selector)) {
+        return el;
+      }
+      el = el.parentElement;
+    }
+  };
 
-    return _closest.call(element, parentSelector);
+  return _closest.call(element, parentSelector);
 }
 
 /**
@@ -145,99 +145,99 @@ function find(arr, checkFn) {
 * Adds the needed event listeners
 */
 function bindEventListeners() {
-    var touchHandler = function touchHandler() {
-        Browser.touch = true;
+  var touchHandler = function touchHandler() {
+    Browser.touch = true;
 
-        if (Browser.iOS()) {
-            document.body.classList.add('tippy-touch');
-        }
-
-        if (Browser.dynamicInputDetection) {
-            document.addEventListener('mousemove', mousemoveHandler);
-        }
-    };
-
-    var mousemoveHandler = function () {
-        var time = void 0;
-
-        return function () {
-            var now = performance && performance.now();
-
-            if (now && now - time < 10) {
-                Browser.touch = false;
-                document.removeEventListener('mousemove', mousemoveHandler);
-                if (!Browser.iOS() && document.body.classList.contains('tippy-touch')) {
-                    document.body.classList.remove('tippy-touch');
-                }
-            }
-
-            time = now;
-        };
-    }();
-
-    var clickHandler = function clickHandler(event) {
-
-        // Simulated events dispatched on the document
-        if (!(event.target instanceof Element)) {
-            return hideAllPoppers();
-        }
-
-        var el = closest(event.target, Selectors.TOOLTIPPED_EL);
-        var popper = closest(event.target, Selectors.POPPER);
-
-        if (popper) {
-            var ref = find(Store, function (ref) {
-                return ref.popper === popper;
-            });
-            var interactive = ref.settings.interactive;
-
-            if (interactive) return;
-        }
-
-        if (el) {
-            var _ref = find(Store, function (ref) {
-                return ref.el === el;
-            });
-            var _ref$settings = _ref.settings,
-                hideOnClick = _ref$settings.hideOnClick,
-                multiple = _ref$settings.multiple,
-                trigger = _ref$settings.trigger;
-
-            // Hide all poppers except the one belonging to the element that was clicked IF
-            // `multiple` is false AND they are a touch user, OR
-            // `multiple` is false AND it's triggered by a click
-
-            if (!multiple && Browser.touch || !multiple && trigger.indexOf('click') !== -1) {
-                return hideAllPoppers(_ref);
-            }
-
-            // If hideOnClick is not strictly true or triggered by a click don't hide poppers
-            if (hideOnClick !== true || trigger.indexOf('click') !== -1) return;
-        }
-
-        // Don't trigger a hide for tippy controllers, and don't needlessly run loop
-        if (closest(event.target, Selectors.CONTROLLER) || !document.querySelector(Selectors.POPPER)) return;
-
-        hideAllPoppers();
-    };
-
-    var blurHandler = function blurHandler(event) {
-        var _document = document,
-            el = _document.activeElement;
-
-        if (el && el.blur && matches.call(el, Selectors.TOOLTIPPED_EL)) {
-            el.blur();
-        }
-    };
-
-    // Hook events
-    document.addEventListener('click', clickHandler);
-    document.addEventListener('touchstart', touchHandler);
-    window.addEventListener('blur', blurHandler);
-
-    if (!Browser.SUPPORTS_TOUCH && (navigator.maxTouchPoints > 0 || navigator.msMaxTouchPoints > 0)) {
-        document.addEventListener('pointerdown', touchHandler);
+    if (Browser.iOS()) {
+      document.body.classList.add('tippy-touch');
     }
+
+    if (Browser.dynamicInputDetection && window.performance) {
+      document.addEventListener('mousemove', mousemoveHandler);
+    }
+  };
+
+  var mousemoveHandler = function () {
+    var time = void 0;
+
+    return function () {
+      var now = performance.now();
+
+      // Chrome 60+ is 1 mousemove per rAF, use 20ms time difference
+      if (now - time < 20) {
+        Browser.touch = false;
+        document.removeEventListener('mousemove', mousemoveHandler);
+        if (!Browser.iOS()) {
+          document.body.classList.remove('tippy-touch');
+        }
+      }
+
+      time = now;
+    };
+  }();
+
+  var clickHandler = function clickHandler(event) {
+    // Simulated events dispatched on the document
+    if (!(event.target instanceof Element)) {
+      return hideAllPoppers();
+    }
+
+    var el = closest(event.target, Selectors.TOOLTIPPED_EL);
+    var popper = closest(event.target, Selectors.POPPER);
+
+    if (popper) {
+      var ref = find(Store, function (ref) {
+        return ref.popper === popper;
+      });
+      var interactive = ref.settings.interactive;
+
+      if (interactive) return;
+    }
+
+    if (el) {
+      var _ref = find(Store, function (ref) {
+        return ref.el === el;
+      });
+      var _ref$settings = _ref.settings,
+          hideOnClick = _ref$settings.hideOnClick,
+          multiple = _ref$settings.multiple,
+          trigger = _ref$settings.trigger;
+
+      // Hide all poppers except the one belonging to the element that was clicked IF
+      // `multiple` is false AND they are a touch user, OR
+      // `multiple` is false AND it's triggered by a click
+
+      if (!multiple && Browser.touch || !multiple && trigger.indexOf('click') !== -1) {
+        return hideAllPoppers(_ref);
+      }
+
+      // If hideOnClick is not strictly true or triggered by a click don't hide poppers
+      if (hideOnClick !== true || trigger.indexOf('click') !== -1) return;
+    }
+
+    // Don't trigger a hide for tippy controllers, and don't needlessly run loop
+    if (closest(event.target, Selectors.CONTROLLER) || !document.querySelector(Selectors.POPPER)) return;
+
+    hideAllPoppers();
+  };
+
+  var blurHandler = function blurHandler(event) {
+    var _document = document,
+        el = _document.activeElement;
+
+    if (el && el.blur && matches.call(el, Selectors.TOOLTIPPED_EL)) {
+      el.blur();
+    }
+  };
+
+  // Hook events
+  document.addEventListener('click', clickHandler);
+  document.addEventListener('touchstart', touchHandler);
+  window.addEventListener('blur', blurHandler);
+
+  if (!Browser.SUPPORTS_TOUCH && (navigator.maxTouchPoints > 0 || navigator.msMaxTouchPoints > 0)) {
+    document.addEventListener('pointerdown', touchHandler);
+  }
 }
 
 /**
@@ -245,16 +245,16 @@ function bindEventListeners() {
 * @return {Boolean} whether the function has run or not
 */
 function init() {
-    if (init.done) return false;
-    init.done = true;
+  if (init.done) return false;
+  init.done = true;
 
-    // If the script is in <head>, document.body is null, so it's set in the
-    // init function
-    Defaults.appendTo = document.body;
+  // If the script is in <head>, document.body is null, so it's set in the
+  // init function
+  Defaults.appendTo = document.body;
 
-    bindEventListeners();
+  bindEventListeners();
 
-    return true;
+  return true;
 }
 
 function noop() {}
@@ -265,7 +265,7 @@ function noop() {}
 * @return {String}
 */
 function getCorePlacement(placement) {
-    return placement.replace(/-.+/, '');
+  return placement.replace(/-.+/, '');
 }
 
 /**
@@ -289,18 +289,18 @@ function findIndex(arr, checkFn) {
 * @return {String} - browser supported prefixed property
 */
 function prefix(property) {
-    var prefixes = [false, 'webkit'];
-    var upperProp = property.charAt(0).toUpperCase() + property.slice(1);
+  var prefixes = [false, 'webkit'];
+  var upperProp = property.charAt(0).toUpperCase() + property.slice(1);
 
-    for (var i = 0; i < prefixes.length; i++) {
-        var _prefix = prefixes[i];
-        var prefixedProp = _prefix ? '' + _prefix + upperProp : property;
-        if (typeof window.document.body.style[prefixedProp] !== 'undefined') {
-            return prefixedProp;
-        }
+  for (var i = 0; i < prefixes.length; i++) {
+    var _prefix = prefixes[i];
+    var prefixedProp = _prefix ? '' + _prefix + upperProp : property;
+    if (typeof window.document.body.style[prefixedProp] !== 'undefined') {
+      return prefixedProp;
     }
+  }
 
-    return null;
+  return null;
 }
 
 /**
@@ -309,7 +309,7 @@ function prefix(property) {
 * @return {Boolean}
 */
 function isVisible(popper) {
-    return popper.style.visibility === 'visible';
+  return popper.style.visibility === 'visible';
 }
 
 /**
@@ -319,7 +319,7 @@ function isVisible(popper) {
 * @return {String}
 */
 function getOffsetDistanceInPx(distance) {
-    return -(distance - Defaults.distance) + 'px';
+  return -(distance - Defaults.distance) + 'px';
 }
 
 /**
@@ -328,10 +328,10 @@ function getOffsetDistanceInPx(distance) {
 * @param {Function} callback
 */
 function modifyClassList(els, callback) {
-    els.forEach(function (el) {
-        if (!el) return;
-        callback(el.classList);
-    });
+  els.forEach(function (el) {
+    if (!el) return;
+    callback(el.classList);
+  });
 }
 
 /**
@@ -340,15 +340,15 @@ function modifyClassList(els, callback) {
 * @param {Number} duration
 */
 function applyTransitionDuration(els, duration) {
-    els.forEach(function (el) {
-        if (!el) return;
+  els.forEach(function (el) {
+    if (!el) return;
 
-        var isContent = matches.call(el, Selectors.CONTENT);
+    var isContent = matches.call(el, Selectors.CONTENT);
 
-        var _duration = isContent ? Math.round(duration / 1.3) : duration;
+    var _duration = isContent ? Math.round(duration / 1.3) : duration;
 
-        el.style[prefix('transitionDuration')] = _duration + 'ms';
-    });
+    el.style[prefix('transitionDuration')] = _duration + 'ms';
+  });
 }
 
 /**
@@ -359,41 +359,41 @@ function applyTransitionDuration(els, duration) {
 * @return {Boolean}
 */
 function cursorIsOutsideInteractiveBorder(event, popper, settings) {
-    if (!popper.getAttribute('x-placement')) return true;
+  if (!popper.getAttribute('x-placement')) return true;
 
-    var x = event.clientX,
-        y = event.clientY;
-    var interactiveBorder = settings.interactiveBorder,
-        distance = settings.distance;
+  var x = event.clientX,
+      y = event.clientY;
+  var interactiveBorder = settings.interactiveBorder,
+      distance = settings.distance;
 
 
-    var rect = popper.getBoundingClientRect();
-    var corePosition = getCorePlacement(popper.getAttribute('x-placement'));
-    var borderWithDistance = interactiveBorder + distance;
+  var rect = popper.getBoundingClientRect();
+  var corePosition = getCorePlacement(popper.getAttribute('x-placement'));
+  var borderWithDistance = interactiveBorder + distance;
 
-    var exceeds = {
-        top: rect.top - y > interactiveBorder,
-        bottom: y - rect.bottom > interactiveBorder,
-        left: rect.left - x > interactiveBorder,
-        right: x - rect.right > interactiveBorder
-    };
+  var exceeds = {
+    top: rect.top - y > interactiveBorder,
+    bottom: y - rect.bottom > interactiveBorder,
+    left: rect.left - x > interactiveBorder,
+    right: x - rect.right > interactiveBorder
+  };
 
-    switch (corePosition) {
-        case 'top':
-            exceeds.top = rect.top - y > borderWithDistance;
-            break;
-        case 'bottom':
-            exceeds.bottom = y - rect.bottom > borderWithDistance;
-            break;
-        case 'left':
-            exceeds.left = rect.left - x > borderWithDistance;
-            break;
-        case 'right':
-            exceeds.right = x - rect.right > borderWithDistance;
-            break;
-    }
+  switch (corePosition) {
+    case 'top':
+      exceeds.top = rect.top - y > borderWithDistance;
+      break;
+    case 'bottom':
+      exceeds.bottom = y - rect.bottom > borderWithDistance;
+      break;
+    case 'left':
+      exceeds.left = rect.left - x > borderWithDistance;
+      break;
+    case 'right':
+      exceeds.right = x - rect.right > borderWithDistance;
+      break;
+  }
 
-    return exceeds.top || exceeds.bottom || exceeds.left || exceeds.right;
+  return exceeds.top || exceeds.bottom || exceeds.left || exceeds.right;
 }
 
 /**
@@ -405,49 +405,48 @@ function cursorIsOutsideInteractiveBorder(event, popper, settings) {
 * @return {Array} - array of listener objects
 */
 function createTrigger(event, el, handlers, touchHold) {
-    var listeners = [];
+  var listeners = [];
 
-    if (event === 'manual') return listeners;
+  if (event === 'manual') return listeners;
 
-    // Enter
-    el.addEventListener(event, handlers.handleTrigger);
-    listeners.push({
-        event: event,
+  // Enter
+  el.addEventListener(event, handlers.handleTrigger);
+  listeners.push({
+    event: event,
+    handler: handlers.handleTrigger
+  });
+
+  // Leave
+  if (event === 'mouseenter') {
+    if (Browser.SUPPORTS_TOUCH && touchHold) {
+      el.addEventListener('touchstart', handlers.handleTrigger);
+      listeners.push({
+        event: 'touchstart',
         handler: handlers.handleTrigger
+      });
+      el.addEventListener('touchend', handlers.handleMouseleave);
+      listeners.push({
+        event: 'touchend',
+        handler: handlers.handleMouseleave
+      });
+    }
+
+    el.addEventListener('mouseleave', handlers.handleMouseleave);
+    listeners.push({
+      event: 'mouseleave',
+      handler: handlers.handleMouseleave
     });
+  }
 
-    // Leave
-    if (event === 'mouseenter') {
+  if (event === 'focus') {
+    el.addEventListener('blur', handlers.handleBlur);
+    listeners.push({
+      event: 'blur',
+      handler: handlers.handleBlur
+    });
+  }
 
-        if (Browser.SUPPORTS_TOUCH && touchHold) {
-            el.addEventListener('touchstart', handlers.handleTrigger);
-            listeners.push({
-                event: 'touchstart',
-                handler: handlers.handleTrigger
-            });
-            el.addEventListener('touchend', handlers.handleMouseleave);
-            listeners.push({
-                event: 'touchend',
-                handler: handlers.handleMouseleave
-            });
-        }
-
-        el.addEventListener('mouseleave', handlers.handleMouseleave);
-        listeners.push({
-            event: 'mouseleave',
-            handler: handlers.handleMouseleave
-        });
-    }
-
-    if (event === 'focus') {
-        el.addEventListener('blur', handlers.handleBlur);
-        listeners.push({
-            event: 'blur',
-            handler: handlers.handleBlur
-        });
-    }
-
-    return listeners;
+  return listeners;
 }
 
 /**
@@ -457,35 +456,34 @@ function createTrigger(event, el, handlers, touchHold) {
 * @param {Function} callback - callback function to fire once transitions complete
 */
 function onTransitionEnd(refData, duration, callback) {
+  // Make callback synchronous if duration is 0
+  if (!duration) {
+    return callback();
+  }
 
-    // Make callback synchronous if duration is 0
-    if (!duration) {
-        return callback();
-    }
+  var tooltip = refData.popper.querySelector(Selectors.TOOLTIP);
+  var transitionendFired = false;
 
-    var tooltip = refData.popper.querySelector(Selectors.TOOLTIP);
-    var transitionendFired = false;
+  var listenerCallback = function listenerCallback(e) {
+    if (e.target !== tooltip) return;
 
-    var listenerCallback = function listenerCallback(e) {
-        if (e.target !== tooltip) return;
+    transitionendFired = true;
 
-        transitionendFired = true;
+    tooltip.removeEventListener('webkitTransitionEnd', listenerCallback);
+    tooltip.removeEventListener('transitionend', listenerCallback);
 
-        tooltip.removeEventListener('webkitTransitionEnd', listenerCallback);
-        tooltip.removeEventListener('transitionend', listenerCallback);
+    callback();
+  };
 
-        callback();
-    };
+  // Wait for transitions to complete
+  tooltip.addEventListener('webkitTransitionEnd', listenerCallback);
+  tooltip.addEventListener('transitionend', listenerCallback);
 
-    // Wait for transitions to complete
-    tooltip.addEventListener('webkitTransitionEnd', listenerCallback);
-    tooltip.addEventListener('transitionend', listenerCallback);
-
-    // transitionend listener sometimes may not fire
-    clearTimeout(refData._transitionendTimeout);
-    refData._transitionendTimeout = setTimeout(function () {
-        !transitionendFired && callback();
-    }, duration);
+  // transitionend listener sometimes may not fire
+  clearTimeout(refData._transitionendTimeout);
+  refData._transitionendTimeout = setTimeout(function () {
+    !transitionendFired && callback();
+  }, duration);
 }
 
 /**
@@ -493,68 +491,68 @@ function onTransitionEnd(refData, duration, callback) {
 * @param {MouseEvent} e
 */
 function followCursorHandler(e) {
-    var _this = this;
+  var _this = this;
 
-    var refData = find(Store, function (refData) {
-        return refData.el === _this;
-    });
+  var refData = find(Store, function (refData) {
+    return refData.el === _this;
+  });
 
-    var popper = refData.popper,
-        offset = refData.settings.offset;
-
-
-    var position = getCorePlacement(popper.getAttribute('x-placement'));
-    var halfPopperWidth = Math.round(popper.offsetWidth / 2);
-    var halfPopperHeight = Math.round(popper.offsetHeight / 2);
-    var viewportPadding = 5;
-    var pageWidth = document.documentElement.offsetWidth || document.body.offsetWidth;
-
-    var pageX = e.pageX,
-        pageY = e.pageY;
+  var popper = refData.popper,
+      offset = refData.settings.offset;
 
 
-    var x = void 0,
-        y = void 0;
+  var position = getCorePlacement(popper.getAttribute('x-placement'));
+  var halfPopperWidth = Math.round(popper.offsetWidth / 2);
+  var halfPopperHeight = Math.round(popper.offsetHeight / 2);
+  var viewportPadding = 5;
+  var pageWidth = document.documentElement.offsetWidth || document.body.offsetWidth;
 
-    switch (position) {
-        case 'top':
-            x = pageX - halfPopperWidth + offset;
-            y = pageY - 2.25 * halfPopperHeight;
-            break;
-        case 'left':
-            x = pageX - 2 * halfPopperWidth - 10;
-            y = pageY - halfPopperHeight + offset;
-            break;
-        case 'right':
-            x = pageX + halfPopperHeight;
-            y = pageY - halfPopperHeight + offset;
-            break;
-        case 'bottom':
-            x = pageX - halfPopperWidth + offset;
-            y = pageY + halfPopperHeight / 1.5;
-            break;
+  var pageX = e.pageX,
+      pageY = e.pageY;
+
+
+  var x = void 0,
+      y = void 0;
+
+  switch (position) {
+    case 'top':
+      x = pageX - halfPopperWidth + offset;
+      y = pageY - 2.25 * halfPopperHeight;
+      break;
+    case 'left':
+      x = pageX - 2 * halfPopperWidth - 10;
+      y = pageY - halfPopperHeight + offset;
+      break;
+    case 'right':
+      x = pageX + halfPopperHeight;
+      y = pageY - halfPopperHeight + offset;
+      break;
+    case 'bottom':
+      x = pageX - halfPopperWidth + offset;
+      y = pageY + halfPopperHeight / 1.5;
+      break;
+  }
+
+  var isRightOverflowing = pageX + viewportPadding + halfPopperWidth + offset > pageWidth;
+  var isLeftOverflowing = pageX - viewportPadding - halfPopperWidth + offset < 0;
+
+  // Prevent left/right overflow
+  if (position === 'top' || position === 'bottom') {
+    if (isRightOverflowing) {
+      x = pageWidth - viewportPadding - 2 * halfPopperWidth;
     }
 
-    var isRightOverflowing = pageX + viewportPadding + halfPopperWidth + offset > pageWidth;
-    var isLeftOverflowing = pageX - viewportPadding - halfPopperWidth + offset < 0;
-
-    // Prevent left/right overflow
-    if (position === 'top' || position === 'bottom') {
-        if (isRightOverflowing) {
-            x = pageWidth - viewportPadding - 2 * halfPopperWidth;
-        }
-
-        if (isLeftOverflowing) {
-            x = viewportPadding;
-        }
+    if (isLeftOverflowing) {
+      x = viewportPadding;
     }
+  }
 
-    popper.style[prefix('transform')] = 'translate3d(' + x + 'px, ' + y + 'px, 0)';
+  popper.style[prefix('transform')] = 'translate3d(' + x + 'px, ' + y + 'px, 0)';
 }
 
 /**!
  * @fileOverview Kickass library to create and place poppers near their reference elements.
- * @version 1.10.8
+ * @version 1.11.0
  * @license
  * Copyright (c) 2016 Federico Zivolo and contributors
  *
@@ -724,30 +722,6 @@ function getScrollParent(element) {
   return getScrollParent(getParentNode(element));
 }
 
-function isOffsetContainer(element) {
-  var nodeName = element.nodeName;
-
-  if (nodeName === 'BODY') {
-    return false;
-  }
-  return nodeName === 'HTML' || element.firstElementChild.offsetParent === element;
-}
-
-/**
- * Finds the root node (document, shadowDOM root) of the given element
- * @method
- * @memberof Popper.Utils
- * @argument {Element} node
- * @returns {Element} root node
- */
-function getRoot(node) {
-  if (node.parentNode !== null) {
-    return getRoot(node.parentNode);
-  }
-
-  return node;
-}
-
 /**
  * Returns the offset parent of the given element
  * @method
@@ -764,7 +738,37 @@ function getOffsetParent(element) {
     return window.document.documentElement;
   }
 
+  // .offsetParent will return the closest TD or TABLE in case
+  // no offsetParent is present, I hate this job...
+  if (['TD', 'TABLE'].indexOf(offsetParent.nodeName) !== -1 && getStyleComputedProperty(offsetParent, 'position') === 'static') {
+    return getOffsetParent(offsetParent);
+  }
+
   return offsetParent;
+}
+
+function isOffsetContainer(element) {
+  var nodeName = element.nodeName;
+
+  if (nodeName === 'BODY') {
+    return false;
+  }
+  return nodeName === 'HTML' || getOffsetParent(element.firstElementChild) === element;
+}
+
+/**
+ * Finds the root node (document, shadowDOM root) of the given element
+ * @method
+ * @memberof Popper.Utils
+ * @argument {Element} node
+ * @returns {Element} root node
+ */
+function getRoot(node) {
+  if (node.parentNode !== null) {
+    return getRoot(node.parentNode);
+  }
+
+  return node;
 }
 
 /**
@@ -1467,10 +1471,10 @@ function isModifierEnabled(modifiers, modifierName) {
  * @method
  * @memberof Popper.Utils
  * @argument {String} property (camelCase)
- * @returns {String} prefixed property (camelCase)
+ * @returns {String} prefixed property (camelCase or PascalCase, depending on the vendor prefix)
  */
 function getSupportedPropertyName(property) {
-  var prefixes = [false, 'ms', 'webkit', 'moz', 'o'];
+  var prefixes = [false, 'ms', 'Webkit', 'Moz', 'O'];
   var upperProp = property.charAt(0).toUpperCase() + property.slice(1);
 
   for (var i = 0; i < prefixes.length - 1; i++) {
@@ -3040,40 +3044,40 @@ var _extends$1 = Object.assign || function (target) {
 * @return {Object} - the popper instance
 */
 function createPopperInstance(refData) {
-    var el = refData.el,
-        popper = refData.popper,
-        _refData$settings = refData.settings,
-        position = _refData$settings.position,
-        popperOptions = _refData$settings.popperOptions,
-        offset = _refData$settings.offset,
-        distance = _refData$settings.distance,
-        flipDuration = _refData$settings.flipDuration;
+  var el = refData.el,
+      popper = refData.popper,
+      _refData$settings = refData.settings,
+      position = _refData$settings.position,
+      popperOptions = _refData$settings.popperOptions,
+      offset = _refData$settings.offset,
+      distance = _refData$settings.distance,
+      flipDuration = _refData$settings.flipDuration;
 
 
-    var tooltip = popper.querySelector(Selectors.TOOLTIP);
-    var flipped = void 0;
+  var tooltip = popper.querySelector(Selectors.TOOLTIP);
 
-    var config = _extends$1({
-        placement: position
-    }, popperOptions || {}, {
-        modifiers: _extends$1({}, popperOptions ? popperOptions.modifiers : {}, {
-            flip: _extends$1({
-                padding: distance + 5 /* 5px from viewport boundary */
-            }, popperOptions && popperOptions.modifiers ? popperOptions.modifiers.flip : {}),
-            offset: _extends$1({
-                offset: offset
-            }, popperOptions && popperOptions.modifiers ? popperOptions.modifiers.offset : {})
-        }),
-        onUpdate: function onUpdate(data) {
-            tooltip.style.top = '';
-            tooltip.style.bottom = '';
-            tooltip.style.left = '';
-            tooltip.style.right = '';
-            tooltip.style[getCorePlacement(popper.getAttribute('x-placement'))] = getOffsetDistanceInPx(distance);
-        }
-    });
+  var config = _extends$1({
+    placement: position
+  }, popperOptions || {}, {
+    modifiers: _extends$1({}, popperOptions ? popperOptions.modifiers : {}, {
+      flip: _extends$1({
+        padding: distance + 5 /* 5px from viewport boundary */
+      }, popperOptions && popperOptions.modifiers ? popperOptions.modifiers.flip : {}),
+      offset: _extends$1({
+        offset: offset
+      }, popperOptions && popperOptions.modifiers ? popperOptions.modifiers.offset : {})
+    }),
+    onUpdate: function onUpdate() {
+      var styles = tooltip.style;
+      styles.top = '';
+      styles.bottom = '';
+      styles.left = '';
+      styles.right = '';
+      styles[getCorePlacement(popper.getAttribute('x-placement'))] = getOffsetDistanceInPx(distance);
+    }
+  });
 
-    return new Popper(el, popper, config);
+  return new Popper(el, popper, config);
 }
 
 /**
@@ -3092,55 +3096,55 @@ function queueExecution(fn) {
 * @param {Object} refData -  the element/popper reference data
 */
 function mountPopper(refData) {
-    var el = refData.el,
-        popper = refData.popper,
-        _refData$settings = refData.settings,
-        appendTo = _refData$settings.appendTo,
-        followCursor = _refData$settings.followCursor,
-        flipDuration = _refData$settings.flipDuration;
+  var el = refData.el,
+      popper = refData.popper,
+      _refData$settings = refData.settings,
+      appendTo = _refData$settings.appendTo,
+      followCursor = _refData$settings.followCursor,
+      flipDuration = _refData$settings.flipDuration;
 
-    // Already on the DOM
+  // Already on the DOM
 
-    if (appendTo.contains(popper)) return;
+  if (appendTo.contains(popper)) return;
 
-    appendTo.appendChild(popper);
+  appendTo.appendChild(popper);
 
-    if (!refData.popperInstance) {
-        // Create instance if it hasn't been created yet
-        refData.popperInstance = createPopperInstance(refData);
+  if (!refData.popperInstance) {
+    // Create instance if it hasn't been created yet
+    refData.popperInstance = createPopperInstance(refData);
 
-        // Update the popper's position whenever its content changes
-        // Not supported in IE10 unless polyfilled
-        if (window.MutationObserver) {
-            var styles = popper.style;
-            var observer = new MutationObserver(function () {
-                styles[prefix('transitionDuration')] = '0ms';
-                refData.popperInstance.update();
-                queueExecution(function () {
-                    styles[prefix('transitionDuration')] = flipDuration + 'ms';
-                });
-            });
-            observer.observe(popper, {
-                childList: true,
-                subtree: true,
-                characterData: true
-            });
-            refData._mutationObserver = observer;
-        }
-    } else {
+    // Update the popper's position whenever its content changes
+    // Not supported in IE10 unless polyfilled
+    if (window.MutationObserver) {
+      var styles = popper.style;
+      var observer = new MutationObserver(function () {
+        styles[prefix('transitionDuration')] = '0ms';
         refData.popperInstance.update();
-
-        if (!followCursor || Browser.touch) {
-            refData.popperInstance.enableEventListeners();
-        }
+        queueExecution(function () {
+          styles[prefix('transitionDuration')] = flipDuration + 'ms';
+        });
+      });
+      observer.observe(popper, {
+        childList: true,
+        subtree: true,
+        characterData: true
+      });
+      refData._mutationObserver = observer;
     }
+  } else {
+    refData.popperInstance.update();
 
-    // Since touch is determined dynamically, followCursor setting
-    // is set on mount
-    if (followCursor && !Browser.touch) {
-        el.addEventListener('mousemove', followCursorHandler);
-        refData.popperInstance.disableEventListeners();
+    if (!followCursor || Browser.touch) {
+      refData.popperInstance.enableEventListeners();
     }
+  }
+
+  // Since touch is determined dynamically, followCursor setting
+  // is set on mount
+  if (followCursor && !Browser.touch) {
+    el.addEventListener('mousemove', followCursorHandler);
+    refData.popperInstance.disableEventListeners();
+  }
 }
 
 /**
@@ -3148,29 +3152,29 @@ function mountPopper(refData) {
 * @param {Object} refData
 */
 function makeSticky(refData) {
-    var popper = refData.popper,
-        popperInstance = refData.popperInstance,
-        stickyDuration = refData.settings.stickyDuration;
+  var popper = refData.popper,
+      popperInstance = refData.popperInstance,
+      stickyDuration = refData.settings.stickyDuration;
 
 
-    var applyTransitionDuration = function applyTransitionDuration() {
-        return popper.style[prefix('transitionDuration')] = stickyDuration + 'ms';
-    };
+  var applyTransitionDuration = function applyTransitionDuration() {
+    return popper.style[prefix('transitionDuration')] = stickyDuration + 'ms';
+  };
 
-    var removeTransitionDuration = function removeTransitionDuration() {
-        return popper.style[prefix('transitionDuration')] = '';
-    };
+  var removeTransitionDuration = function removeTransitionDuration() {
+    return popper.style[prefix('transitionDuration')] = '';
+  };
 
-    var updatePosition = function updatePosition() {
-        popperInstance && popperInstance.scheduleUpdate();
+  var updatePosition = function updatePosition() {
+    popperInstance && popperInstance.scheduleUpdate();
 
-        applyTransitionDuration();
+    applyTransitionDuration();
 
-        isVisible(popper) ? window.requestAnimationFrame(updatePosition) : removeTransitionDuration();
-    };
+    isVisible(popper) ? window.requestAnimationFrame(updatePosition) : removeTransitionDuration();
+  };
 
-    // Wait until Popper's position has been updated initially
-    queueExecution(updatePosition);
+  // Wait until Popper's position has been updated initially
+  queueExecution(updatePosition);
 }
 
 /**
@@ -3181,91 +3185,90 @@ function makeSticky(refData) {
 * @return {Element} - the popper element
 */
 function createPopperElement(id, title, settings) {
-    var position = settings.position,
-        distance = settings.distance,
-        arrow = settings.arrow,
-        animateFill = settings.animateFill,
-        inertia = settings.inertia,
-        animation = settings.animation,
-        arrowSize = settings.arrowSize,
-        size = settings.size,
-        theme = settings.theme,
-        html = settings.html,
-        zIndex = settings.zIndex,
-        interactive = settings.interactive;
+  var position = settings.position,
+      distance = settings.distance,
+      arrow = settings.arrow,
+      animateFill = settings.animateFill,
+      inertia = settings.inertia,
+      animation = settings.animation,
+      arrowSize = settings.arrowSize,
+      size = settings.size,
+      theme = settings.theme,
+      html = settings.html,
+      zIndex = settings.zIndex,
+      interactive = settings.interactive;
 
 
-    var popper = document.createElement('div');
-    popper.setAttribute('class', 'tippy-popper');
-    popper.setAttribute('role', 'tooltip');
-    popper.setAttribute('aria-hidden', 'true');
-    popper.setAttribute('id', 'tippy-tooltip-' + id);
-    popper.style.zIndex = zIndex;
+  var popper = document.createElement('div');
+  popper.setAttribute('class', 'tippy-popper');
+  popper.setAttribute('role', 'tooltip');
+  popper.setAttribute('aria-hidden', 'true');
+  popper.setAttribute('id', 'tippy-tooltip-' + id);
+  popper.style.zIndex = zIndex;
 
-    var tooltip = document.createElement('div');
-    tooltip.setAttribute('class', 'tippy-tooltip tippy-tooltip--' + size + ' leave');
-    tooltip.setAttribute('data-animation', animation);
+  var tooltip = document.createElement('div');
+  tooltip.setAttribute('class', 'tippy-tooltip tippy-tooltip--' + size + ' leave');
+  tooltip.setAttribute('data-animation', animation);
 
-    theme.split(' ').forEach(function (t) {
-        tooltip.classList.add(t + '-theme');
-    });
+  theme.split(' ').forEach(function (t) {
+    tooltip.classList.add(t + '-theme');
+  });
 
-    if (arrow) {
-        // Add an arrow
-        var _arrow = document.createElement('div');
-        _arrow.setAttribute('class', 'arrow-' + arrowSize);
-        _arrow.setAttribute('x-arrow', '');
-        tooltip.appendChild(_arrow);
-    }
+  if (arrow) {
+    // Add an arrow
+    var _arrow = document.createElement('div');
+    _arrow.setAttribute('class', 'arrow-' + arrowSize);
+    _arrow.setAttribute('x-arrow', '');
+    tooltip.appendChild(_arrow);
+  }
 
-    if (animateFill) {
-        // Create animateFill circle element for animation
-        tooltip.setAttribute('data-animatefill', '');
-        var circle = document.createElement('div');
-        circle.setAttribute('class', 'leave');
-        circle.setAttribute('x-circle', '');
-        tooltip.appendChild(circle);
-    }
+  if (animateFill) {
+    // Create animateFill circle element for animation
+    tooltip.setAttribute('data-animatefill', '');
+    var circle = document.createElement('div');
+    circle.setAttribute('class', 'leave');
+    circle.setAttribute('x-circle', '');
+    tooltip.appendChild(circle);
+  }
 
-    if (inertia) {
-        // Change transition timing function cubic bezier
-        tooltip.setAttribute('data-inertia', '');
-    }
+  if (inertia) {
+    // Change transition timing function cubic bezier
+    tooltip.setAttribute('data-inertia', '');
+  }
 
-    if (interactive) {
-        tooltip.setAttribute('data-interactive', '');
-    }
+  if (interactive) {
+    tooltip.setAttribute('data-interactive', '');
+  }
 
-    // Tooltip content (text or HTML)
-    var content = document.createElement('div');
-    content.setAttribute('class', 'tippy-tooltip-content');
+  // Tooltip content (text or HTML)
+  var content = document.createElement('div');
+  content.setAttribute('class', 'tippy-tooltip-content');
 
-    if (html) {
+  if (html) {
+    var templateId = void 0;
 
-        var templateId = void 0;
-
-        if (html instanceof Element) {
-            content.appendChild(html);
-            templateId = '#' + html.id || 'tippy-html-template';
-        } else {
-            content.innerHTML = document.getElementById(html.replace('#', '')).innerHTML;
-            templateId = html;
-        }
-
-        popper.classList.add('html-template');
-        interactive && popper.setAttribute('tabindex', '-1');
-        tooltip.setAttribute('data-template-id', templateId);
+    if (html instanceof Element) {
+      content.appendChild(html);
+      templateId = '#' + html.id || 'tippy-html-template';
     } else {
-        content.innerHTML = title;
+      content.innerHTML = document.getElementById(html.replace('#', '')).innerHTML;
+      templateId = html;
     }
 
-    // Init distance. Further updates are made in the popper instance's `onUpdate()` method
-    tooltip.style[getCorePlacement(position)] = getOffsetDistanceInPx(distance);
+    popper.classList.add('html-template');
+    interactive && popper.setAttribute('tabindex', '-1');
+    tooltip.setAttribute('data-template-id', templateId);
+  } else {
+    content.innerHTML = title;
+  }
 
-    tooltip.appendChild(content);
-    popper.appendChild(tooltip);
+  // Init distance. Further updates are made in the popper instance's `onUpdate()` method
+  tooltip.style[getCorePlacement(position)] = getOffsetDistanceInPx(distance);
 
-    return popper;
+  tooltip.appendChild(content);
+  popper.appendChild(tooltip);
+
+  return popper;
 }
 
 /**
@@ -3274,11 +3277,11 @@ function createPopperElement(id, title, settings) {
 * @return {Elements[]}
 */
 function getArrayOfElements(selector) {
-    if (selector instanceof Element) {
-        return [selector];
-    }
+  if (selector instanceof Element) {
+    return [selector];
+  }
 
-    return [].slice.call(document.querySelectorAll(selector));
+  return [].slice.call(document.querySelectorAll(selector));
 }
 
 /**
@@ -3286,9 +3289,9 @@ function getArrayOfElements(selector) {
 * @param {Element} el
 */
 function removeTitle(el) {
-    var title = el.getAttribute('title');
-    el.setAttribute('data-original-title', title || 'html');
-    el.removeAttribute('title');
+  var title = el.getAttribute('title');
+  el.setAttribute('data-original-title', title || 'html');
+  el.removeAttribute('title');
 }
 
 /**
@@ -3297,9 +3300,9 @@ function removeTitle(el) {
 * @return {Boolean}
 */
 function elementIsInViewport(el) {
-    var rect = el.getBoundingClientRect();
+  var rect = el.getBoundingClientRect();
 
-    return rect.top >= 0 && rect.left >= 0 && rect.bottom <= (window.innerHeight || document.documentElement.clientHeight) && rect.right <= (window.innerWidth || document.documentElement.clientWidth);
+  return rect.top >= 0 && rect.left >= 0 && rect.bottom <= (window.innerHeight || document.documentElement.clientHeight) && rect.right <= (window.innerWidth || document.documentElement.clientWidth);
 }
 
 /**
@@ -3308,8 +3311,8 @@ function elementIsInViewport(el) {
 * @param {Element} circle
 */
 function triggerReflow(tooltip, circle) {
-    // Safari needs the specific 'transform' property to be accessed
-    circle ? window.getComputedStyle(circle)[prefix('transform')] : window.getComputedStyle(tooltip).opacity;
+  // Safari needs the specific 'transform' property to be accessed
+  circle ? window.getComputedStyle(circle)[prefix('transform')] : window.getComputedStyle(tooltip).opacity;
 }
 
 /**
@@ -3319,30 +3322,29 @@ function triggerReflow(tooltip, circle) {
 * @return {Object} - individual settings
 */
 function getIndividualSettings(el, instanceSettings) {
+  var settings = DefaultsKeys.reduce(function (acc, key) {
+    var val = el.getAttribute('data-' + key.toLowerCase()) || instanceSettings[key];
 
-    var settings = DefaultsKeys.reduce(function (acc, key) {
-        var val = el.getAttribute('data-' + key.toLowerCase()) || instanceSettings[key];
+    // Convert strings to booleans
+    if (val === 'false') val = false;
+    if (val === 'true') val = true;
 
-        // Convert strings to booleans
-        if (val === 'false') val = false;
-        if (val === 'true') val = true;
+    // Convert number strings to true numbers
+    if (isFinite(val) && !isNaN(parseFloat(val))) {
+      val = parseFloat(val);
+    }
 
-        // Convert number strings to true numbers
-        if (isFinite(val) && !isNaN(parseFloat(val))) {
-            val = parseFloat(val);
-        }
+    // Convert array strings to actual arrays
+    if (typeof val === 'string' && val.trim().charAt(0) === '[') {
+      val = JSON.parse(val);
+    }
 
-        // Convert array strings to actual arrays
-        if (typeof val === 'string' && val.trim().charAt(0) === '[') {
-            val = JSON.parse(val);
-        }
+    acc[key] = val;
 
-        acc[key] = val;
+    return acc;
+  }, {});
 
-        return acc;
-    }, {});
-
-    return _extends$1({}, instanceSettings, settings);
+  return _extends$1({}, instanceSettings, settings);
 }
 
 /**
@@ -3350,196 +3352,195 @@ function getIndividualSettings(el, instanceSettings) {
 * @param {Element} el
 * @param {Element} popper
 * @param {Object} settings
-* @return {Object} - relevant listener callback methods
+* @return {Object} - relevant listener handlers
 */
 function getEventListenerHandlers(el, popper, settings) {
-    var _this = this;
+  var _this = this;
 
-    var position = settings.position,
-        delay = settings.delay,
-        duration = settings.duration,
-        interactive = settings.interactive,
-        interactiveBorder = settings.interactiveBorder,
-        distance = settings.distance,
-        hideOnClick = settings.hideOnClick,
-        trigger = settings.trigger,
-        touchHold = settings.touchHold,
-        touchWait = settings.touchWait;
+  var position = settings.position,
+      delay = settings.delay,
+      duration = settings.duration,
+      interactive = settings.interactive,
+      interactiveBorder = settings.interactiveBorder,
+      distance = settings.distance,
+      hideOnClick = settings.hideOnClick,
+      trigger = settings.trigger,
+      touchHold = settings.touchHold,
+      touchWait = settings.touchWait;
 
 
-    var showDelay = void 0,
-        hideDelay = void 0;
+  var showDelay = void 0,
+      hideDelay = void 0;
 
-    var clearTimeouts = function clearTimeouts() {
-        clearTimeout(showDelay);
-        clearTimeout(hideDelay);
-    };
+  var clearTimeouts = function clearTimeouts() {
+    clearTimeout(showDelay);
+    clearTimeout(hideDelay);
+  };
 
-    var _show = function _show() {
-        clearTimeouts();
+  var _show = function _show() {
+    clearTimeouts();
 
-        // Not hidden. For clicking when it also has a `focus` event listener
-        if (isVisible(popper)) return;
+    // Not hidden. For clicking when it also has a `focus` event listener
+    if (isVisible(popper)) return;
 
-        var _delay = Array.isArray(delay) ? delay[0] : delay;
+    var _delay = Array.isArray(delay) ? delay[0] : delay;
 
-        if (delay) {
-            showDelay = setTimeout(function () {
-                return _this.show(popper);
-            }, _delay);
-        } else {
-            _this.show(popper);
-        }
-    };
+    if (delay) {
+      showDelay = setTimeout(function () {
+        return _this.show(popper);
+      }, _delay);
+    } else {
+      _this.show(popper);
+    }
+  };
 
-    var show = function show(event) {
-        return _this.callbacks.wait ? _this.callbacks.wait.call(popper, _show, event) : _show();
-    };
+  var show = function show(event) {
+    return _this.callbacks.wait ? _this.callbacks.wait.call(popper, _show, event) : _show();
+  };
 
-    var hide = function hide() {
-        clearTimeouts();
+  var hide = function hide() {
+    clearTimeouts();
 
-        var _delay = Array.isArray(delay) ? delay[1] : delay;
+    var _delay = Array.isArray(delay) ? delay[1] : delay;
 
-        if (delay) {
-            hideDelay = setTimeout(function () {
-                return _this.hide(popper);
-            }, _delay);
-        } else {
-            _this.hide(popper);
-        }
-    };
+    if (delay) {
+      hideDelay = setTimeout(function () {
+        return _this.hide(popper);
+      }, _delay);
+    } else {
+      _this.hide(popper);
+    }
+  };
 
-    var handleTrigger = function handleTrigger(event) {
+  var handleTrigger = function handleTrigger(event) {
+    var mouseenterTouch = event.type === 'mouseenter' && Browser.SUPPORTS_TOUCH && Browser.touch;
 
-        var mouseenterTouch = event.type === 'mouseenter' && Browser.SUPPORTS_TOUCH && Browser.touch;
+    if (mouseenterTouch && touchHold) return;
 
-        if (mouseenterTouch && touchHold) return;
+    // Toggle show/hide when clicking click-triggered tooltips
+    var isClick = event.type === 'click';
+    var isNotPersistent = hideOnClick !== 'persistent';
 
-        // Toggle show/hide when clicking click-triggered tooltips
-        var isClick = event.type === 'click';
-        var isNotPersistent = hideOnClick !== 'persistent';
+    isClick && isVisible(popper) && isNotPersistent ? hide() : show(event);
 
-        isClick && isVisible(popper) && isNotPersistent ? hide() : show(event);
+    if (mouseenterTouch && Browser.iOS() && el.click) {
+      el.click();
+    }
+  };
 
-        if (mouseenterTouch && Browser.iOS() && el.click) {
-            el.click();
-        }
-    };
+  var handleMouseleave = function handleMouseleave(event) {
 
-    var handleMouseleave = function handleMouseleave(event) {
+    // Don't fire 'mouseleave', use the 'touchend'
+    if (event.type === 'mouseleave' && Browser.SUPPORTS_TOUCH && Browser.touch && touchHold) {
+      return;
+    }
 
-        // Don't fire 'mouseleave', use the 'touchend'
-        if (event.type === 'mouseleave' && Browser.SUPPORTS_TOUCH && Browser.touch && touchHold) {
-            return;
-        }
+    if (interactive) {
+      // Temporarily handle mousemove to check if the mouse left somewhere
+      // other than its popper
+      var handleMousemove = function handleMousemove(event) {
 
-        if (interactive) {
-            // Temporarily handle mousemove to check if the mouse left somewhere
-            // other than its popper
-            var handleMousemove = function handleMousemove(event) {
+        var triggerHide = function triggerHide() {
+          document.body.removeEventListener('mouseleave', hide);
+          document.removeEventListener('mousemove', handleMousemove);
+          hide();
+        };
 
-                var triggerHide = function triggerHide() {
-                    document.body.removeEventListener('mouseleave', hide);
-                    document.removeEventListener('mousemove', handleMousemove);
-                    hide();
-                };
+        var closestTooltippedEl = closest(event.target, Selectors.TOOLTIPPED_EL);
 
-                var closestTooltippedEl = closest(event.target, Selectors.TOOLTIPPED_EL);
+        var isOverPopper = closest(event.target, Selectors.POPPER) === popper;
+        var isOverEl = closestTooltippedEl === el;
+        var isClickTriggered = trigger.indexOf('click') !== -1;
+        var isOverOtherTooltippedEl = closestTooltippedEl && closestTooltippedEl !== el;
 
-                var isOverPopper = closest(event.target, Selectors.POPPER) === popper;
-                var isOverEl = closestTooltippedEl === el;
-                var isClickTriggered = trigger.indexOf('click') !== -1;
-                var isOverOtherTooltippedEl = closestTooltippedEl && closestTooltippedEl !== el;
-
-                if (isOverOtherTooltippedEl) {
-                    return triggerHide();
-                }
-
-                if (isOverPopper || isOverEl || isClickTriggered) return;
-
-                if (cursorIsOutsideInteractiveBorder(event, popper, settings)) {
-                    triggerHide();
-                }
-            };
-
-            document.body.addEventListener('mouseleave', hide);
-            document.addEventListener('mousemove', handleMousemove);
-
-            return;
+        if (isOverOtherTooltippedEl) {
+          return triggerHide();
         }
 
-        // If it's not interactive, just hide it
-        hide();
-    };
+        if (isOverPopper || isOverEl || isClickTriggered) return;
 
-    var handleBlur = function handleBlur(event) {
-        // Ignore blur on touch devices, if there is no `relatedTarget`, hide
-        // If the related target is a popper, ignore
-        if (!event.relatedTarget || Browser.touch) return;
-        if (closest(event.relatedTarget, Selectors.POPPER)) return;
+        if (cursorIsOutsideInteractiveBorder(event, popper, settings)) {
+          triggerHide();
+        }
+      };
 
-        hide();
-    };
+      document.body.addEventListener('mouseleave', hide);
+      document.addEventListener('mousemove', handleMousemove);
 
-    return {
-        handleTrigger: handleTrigger,
-        handleMouseleave: handleMouseleave,
-        handleBlur: handleBlur
-    };
+      return;
+    }
+
+    // If it's not interactive, just hide it
+    hide();
+  };
+
+  var handleBlur = function handleBlur(event) {
+    // Ignore blur on touch devices, if there is no `relatedTarget`, hide
+    // If the related target is a popper, ignore
+    if (!event.relatedTarget || Browser.touch) return;
+    if (closest(event.relatedTarget, Selectors.POPPER)) return;
+
+    hide();
+  };
+
+  return {
+    handleTrigger: handleTrigger,
+    handleMouseleave: handleMouseleave,
+    handleBlur: handleBlur
+  };
 }
 
 var idCounter = 1;
 
 /**
 * Creates tooltips for all el elements that match the instance's selector
-* @param {Element[]} els - Array of elements
+* @param {Element[]} els
 * @return {Object[]} Array of ref data objects
 */
 function createTooltips(els) {
-    var _this = this;
+  var _this = this;
 
-    return els.reduce(function (a, el) {
+  return els.reduce(function (a, el) {
+    var id = idCounter;
 
-        var settings = _this.settings.performance ? _this.settings : getIndividualSettings(el, _this.settings);
+    var settings = _this.settings.performance ? _this.settings : getIndividualSettings(el, _this.settings);
+    // animateFill is disabled if an arrow is true
+    if (settings.arrow) settings.animateFill = false;
 
-        // animateFill is disabled if an arrow is true
-        if (settings.arrow) settings.animateFill = false;
-
-        var html = settings.html,
-            trigger = settings.trigger,
-            touchHold = settings.touchHold;
+    var html = settings.html,
+        trigger = settings.trigger,
+        touchHold = settings.touchHold;
 
 
-        var title = el.getAttribute('title');
-        if (!title && !html) return a;
+    var title = el.getAttribute('title');
+    if (!title && !html) return a;
 
-        var id = idCounter;
-        el.setAttribute('data-tooltipped', '');
-        el.setAttribute('aria-describedby', 'tippy-tooltip-' + id);
-        removeTitle(el);
+    el.setAttribute('data-tooltipped', '');
+    el.setAttribute('aria-describedby', 'tippy-tooltip-' + id);
+    removeTitle(el);
 
-        var popper = createPopperElement(id, title, settings);
-        var handlers = getEventListenerHandlers.call(_this, el, popper, settings);
-        var listeners = [];
+    var popper = createPopperElement(id, title, settings);
+    var handlers = getEventListenerHandlers.call(_this, el, popper, settings);
 
-        trigger.trim().split(' ').forEach(function (event) {
-            return listeners = listeners.concat(createTrigger(event, el, handlers, touchHold));
-        });
+    var listeners = [];
 
-        a.push({
-            id: id,
-            el: el,
-            popper: popper,
-            settings: settings,
-            listeners: listeners,
-            tippyInstance: _this
-        });
+    trigger.trim().split(' ').forEach(function (event) {
+      return listeners = listeners.concat(createTrigger(event, el, handlers, touchHold));
+    });
 
-        idCounter++;
+    a.push({
+      id: id,
+      el: el,
+      popper: popper,
+      settings: settings,
+      listeners: listeners,
+      tippyInstance: _this
+    });
 
-        return a;
-    }, []);
+    idCounter++;
+
+    return a;
+  }, []);
 }
 
 /* Utility functions */
@@ -3550,377 +3551,383 @@ function createTooltips(els) {
 */
 
 var Tippy = function () {
-    function Tippy(selector) {
-        var settings = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : {};
-        classCallCheck$1(this, Tippy);
+  function Tippy(selector) {
+    var settings = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : {};
+    classCallCheck$1(this, Tippy);
+
+    // Use default browser tooltip on unsupported browsers
+    if (!Browser.SUPPORTED) return;
+
+    // DOM is presumably mostly ready (for document.body) by instantiation time
+    init();
+
+    this.state = {
+      destroyed: false
+    };
+
+    this.selector = selector;
+
+    this.settings = _extends$1({}, Defaults, settings);
+
+    // DEPRECATION: `on` prefixed callbacks are now preferred over non-
+    // as it better indicates it's a callback function
+    this.callbacks = {
+      wait: settings.wait,
+      show: settings.onShow || settings.show || noop,
+      shown: settings.onShown || settings.shown || noop,
+      hide: settings.onHide || settings.hide || noop,
+      hidden: settings.onHidden || settings.hidden || noop
+    };
+
+    this.store = createTooltips.call(this, getArrayOfElements(selector));
+    Store.push.apply(Store, this.store);
+  }
+
+  /**
+  * Returns the reference element's popper element
+  * @param {Element} el
+  * @return {Element}
+  */
 
 
-        // Use default browser tooltip on unsupported browsers
-        if (!Browser.SUPPORTED) return;
-
-        // DOM is presumably mostly ready (for document.body) by instantiation time
-        init();
-
-        this.state = {
-            destroyed: false
-        };
-
-        this.selector = selector;
-
-        this.settings = _extends$1({}, Defaults, settings);
-
-        // DEPRECATION: `on` prefixed callbacks are now preferred over non-
-        // as it better indicates it's a callback function
-        this.callbacks = {
-            wait: settings.wait,
-            show: settings.onShow || settings.show || noop,
-            shown: settings.onShown || settings.shown || noop,
-            hide: settings.onHide || settings.hide || noop,
-            hidden: settings.onHidden || settings.hidden || noop
-        };
-
-        this.store = createTooltips.call(this, getArrayOfElements(selector));
-        Store.push.apply(Store, this.store);
+  createClass$1(Tippy, [{
+    key: 'getPopperElement',
+    value: function getPopperElement(el) {
+      try {
+        return find(this.store, function (refData) {
+          return refData.el === el;
+        }).popper;
+      } catch (e) {
+        console.error('[getPopperElement]: Element passed as the argument does not exist in the instance');
+      }
     }
 
     /**
-    * Returns the reference element's popper element
-    * @param {Element} el
+    * Returns a popper's reference element
+    * @param {Element} popper
     * @return {Element}
     */
 
+  }, {
+    key: 'getReferenceElement',
+    value: function getReferenceElement(popper) {
+      try {
+        return find(this.store, function (refData) {
+          return refData.popper === popper;
+        }).el;
+      } catch (e) {
+        console.error('[getReferenceElement]: Popper passed as the argument does not exist in the instance');
+      }
+    }
 
-    createClass$1(Tippy, [{
-        key: 'getPopperElement',
-        value: function getPopperElement(el) {
-            try {
-                return find(this.store, function (refData) {
-                    return refData.el === el;
-                }).popper;
-            } catch (e) {
-                console.error('[getPopperElement]: Element passed as the argument does not exist in the instance');
-            }
+    /**
+    * Returns the reference data object from either the reference element or popper element
+    * @param {Element} x (reference element or popper)
+    * @return {Object}
+    */
+
+  }, {
+    key: 'getReferenceData',
+    value: function getReferenceData(x) {
+      return find(this.store, function (refData) {
+        return refData.el === x || refData.popper === x;
+      });
+    }
+
+    /**
+    * Shows a popper
+    * @param {Element} popper
+    * @param {Number} customDuration (optional)
+    */
+
+  }, {
+    key: 'show',
+    value: function show(popper, customDuration) {
+      var _this = this;
+
+      if (this.state.destroyed) return;
+
+      this.callbacks.show.call(popper);
+
+      var refData = find(this.store, function (refData) {
+        return refData.popper === popper;
+      });
+      var tooltip = popper.querySelector(Selectors.TOOLTIP);
+      var circle = popper.querySelector(Selectors.CIRCLE);
+      var content = popper.querySelector(Selectors.CONTENT);
+
+      var el = refData.el,
+          _refData$settings = refData.settings,
+          appendTo = _refData$settings.appendTo,
+          sticky = _refData$settings.sticky,
+          interactive = _refData$settings.interactive,
+          followCursor = _refData$settings.followCursor,
+          flipDuration = _refData$settings.flipDuration,
+          duration = _refData$settings.duration,
+          dynamicTitle = _refData$settings.dynamicTitle;
+
+
+      if (dynamicTitle) {
+        var title = el.getAttribute('title');
+        content.innerHTML = title || content.innerHTML;
+        title && removeTitle(el);
+      }
+
+      var _duration = customDuration !== undefined ? customDuration : Array.isArray(duration) ? duration[0] : duration;
+
+      // Remove transition duration (prevent a transition when popper changes position)
+      applyTransitionDuration([popper, tooltip, circle], 0);
+
+      mountPopper(refData);
+
+      popper.style.visibility = 'visible';
+      popper.setAttribute('aria-hidden', 'false');
+
+      // Wait for popper to update position and alter x-placement
+      queueExecution(function () {
+        if (!isVisible(popper)) return;
+
+        // Sometimes the arrow will not be in the correct position,
+        // force another update
+        if (!followCursor || Browser.touch) {
+          refData.popperInstance.update();
         }
 
-        /**
-        * Returns a popper's reference element
-        * @param {Element} popper
-        * @return {Element}
-        */
-
-    }, {
-        key: 'getReferenceElement',
-        value: function getReferenceElement(popper) {
-            try {
-                return find(this.store, function (refData) {
-                    return refData.popper === popper;
-                }).el;
-            } catch (e) {
-                console.error('[getReferenceElement]: Popper passed as the argument does not exist in the instance');
-            }
+        // Re-apply transition durations
+        applyTransitionDuration([tooltip, circle], _duration);
+        if (!followCursor || Browser.touch) {
+          applyTransitionDuration([popper], flipDuration);
         }
 
-        /**
-        * Returns the reference data object from either the reference element or popper element
-        * @param {Element} x (reference element or popper)
-        * @return {Object}
-        */
-
-    }, {
-        key: 'getReferenceData',
-        value: function getReferenceData(x) {
-            return find(this.store, function (refData) {
-                return refData.el === x || refData.popper === x;
-            });
-        }
-
-        /**
-        * Shows a popper
-        * @param {Element} popper
-        * @param {Number} customDuration (optional)
-        */
-
-    }, {
-        key: 'show',
-        value: function show(popper, customDuration) {
-            var _this = this;
-
-            if (this.state.destroyed) return;
-
-            this.callbacks.show.call(popper);
-
-            var refData = find(this.store, function (refData) {
-                return refData.popper === popper;
-            });
-            var tooltip = popper.querySelector(Selectors.TOOLTIP);
-            var circle = popper.querySelector(Selectors.CIRCLE);
-            var content = popper.querySelector(Selectors.CONTENT);
-
-            var el = refData.el,
-                _refData$settings = refData.settings,
-                appendTo = _refData$settings.appendTo,
-                sticky = _refData$settings.sticky,
-                interactive = _refData$settings.interactive,
-                followCursor = _refData$settings.followCursor,
-                flipDuration = _refData$settings.flipDuration,
-                duration = _refData$settings.duration;
-
-
-            var _duration = customDuration !== undefined ? customDuration : Array.isArray(duration) ? duration[0] : duration;
-
-            // Remove transition duration (prevent a transition when popper changes position)
-            applyTransitionDuration([popper, tooltip, circle], 0);
-
-            mountPopper(refData);
-
-            popper.style.visibility = 'visible';
-            popper.setAttribute('aria-hidden', 'false');
-
-            // Wait for popper to update position and alter x-placement
-            queueExecution(function () {
-                if (!isVisible(popper)) return;
-
-                // Sometimes the arrow will not be in the correct position,
-                // force another update
-                if (!followCursor || Browser.touch) {
-                    refData.popperInstance.update();
-                }
-
-                // Re-apply transition durations
-                applyTransitionDuration([tooltip, circle], _duration);
-                if (!followCursor || Browser.touch) {
-                    applyTransitionDuration([popper], flipDuration);
-                }
-
-                // Make content fade out a bit faster than the tooltip if `animateFill`
-                if (circle) content.style.opacity = 1;
-
-                // Interactive tooltips receive a class of 'active'
-                interactive && el.classList.add('active');
-
-                // Update popper's position on every animation frame
-                sticky && makeSticky(refData);
+        // Make content fade out a bit faster than the tooltip if `animateFill`
+        if (circle) content.style.opacity = 1;
 
-                // Repaint/reflow is required for CSS transition when appending
-                triggerReflow(tooltip, circle);
-
-                modifyClassList([tooltip, circle], function (list) {
-                    list.contains('tippy-notransition') && list.remove('tippy-notransition');
-                    list.remove('leave');
-                    list.add('enter');
-                });
-
-                // Wait for transitions to complete
-                onTransitionEnd(refData, _duration, function () {
-                    if (!isVisible(popper) || refData._onShownFired) return;
-
-                    // Focus interactive tooltips only
-                    interactive && popper.focus();
-
-                    // Remove transitions from tooltip
-                    tooltip.classList.add('tippy-notransition');
-
-                    // Prevents shown() from firing more than once from early transition cancellations
-                    refData._onShownFired = true;
-
-                    _this.callbacks.shown.call(popper);
-                });
-            });
-        }
+        // Interactive tooltips receive a class of 'active'
+        interactive && el.classList.add('active');
 
-        /**
-        * Hides a popper
-        * @param {Element} popper
-        * @param {Number} customDuration (optional)
-        */
-
-    }, {
-        key: 'hide',
-        value: function hide(popper, customDuration) {
-            var _this2 = this;
-
-            if (this.state.destroyed) return;
+        // Update popper's position on every animation frame
+        sticky && makeSticky(refData);
 
-            this.callbacks.hide.call(popper);
+        // Repaint/reflow is required for CSS transition when appending
+        triggerReflow(tooltip, circle);
 
-            var refData = find(this.store, function (refData) {
-                return refData.popper === popper;
-            });
-            var tooltip = popper.querySelector(Selectors.TOOLTIP);
-            var circle = popper.querySelector(Selectors.CIRCLE);
-            var content = popper.querySelector(Selectors.CONTENT);
-
-            var el = refData.el,
-                _refData$settings2 = refData.settings,
-                appendTo = _refData$settings2.appendTo,
-                sticky = _refData$settings2.sticky,
-                interactive = _refData$settings2.interactive,
-                followCursor = _refData$settings2.followCursor,
-                html = _refData$settings2.html,
-                trigger = _refData$settings2.trigger,
-                duration = _refData$settings2.duration;
+        modifyClassList([tooltip, circle], function (list) {
+          list.contains('tippy-notransition') && list.remove('tippy-notransition');
+          list.remove('leave');
+          list.add('enter');
+        });
 
+        // Wait for transitions to complete
+        onTransitionEnd(refData, _duration, function () {
+          if (!isVisible(popper) || refData._onShownFired) return;
 
-            var _duration = customDuration !== undefined ? customDuration : Array.isArray(duration) ? duration[1] : duration;
+          // Focus interactive tooltips only
+          interactive && popper.focus();
 
-            refData._onShownFired = false;
-            interactive && el.classList.remove('active');
+          // Remove transitions from tooltip
+          tooltip.classList.add('tippy-notransition');
 
-            popper.style.visibility = 'hidden';
-            popper.setAttribute('aria-hidden', 'true');
+          // Prevents shown() from firing more than once from early transition cancellations
+          refData._onShownFired = true;
 
-            applyTransitionDuration([tooltip, circle, circle ? content : null], _duration);
+          _this.callbacks.shown.call(popper);
+        });
+      });
+    }
 
-            if (circle) content.style.opacity = 0;
+    /**
+    * Hides a popper
+    * @param {Element} popper
+    * @param {Number} customDuration (optional)
+    */
 
-            modifyClassList([tooltip, circle], function (list) {
-                list.contains('tippy-tooltip') && list.remove('tippy-notransition');
-                list.remove('enter');
-                list.add('leave');
-            });
+  }, {
+    key: 'hide',
+    value: function hide(popper, customDuration) {
+      var _this2 = this;
 
-            // Re-focus click-triggered html elements
-            // and the tooltipped element IS in the viewport (otherwise it causes unsightly scrolling
-            // if the tooltip is closed and the element isn't in the viewport anymore)
-            if (html && trigger.indexOf('click') !== -1 && elementIsInViewport(el)) {
-                el.focus();
-            }
-
-            // Wait for transitions to complete
-            onTransitionEnd(refData, _duration, function () {
-                if (isVisible(popper) || !appendTo.contains(popper)) return;
-
-                el.removeEventListener('mousemove', followCursorHandler);
-
-                refData.popperInstance.disableEventListeners();
-
-                appendTo.removeChild(popper);
+      if (this.state.destroyed) return;
 
-                _this2.callbacks.hidden.call(popper);
-            });
-        }
+      this.callbacks.hide.call(popper);
 
-        /**
-        * Updates a popper with new content
-        * @param {Element} popper
-        */
+      var refData = find(this.store, function (refData) {
+        return refData.popper === popper;
+      });
+      var tooltip = popper.querySelector(Selectors.TOOLTIP);
+      var circle = popper.querySelector(Selectors.CIRCLE);
+      var content = popper.querySelector(Selectors.CONTENT);
 
-    }, {
-        key: 'update',
-        value: function update(popper) {
-            if (this.state.destroyed) return;
+      var el = refData.el,
+          _refData$settings2 = refData.settings,
+          appendTo = _refData$settings2.appendTo,
+          sticky = _refData$settings2.sticky,
+          interactive = _refData$settings2.interactive,
+          followCursor = _refData$settings2.followCursor,
+          html = _refData$settings2.html,
+          trigger = _refData$settings2.trigger,
+          duration = _refData$settings2.duration;
 
-            var refData = find(this.store, function (refData) {
-                return refData.popper === popper;
-            });
-            var content = popper.querySelector(Selectors.CONTENT);
-            var el = refData.el,
-                html = refData.settings.html;
 
+      var _duration = customDuration !== undefined ? customDuration : Array.isArray(duration) ? duration[1] : duration;
 
-            if (html instanceof Element) {
-                console.warn('Aborted: update() should not be used if `html` is a DOM element');
-                return;
-            }
+      refData._onShownFired = false;
+      interactive && el.classList.remove('active');
 
-            content.innerHTML = html ? document.getElementById(html.replace('#', '')).innerHTML : el.getAttribute('title') || el.getAttribute('data-original-title');
+      popper.style.visibility = 'hidden';
+      popper.setAttribute('aria-hidden', 'true');
 
-            if (!html) removeTitle(el);
-        }
+      applyTransitionDuration([tooltip, circle, circle ? content : null], _duration);
 
-        /**
-        * Destroys a popper
-        * @param {Element} popper
-        * @param {Boolean} _isLast - private param used by destroyAll to optimize
-        */
+      if (circle) content.style.opacity = 0;
 
-    }, {
-        key: 'destroy',
-        value: function destroy(popper, _isLast) {
-            var _this3 = this;
+      modifyClassList([tooltip, circle], function (list) {
+        list.contains('tippy-tooltip') && list.remove('tippy-notransition');
+        list.remove('enter');
+        list.add('leave');
+      });
 
-            if (this.state.destroyed) return;
+      // Re-focus click-triggered html elements
+      // and the tooltipped element IS in the viewport (otherwise it causes unsightly scrolling
+      // if the tooltip is closed and the element isn't in the viewport anymore)
+      if (html && trigger.indexOf('click') !== -1 && elementIsInViewport(el)) {
+        el.focus();
+      }
 
-            var refData = find(this.store, function (refData) {
-                return refData.popper === popper;
-            });
+      // Wait for transitions to complete
+      onTransitionEnd(refData, _duration, function () {
+        if (isVisible(popper) || !appendTo.contains(popper)) return;
 
-            var el = refData.el,
-                popperInstance = refData.popperInstance,
-                listeners = refData.listeners,
-                _mutationObserver = refData._mutationObserver;
+        el.removeEventListener('mousemove', followCursorHandler);
 
-            // Ensure the popper is hidden
+        refData.popperInstance.disableEventListeners();
+
+        appendTo.removeChild(popper);
 
-            if (isVisible(popper)) {
-                this.hide(popper, 0);
-            }
+        _this2.callbacks.hidden.call(popper);
+      });
+    }
 
-            // Remove Tippy-only event listeners from tooltipped element
-            listeners.forEach(function (listener) {
-                return el.removeEventListener(listener.event, listener.handler);
-            });
+    /**
+    * Updates a popper with new content
+    * @param {Element} popper
+    */
 
-            // Restore original title
-            el.setAttribute('title', el.getAttribute('data-original-title'));
+  }, {
+    key: 'update',
+    value: function update(popper) {
+      if (this.state.destroyed) return;
 
-            el.removeAttribute('data-original-title');
-            el.removeAttribute('data-tooltipped');
-            el.removeAttribute('aria-describedby');
+      var refData = find(this.store, function (refData) {
+        return refData.popper === popper;
+      });
+      var content = popper.querySelector(Selectors.CONTENT);
+      var el = refData.el,
+          html = refData.settings.html;
 
-            popperInstance && popperInstance.destroy();
-            _mutationObserver && _mutationObserver.disconnect();
 
-            // Remove from store
-            Store.splice(findIndex(Store, function (refData) {
-                return refData.popper === popper;
-            }), 1);
+      if (html instanceof Element) {
+        console.warn('Aborted: update() should not be used if `html` is a DOM element');
+        return;
+      }
 
-            // Ensure filter is called only once
-            if (_isLast === undefined || _isLast) {
-                this.store = Store.filter(function (refData) {
-                    return refData.tippyInstance === _this3;
-                });
-            }
-        }
+      content.innerHTML = html ? document.getElementById(html.replace('#', '')).innerHTML : el.getAttribute('title') || el.getAttribute('data-original-title');
 
-        /**
-        * Destroys all tooltips created by the instance
-        */
+      if (!html) removeTitle(el);
+    }
 
-    }, {
-        key: 'destroyAll',
-        value: function destroyAll() {
-            var _this4 = this;
+    /**
+    * Destroys a popper
+    * @param {Element} popper
+    * @param {Boolean} _isLast - private param used by destroyAll to optimize
+    */
 
-            if (this.state.destroyed) return;
+  }, {
+    key: 'destroy',
+    value: function destroy(popper, _isLast) {
+      var _this3 = this;
 
-            var storeLength = this.store.length;
+      if (this.state.destroyed) return;
 
-            this.store.forEach(function (_ref, index) {
-                var popper = _ref.popper;
+      var refData = find(this.store, function (refData) {
+        return refData.popper === popper;
+      });
 
-                _this4.destroy(popper, index === storeLength - 1);
-            });
+      var el = refData.el,
+          popperInstance = refData.popperInstance,
+          listeners = refData.listeners,
+          _mutationObserver = refData._mutationObserver;
 
-            this.store = null;
-            this.state.destroyed = true;
-        }
-    }]);
-    return Tippy;
+      // Ensure the popper is hidden
+
+      if (isVisible(popper)) {
+        this.hide(popper, 0);
+      }
+
+      // Remove Tippy-only event listeners from tooltipped element
+      listeners.forEach(function (listener) {
+        return el.removeEventListener(listener.event, listener.handler);
+      });
+
+      // Restore original title
+      el.setAttribute('title', el.getAttribute('data-original-title'));
+
+      el.removeAttribute('data-original-title');
+      el.removeAttribute('data-tooltipped');
+      el.removeAttribute('aria-describedby');
+
+      popperInstance && popperInstance.destroy();
+      _mutationObserver && _mutationObserver.disconnect();
+
+      // Remove from store
+      Store.splice(findIndex(Store, function (refData) {
+        return refData.popper === popper;
+      }), 1);
+
+      // Ensure filter is called only once
+      if (_isLast === undefined || _isLast) {
+        this.store = Store.filter(function (refData) {
+          return refData.tippyInstance === _this3;
+        });
+      }
+    }
+
+    /**
+    * Destroys all tooltips created by the instance
+    */
+
+  }, {
+    key: 'destroyAll',
+    value: function destroyAll() {
+      var _this4 = this;
+
+      if (this.state.destroyed) return;
+
+      var storeLength = this.store.length;
+
+      this.store.forEach(function (_ref, index) {
+        var popper = _ref.popper;
+
+        _this4.destroy(popper, index === storeLength - 1);
+      });
+
+      this.store = null;
+      this.state.destroyed = true;
+    }
+  }]);
+  return Tippy;
 }();
 
 function tippy(selector, settings) {
-    return new Tippy(selector, settings);
+  return new Tippy(selector, settings);
 }
 
 tippy.Browser = Browser;
 tippy.Defaults = Defaults;
 tippy.disableDynamicInputDetection = function () {
-    return Browser.dynamicInputDetection = false;
+  return Browser.dynamicInputDetection = false;
 };
 tippy.enableDynamicInputDetection = function () {
-    return Browser.dynamicInputDetection = true;
+  return Browser.dynamicInputDetection = true;
 };
 
 var createVirtualElement = function createVirtualElement() {

--- a/tests/functional.js
+++ b/tests/functional.js
@@ -3273,12 +3273,15 @@ function createPopperElement(id, title, settings) {
 
 /**
 * Returns an array of elements based on the selector input
-* @param {String|Element} selector
+* @param {String|Array|Element} selector
 * @return {Elements[]}
 */
 function getArrayOfElements(selector) {
   if (selector instanceof Element) {
     return [selector];
+  }
+  if (Object.prototype.toString.call(selector) === '[object Array]') {
+    return selector;
   }
 
   return [].slice.call(document.querySelectorAll(selector));
@@ -4678,17 +4681,22 @@ describe('core', function () {
         it('returns an array of Elements', function () {
             var el1 = createVirtualElement();
             var el2 = createVirtualElement();
+            var el3 = createVirtualElement();
+            var el4 = createVirtualElement();
 
             document.body.appendChild(el2);
 
             var res1 = getArrayOfElements(el1);
-            var res2 = getArrayOfElements('.test');[res1, res2].forEach(function (res) {
+            var res2 = getArrayOfElements('.test');
+            var res3 = getArrayOfElements([el3, el4]);[res1, res2, res3].forEach(function (res) {
                 return expect(res.every(function (item) {
                     return item instanceof Element;
                 })).toBe(true);
             });
 
             document.body.removeChild(el2);
+            document.body.removeChild(el3);
+            document.body.removeChild(el4);
         });
     });
 

--- a/tests/spec/functional.js
+++ b/tests/spec/functional.js
@@ -775,17 +775,22 @@ describe('core', () => {
         it('returns an array of Elements', () => {
             const el1 = createVirtualElement()
             const el2 = createVirtualElement()
+            const el3 = createVirtualElement()
+            const el4 = createVirtualElement()
 
             document.body.appendChild(el2)
 
             const res1 = getArrayOfElements(el1)
             const res2 = getArrayOfElements('.test')
+            const res3 = getArrayOfElements([el3, el4])
 
-            ;[res1, res2].forEach(res =>
+            ;[res1, res2, res3].forEach(res =>
                 expect(res.every(item => item instanceof Element)).toBe(true)
             )
 
             document.body.removeChild(el2)
+            document.body.removeChild(el3)
+            document.body.removeChild(el4)
         })
     })
 


### PR DESCRIPTION
For apps it can be helpful to pass array of elements instead of doing it one by one.
For example React.js app

```jsx
const titleEls =  Array.prototype.slice.call(
    ReactDOM.findDOMNode(this).querySelectorAll('[title]')
);
tippy(titleEls, {arrow: true});
```

P.S. Is there any instruction how to run tests? 

```bash
npm run tests
> rollup -c scripts/rollup.tests.config.js
⚠️   No format option was supplied – defaulting to 'es'
https://github.com/rollup/rollup/wiki/JavaScript-API#format
```

P.S2. rollup is not in devDependencies so it make sense to add it