### PR TITLE
Reintroduce maxWidth option

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -45,6 +45,7 @@ export interface Props {
   interactiveDebounce?: number
   lazy?: boolean
   livePlacement?: boolean
+  maxWidth?: number | string
   multiple?: boolean
   offset?: number | string
   onHidden?(instance: Instance): void

--- a/src/js/defaults.js
+++ b/src/js/defaults.js
@@ -21,6 +21,7 @@ export let Defaults = {
   interactiveDebounce: 0,
   lazy: true,
   livePlacement: true,
+  maxWidth: '',
   multiple: false,
   offset: 0,
   onHidden() {},

--- a/src/js/utils.js
+++ b/src/js/utils.js
@@ -195,6 +195,8 @@ export const createPopperElement = (id, props) => {
 
   const tooltip = div()
   tooltip.className = 'tippy-tooltip'
+  tooltip.style.maxWidth =
+    props.maxWidth + (typeof props.maxWidth === 'number' ? 'px' : '')
   tooltip.setAttribute('data-size', props.size)
   tooltip.setAttribute('data-animation', props.animation)
   tooltip.setAttribute('data-state', 'hidden')

--- a/src/scss/tippy.scss
+++ b/src/scss/tippy.scss
@@ -16,6 +16,7 @@
   transition-timing-function: cubic-bezier(0.165, 0.84, 0.44, 1);
   pointer-events: none;
   line-height: 1.4;
+  max-width: calc(100% - 10px);
 
   @each $placement in $placements {
     &[x-placement^='#{$placement}'] {
@@ -201,12 +202,5 @@
   }
   &[data-state='hidden'] {
     opacity: 0;
-  }
-}
-
-@media (max-width: 360px) {
-  .tippy-popper {
-    max-width: 96%;
-    max-width: calc(100% - 20px);
   }
 }

--- a/tests/spec/props.test.js
+++ b/tests/spec/props.test.js
@@ -569,3 +569,10 @@ describe('popperOptions', () => {
     expect(popperInstance.options.modifiers.offset.test).toBe(true)
   })
 })
+
+describe('maxWidth', () => {
+  const strTip = tippy.one(h(), { maxWidth: '100px' })
+  expect(strTip.popperChildren.tooltip.style.maxWidth).toBe('100px')
+  const numTip = tippy.one(h(), { maxWidth: 100 })
+  expect(numTip.popperChildren.tooltip.style.maxWidth).toBe('100px')
+})

--- a/tests/spec/props.test.js
+++ b/tests/spec/props.test.js
@@ -571,8 +571,15 @@ describe('popperOptions', () => {
 })
 
 describe('maxWidth', () => {
-  const strTip = tippy.one(h(), { maxWidth: '100px' })
-  expect(strTip.popperChildren.tooltip.style.maxWidth).toBe('100px')
-  const numTip = tippy.one(h(), { maxWidth: 100 })
-  expect(numTip.popperChildren.tooltip.style.maxWidth).toBe('100px')
+  it('adds the value to tooltip.style.maxWidth', () => {
+    const pxTip = tippy.one(h(), { maxWidth: '100px' })
+    expect(pxTip.popperChildren.tooltip.style.maxWidth).toBe('100px')
+    const remTip = tippy.one(h(), { maxWidth: '100rem' })
+    expect(remTip.popperChildren.tooltip.style.maxWidth).toBe('100rem')
+  })
+
+  it('auto-adds "px" to a number', () => {
+    const numTip = tippy.one(h(), { maxWidth: 100 })
+    expect(numTip.popperChildren.tooltip.style.maxWidth).toBe('100px')
+  })
 })


### PR DESCRIPTION
Resolves #361 

We remove the media query and place this property in `.tippy-popper`

```css
.tippy-popper {
  max-width: calc(100% - 10px);
}
```

It prevents the tooltip from ever overflowing if it's too large due to its content, even if style.maxWidth is specified.

Also unlike in V2 you can just use a number without a unit and "px" gets added.

Thoughts? /cc @darrensw777