### PR TITLE
add useCapture static method for global click listener

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,7 @@
 .DS_Store
 /node_modules
-dist/tests
+dist
+coverage
 .cache/
+package-lock.json
+.devserver

--- a/src/js/core/bindEventListeners.js
+++ b/src/js/core/bindEventListeners.js
@@ -8,7 +8,7 @@ import toArray from '../utils/toArray'
 /**
  * Adds the needed event listeners
  */
-export default function bindEventListeners() {
+export default function bindEventListeners(useCapture) {
   const onDocumentTouch = () => {
     if (browser.usingTouch) return
 
@@ -95,7 +95,7 @@ export default function bindEventListeners() {
     })
   }
 
-  document.addEventListener('click', onDocumentClick)
+  document.addEventListener('click', onDocumentClick, useCapture)
   document.addEventListener('touchstart', onDocumentTouch)
   window.addEventListener('blur', onWindowBlur)
   window.addEventListener('resize', onWindowResize)

--- a/src/js/tippy.js
+++ b/src/js/tippy.js
@@ -11,6 +11,7 @@ import createTooltips from './core/createTooltips'
 import bindEventListeners from './core/bindEventListeners'
 
 let eventListenersBound = false
+let useCapture = false
 
 /**
  * Exported module
@@ -21,7 +22,7 @@ let eventListenersBound = false
  */
 function tippy(selector, options, one) {
   if (browser.supported && !eventListenersBound) {
-    bindEventListeners()
+    bindEventListeners(useCapture)
     eventListenersBound = true
   }
 
@@ -57,6 +58,9 @@ tippy.one = (selector, options) => tippy(selector, options, true).tooltips[0]
 tippy.disableAnimations = () => {
   defaults.updateDuration = defaults.duration = 0
   defaults.animateFill = false
+}
+tippy.useCapture = () => {
+  useCapture = true
 }
 
 export default tippy


### PR DESCRIPTION
@gargrave. How's this?

```js
// Call this before invoking `tippy()`
tippy.useCapture()
```