### PR TITLE
Add Chrome tests runner for TravisCI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,11 @@
+dist: trusty
+sudo: false
+addons:
+  chrome: stable
 language: node_js
 node_js:
   - "7"
 before_script:
-  - export DISPLAY=:99.0
-  - sh -e /etc/init.d/xvfb start
+  - "export DISPLAY=:99.0"
+  - "sh -e /etc/init.d/xvfb start"
+  - sleep 3

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -52,10 +52,19 @@ module.exports = function(config) {
     // enable / disable watching file and executing tests whenever any file changes
     autoWatch: false,
 
+    customLaunchers: {
+      NoSandboxHeadlessChrome: {
+        base: 'ChromeHeadless',
+        flags: [
+          '--no-sandbox'
+        ]
+      }
+    },
+
 
     // start these browsers
     // available browser launchers: https://npmjs.org/browse/keyword/karma-launcher
-    browsers: ['Firefox'],
+    browsers: ['Firefox', 'NoSandboxHeadlessChrome'],
 
 
     // Continuous Integration mode


### PR DESCRIPTION
Now tests will run on Firefox and Chrome browsers for TravisCI integration