### PR TITLE
Better NodeList Detection

### DIFF
--- a/src/js/core/getArrayOfElements.js
+++ b/src/js/core/getArrayOfElements.js
@@ -12,9 +12,13 @@ export default function getArrayOfElements(selector) {
     return selector
   }
 
-  if (selector.constructor.name === 'NodeList') {
+  if (selector instanceof NodeList) {
     return [].slice.call(selector)
   }
 
-  return [].slice.call(document.querySelectorAll(selector))
+  try {
+    return [].slice.call(document.querySelectorAll(selector))
+  } catch (_) {
+    return []
+  }
 }


### PR DESCRIPTION
Hi there!

Thanks so much for accepting my previous pull requests! Have been using these features in production and it has gone wonderfully. I noticed when testing in IE that my `NodeList` detection was bugged - unfortunately IE does not have the `constructor.name` property (of course), so if using a `NodeList` input, it would break. This method is much more reliable for detecting whether your input is actually a `NodeList` or not. I tested this in IE and it is working nice and smoothly.

👬 