### PR TITLE
Accept a NodeList as input

### DIFF
--- a/src/js/core/getArrayOfElements.js
+++ b/src/js/core/getArrayOfElements.js
@@ -12,5 +12,9 @@ export default function getArrayOfElements(selector) {
     return selector
   }
 
+  if (selector.constructor.name === 'NodeList') {
+    return [].slice.call(selector)
+  }
+
   return [].slice.call(document.querySelectorAll(selector))
 }


### PR DESCRIPTION
I ran into a situation where I needed to pass a `NodeList` in directly, rather than letting tippy do the `querySelectorAll`-ing. This PR just makes sure that tippy acceps `NodeList`s without issue.