### PR TITLE
Added option to override reference object v2

### DIFF
--- a/src/js/core/getArrayOfElements.js
+++ b/src/js/core/getArrayOfElements.js
@@ -20,5 +20,9 @@ export default function getArrayOfElements(selector) {
     return [].slice.call(selector)
   }
 
-  return [].slice.call(document.querySelectorAll(selector))
+  try {
+    return [].slice.call(document.querySelectorAll(selector))
+  } catch (_) {
+    return []
+  }
 }

--- a/src/js/core/getArrayOfElements.js
+++ b/src/js/core/getArrayOfElements.js
@@ -12,6 +12,10 @@ export default function getArrayOfElements(selector) {
     return selector
   }
 
+  if (typeof selector == 'object' && ! (selector instanceof Element)){
+    return [selector]
+  }
+
   if (selector instanceof NodeList) {
     return [].slice.call(selector)
   }

--- a/src/js/core/getArrayOfElements.js
+++ b/src/js/core/getArrayOfElements.js
@@ -12,11 +12,7 @@ export default function getArrayOfElements(selector) {
     return selector
   }
 
-  if (typeof selector == 'object' && ! (selector instanceof Element)){
-    return [selector]
-  }
-
-  if (selector.constructor.name === 'NodeList') {
+  if (selector instanceof NodeList) {
     return [].slice.call(selector)
   }
 

--- a/src/js/core/getArrayOfElements.js
+++ b/src/js/core/getArrayOfElements.js
@@ -12,6 +12,10 @@ export default function getArrayOfElements(selector) {
     return selector
   }
 
+  if (typeof selector == 'object' && ! (selector instanceof Element)){
+    return [selector]
+  }
+
   if (selector.constructor.name === 'NodeList') {
     return [].slice.call(selector)
   }

--- a/src/js/tippy.js
+++ b/src/js/tippy.js
@@ -113,7 +113,7 @@ class Tippy {
     const data = find(this.store, data => data.popper === popper)
     const { tooltip, circle, content } = getInnerElements(popper)
 
-    if (!document.body.contains(data.el)) {
+    if (!this.selector.refObj && !document.body.contains(data.el)) {
       this.destroy(popper)
       return
     }
@@ -351,7 +351,36 @@ class Tippy {
   }
 }
 
+function isElement(element) {
+  return element instanceof Element;
+}
+
+
 function tippy(selector, settings) {
+
+    //Create a virtual object for tippy
+    if (typeof selector === 'object' && !isElement(selector)) {
+      selector = {
+        refObj: true,
+        record: {},
+        getBoundingClientRect: selector.getBoundingClientRect,
+        clientWidth: selector.clientWidth,
+        clientHeight: selector.clientHeight,
+        setAttribute: function (key, val) { this.record[key] = val },
+        getAttribute: function (key) { return this.record[key] },
+        removeAttribute: function (key) { return this.record[key] = null },
+        addEventListener: function (key, val) { },
+        removeEventListener: function (key) { },
+        classList : {
+          recordC: {},
+          add : function (key) {this.recordC[key] = true},
+          remove : function (key) {this.recordC[key] = false; return true},
+          contains : function(key) {return this.recordC[key]}
+        }
+      }
+    }
+
+
   return new Tippy(selector, settings)
 }
 

--- a/src/js/tippy.js
+++ b/src/js/tippy.js
@@ -351,34 +351,29 @@ class Tippy {
   }
 }
 
-function isElement(element) {
-  return element instanceof Element;
-}
-
-
 function tippy(selector, settings) {
 
     //Create a virtual object for tippy
-    if (typeof selector === 'object' && !isElement(selector)) {
+    if (typeof selector === 'object' && !(selector instanceof Element)) {
       selector = {
         refObj: true,
         record: {},
         getBoundingClientRect: selector.getBoundingClientRect,
         clientWidth: selector.clientWidth,
         clientHeight: selector.clientHeight,
-        setAttribute: function (key, val) { this.record[key] = val },
-        getAttribute: function (key) { return this.record[key] },
-        removeAttribute: function (key) { return this.record[key] = null },
-        addEventListener: function (key, val) { },
-        removeEventListener: function (key) { },
+        setAttribute:  (key, val) => { selector.record[key] = val },
+        getAttribute:  key => selector.record[key] ,
+        removeAttribute: key => selector.record[key] = null ,
+        addEventListener: (key, val) => { },
+        removeEventListener: key => { },
         classList : {
           recordC: {},
-          add : function (key) {this.recordC[key] = true},
-          remove : function (key) {this.recordC[key] = false; return true},
-          contains : function(key) {return this.recordC[key]}
+          add : key => selector.recordC[key] = true,
+          remove : key => {selector.recordC[key] = false; return true},
+          contains : key => selector.recordC[key]}
         }
       }
-    }
+    
 
 
   return new Tippy(selector, settings)


### PR DESCRIPTION
Note : Previous PR had conflicts due to new commits being made to master. Conflicts have been resolved. 

#### Sample Usage 
```js
var tip = tippy(refObject, {html: '#template'}); 
```

#### Changes 
* Created a virtual object if a reference object is passed in, so all tippy.js can be used without being modified
* Restored dist files 
* Added checks to ensure certain operations weren't causing errors with the virtual object 
* Removed console.logs used for debugging 
* Resolved issues with getArrayOfElements.js