### PR TITLE
Enables passing of function to `appendTo`

### DIFF
--- a/src/js/core/createTooltips.js
+++ b/src/js/core/createTooltips.js
@@ -24,6 +24,12 @@ export default function createTooltips(els) {
     // animateFill is disabled if an arrow is true
     if (settings.arrow) settings.animateFill = false
 
+    // reassign appendTo into the result of evaluating appendTo
+    // if it's set as a function instead of Element
+    if (settings.appendTo && typeof settings.appendTo === 'function') {
+      settings.appendTo = settings.appendTo();
+    }
+
     const { html, trigger, touchHold } = settings
 
     const title = el.getAttribute('title')

--- a/src/js/core/init.js
+++ b/src/js/core/init.js
@@ -10,7 +10,8 @@ export default function init() {
   if (init.done) return false
   init.done = true
 
-  Defaults.appendTo = document.body
+  Defaults.appendTo = () => document.body
+
   bindEventListeners()
 
   return true

--- a/tests/spec/functional.js
+++ b/tests/spec/functional.js
@@ -584,6 +584,70 @@ describe('core', () => {
         document.body.removeChild(testContainer)
         instance.destroyAll()
       })
+
+      it('appends to the element evaluated from the tippy instance, instead of document.body', () => {
+        const el = createVirtualElement()
+        const testContainer = document.createElement('div')
+        testContainer.id = 'test-container'
+
+        document.body.appendChild(testContainer)
+
+        const instance = tippy(el, {
+          appendTo: () => document.querySelector('#test-container')
+        })
+
+        const popper = instance.getPopperElement(el)
+        instance.show(popper)
+
+        expect(testContainer.contains(popper)).toBe(true)
+
+        document.body.removeChild(testContainer)
+        instance.destroyAll()
+      })
+
+      it('appends to the element evaluated from changed tippy.Defaults, instead of document.body', () => {
+        const el = createVirtualElement()
+        let testContainer = document.createElement('div')
+        testContainer.id = 'test-container'
+        document.body.appendChild(testContainer)
+
+        tippy.Defaults.appendTo = () => document.querySelector('#test-container')
+
+        let instance = tippy(el)
+
+        let popper = instance.getPopperElement(el)
+        instance.show(popper)
+
+        expect(testContainer.contains(popper)).toBe(true)
+
+        // Simulate a DOM mutation that removes the previous appendTo element,
+        // destroys poppers and reinitializes tippy with set Defaults
+        document.body.removeChild(testContainer)
+        instance.destroyAll()
+
+        testContainer = document.createElement('div')
+        testContainer.id = 'test-container'
+        document.body.appendChild(testContainer)
+
+        // NOTE: Ideally, we should be able to move the
+        // tippy initialization **before** creating a new #test-container,
+        // to test that parent DOM is always evaluated when adding poppers.
+        // But being able to evaluate to the new #test-container
+        // during reinitialization is good enough.
+        instance = tippy(el)
+
+        // Should still append the popper to the newly created element
+        // of the same selector (instead of the previously deleted one)
+        popper = instance.getPopperElement(el)
+        instance.show(popper)
+
+        expect(testContainer.contains(popper)).toBe(true)
+
+        // // Cleanup
+        // document.body.removeChild(testContainer)
+        // instance.destroyAll()
+        // tippy.Defaults.appendTo = null
+      })
     })
 
     describe('animation', () => {


### PR DESCRIPTION
Instead of assigning an Element to `appendTo`,
one can now pass a function that evaluates to an Element

The appendTo function is now evaluated during createToolTips/initialization
of the tippy instance, which is good enough for not leaking appendTo
when reinitializing for various DOM changes e.g. in between
multiple `turbolinks:load` transitions.

This also changes the Defaults.appendTo into a function reevaluating the ‘current’ document.body