### PR TITLE
Introduce types file for TypeScript module support

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,112 @@
+import Popper from 'popper.js'
+
+export type BasicPlacement = 'top' | 'bottom' | 'left' | 'right'
+
+export type Placement =
+  | BasicPlacement
+  | 'top-start'
+  | 'top-end'
+  | 'bottom-start'
+  | 'bottom-end'
+  | 'left-start'
+  | 'left-end'
+  | 'right-start'
+  | 'right-end'
+
+export type Content = string | Element
+
+export type Selector = string | Element | NodeList | Popper.ReferenceObject
+
+export interface Options {
+  a11y?: boolean
+  allowHTML?: boolean
+  animateFill?: boolean
+  animation?: 'fade' | 'scale' | 'shift-toward' | 'perspective' | 'shift-away'
+  appendTo?: Element | ((ref: Element) => Element)
+  arrow?: boolean
+  arrowType?: 'sharp' | 'round'
+  arrowTransform?: string
+  content?: Content
+  delay?: number | [number, number]
+  duration?: number | [number, number]
+  distance?: number
+  flip?: boolean
+  flipBehavior?: 'flip' | Placement[]
+  followCursor?: boolean | 'vertical' | 'horizontal'
+  hideOnClick?: boolean | 'toggle'
+  inertia?: boolean
+  interactive?: boolean
+  interactiveBorder?: number
+  interactiveDebounce?: number
+  lazy?: boolean
+  livePlacement?: boolean
+  multiple?: boolean
+  offset?: number | string
+  onHidden?(instance: Instance): void
+  onHide?(instance: Instance): void
+  onShow?(instance: Instance): void
+  onShown?(instance: Instance): void
+  performance?: boolean
+  placement?: Placement
+  popperOptions?: Popper.PopperOptions
+  shouldPopperHideOnBlur?: (event: FocusEvent) => boolean
+  showOnInit?: boolean
+  size?: 'small' | 'regular' | 'large'
+  sticky?: boolean
+  target?: string
+  theme?: string
+  touch?: boolean
+  touchHold?: boolean
+  trigger?: 'mouseenter' | 'focus' | 'click' | 'manual'
+  updateDuration?: number
+  wait?(instance: Instance, event: Event): void
+  zIndex?: number
+}
+
+export interface Instance {
+  clearDelayTimeouts(): void
+  destroy(): void
+  disable(): void
+  enable(): void
+  hide(duration?: number): void
+  id: number
+  popper: Element
+  popperChildren: {
+    arrow: Element | null
+    backdrop: Element | null
+    content: Element | null
+    tooltip: Element | null
+  }
+  popperInstance: Popper | null
+  props: Options
+  reference: Element
+  set(options: Options): void
+  setContent(content: Content): void
+  show(duration?: number): void
+  state: {
+    isEnabled: boolean
+    isVisible: boolean
+    isDestroyed: boolean
+  }
+}
+
+export interface Collection {
+  destroyAll(): void
+  instances: Instance[]
+  props: Options
+  targets: Selector | Selector[]
+}
+
+export interface Tippy {
+  (selector: Selector, options?: Options): Collection
+  readonly defaults: Options
+  readonly version: string
+  disableAnimations(): void
+  hideAllPoppers(): void
+  one(selector: Selector, options?: Options): Instance
+  setDefaults(options: Options): void
+  useCapture(): void
+}
+
+declare const tippy: Tippy
+export default tippy

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description": "Vanilla JS Tooltip & Popover Library",
   "main": "dist/tippy.all.js",
   "module": "dist/esm/tippy.standalone.js",
+  "types": "index.d.ts",
   "author": "atomiks",
   "license": "MIT",
   "keywords": [


### PR DESCRIPTION
Basically, I've created `index.d.ts` in the main directory with a tweaked version of @smajl typings found in #186 discussion.

If you want to use the standalone file instead of the default one you can declare a module in `*.d.ts` file inside your project like this:
```ts
declare module 'tippy.js/dist/tippy.standalone' {
  import { Tippy } from 'tippy.js';
  const tippy: Tippy;
  export default tippy;
}
```

If you have any suggestions, please let me know :slightly_smiling_face: 
Before merging I could probably add comments to each definition.