### PR TITLE
Add state.isMounted, state.isShown, and props.onMount()

### DIFF
--- a/src/js/createTippy.js
+++ b/src/js/createTippy.js
@@ -51,7 +51,6 @@ export default function createTippy(reference, collectionProps) {
     props.interactiveDebounce > 0
       ? debounce(onMouseMove, props.interactiveDebounce)
       : onMouseMove
-  let isMounted = false
 
   /* ======================= 🔑 Public members 🔑 ======================= */
   const id = idCounter++
@@ -63,7 +62,9 @@ export default function createTippy(reference, collectionProps) {
   const state = {
     isEnabled: true,
     isVisible: false,
-    isDestroyed: false
+    isDestroyed: false,
+    isMounted: false,
+    isShown: false
   }
 
   const popperInstance = null
@@ -534,7 +535,8 @@ export default function createTippy(reference, collectionProps) {
 
     if (!tip.props.appendTo.contains(tip.popper)) {
       tip.props.appendTo.appendChild(tip.popper)
-      isMounted = true
+      tip.props.onMount(tip)
+      tip.state.isMounted = true
     }
   }
 
@@ -560,7 +562,7 @@ export default function createTippy(reference, collectionProps) {
         tip.popperInstance.scheduleUpdate()
       }
 
-      if (isMounted) {
+      if (tip.state.isMounted) {
         requestAnimationFrame(updatePosition)
       } else {
         applyTransitionDuration([tip.popper], 0)
@@ -851,6 +853,7 @@ export default function createTippy(reference, collectionProps) {
         tip.reference.setAttribute('aria-describedby', tip.popper.id)
 
         tip.props.onShown(tip)
+        tip.state.isShown = true
       })
     })
   }
@@ -879,6 +882,7 @@ export default function createTippy(reference, collectionProps) {
 
     tip.popper.style.visibility = 'hidden'
     tip.state.isVisible = false
+    tip.state.isShown = false
 
     applyTransitionDuration(
       [
@@ -919,7 +923,7 @@ export default function createTippy(reference, collectionProps) {
       tip.popperInstance.disableEventListeners()
 
       tip.props.appendTo.removeChild(tip.popper)
-      isMounted = false
+      tip.state.isMounted = false
 
       tip.props.onHidden(tip)
     })

--- a/src/js/defaults.js
+++ b/src/js/defaults.js
@@ -41,7 +41,8 @@ export let Defaults = {
   onShow() {},
   onShown() {},
   onHide() {},
-  onHidden() {}
+  onHidden() {},
+  onMount() {}
 }
 
 export const setDefaults = partialDefaults => {

--- a/tests/spec/props.test.js
+++ b/tests/spec/props.test.js
@@ -434,6 +434,20 @@ describe('onShow', () => {
   })
 })
 
+describe('onMount', () => {
+  it('is called once the tooltip is mounted to the DOM', done => {
+    const instance = tippy.one(h(), {
+      onMount: tip => {
+        expect(tip).toBe(instance)
+        expect(document.documentElement.contains(tip.popper)).toBe(true)
+        done()
+      },
+      duration: 0
+    })
+    instance.show()
+  })
+})
+
 describe('onShown', () => {
   it('is called on transition end of show, passed the instance as an argument', async () => {
     const spy = jest.fn()


### PR DESCRIPTION
Offers more comprehensive knowledge about the state of the tooltip.

`onMount()` allows users to access the dimensions of the tooltip, because `onShow()` is called before mounting.