### PR TITLE
Remove the word "simply" from documentation

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -201,7 +201,7 @@
             </p>
             <pre><code>https://unpkg.com/tippy.js@2.2.3/dist/</code></pre>
 
-            <p>Simply include the <code>tippy.all.min.js</code> file in your document before your own scripts:</p>
+            <p>Then include the <code>tippy.all.min.js</code> file in your document before your own scripts:</p>
             <pre><code class="language-markup">&lt;script src="https://unpkg.com/tippy.js@2.2.3/dist/tippy.all.min.js"&gt;&lt;/script&gt;</code></pre>
 
             <p>This is the bundled version which includes Popper.js and automatically injects Tippy's CSS stylesheet
@@ -1087,7 +1087,7 @@ tip.destroyAll()</code></pre>
 
             <h4>Update the tooltip</h4>
             <p>In V1, for tooltips whose content needed to be changed, there was an <code>update()</code> method. This has been replaced by a much easier way.</p>
-            <p>For standard tooltips, simply set the <code>dynamicTitle</code> option to <code>true</code>.</p>
+            <p>For standard tooltips, set the <code>dynamicTitle</code> option to <code>true</code>.</p>
 <pre><code class="language-js">tippy(btn, {
   dynamicTitle: true
 })</code></pre>


### PR DESCRIPTION
The word "simply" (like the word "just") is probably intended to convey that the instructions are straightforward, but it can have the unintended side-effect of making the reader feel overwhelmed:

http://bradfrost.com/blog/post/just/