### PR TITLE
Modify how transitionend listener is determined

### DIFF
--- a/src/js/core/Tippy.js
+++ b/src/js/core/Tippy.js
@@ -716,7 +716,9 @@ export function _onTransitionEnd(duration, callback) {
   const toggleListeners = (action, listener) => {
     if (!listener) return
     tooltip[action + 'EventListener'](
-      'ontransitionend' in window ? 'transitionend' : 'webkitTransitionEnd',
+      'transition' in document.body.style
+        ? 'transitionend'
+        : 'webkitTransitionEnd',
       listener
     )
   }


### PR DESCRIPTION
FOR #263

This PR provides a function to safely determine the correct transitionend listener to use for the active browser. This fixes an issue with IE11 where onHidden and onShown are not being called.