### PR TITLE
Add 'boundary' option

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -31,6 +31,7 @@ export interface Props {
   arrow?: boolean
   arrowType?: 'sharp' | 'round'
   arrowTransform?: string
+  boundary?: 'scrollParent' | 'window' | 'viewport' | HTMLElement
   content?: Content
   delay?: number | [number, number]
   duration?: number | [number, number]

--- a/src/js/createTippy.js
+++ b/src/js/createTippy.js
@@ -19,7 +19,14 @@ import { canReceiveFocus } from './reference'
 import { validateOptions, evaluateProps } from './props'
 import computeArrowTransform from './deprecated_computeArrowTransform'
 import { closest, closestCallback, arrayFrom } from './ponyfills'
-import { defer, focus, hasOwnProperty, debounce, getValue } from './utils'
+import {
+  defer,
+  focus,
+  hasOwnProperty,
+  debounce,
+  getValue,
+  getModifier,
+} from './utils'
 
 let idCounter = 1
 
@@ -481,35 +488,27 @@ export default function createTippy(reference, collectionProps) {
 
     return new Popper(tip.reference, tip.popper, {
       placement: tip.props.placement,
-      ...(popperOptions || {}),
+      ...popperOptions,
       modifiers: {
         ...(popperOptions ? popperOptions.modifiers : {}),
         preventOverflow: {
           boundariesElement: tip.props.boundary,
-          ...(popperOptions && popperOptions.modifiers
-            ? popperOptions.modifiers.preventOverflow
-            : {}),
+          ...getModifier(popperOptions, 'preventOverflow'),
         },
         arrow: {
           element: arrow,
           enabled: !!arrow,
-          ...(popperOptions && popperOptions.modifiers
-            ? popperOptions.modifiers.arrow
-            : {}),
+          ...getModifier(popperOptions, 'arrow'),
         },
         flip: {
           enabled: tip.props.flip,
           padding: tip.props.distance + 5 /* 5px from viewport boundary */,
           behavior: tip.props.flipBehavior,
-          ...(popperOptions && popperOptions.modifiers
-            ? popperOptions.modifiers.flip
-            : {}),
+          ...getModifier(popperOptions, 'flip'),
         },
         offset: {
           offset: tip.props.offset,
-          ...(popperOptions && popperOptions.modifiers
-            ? popperOptions.modifiers.offset
-            : {}),
+          ...getModifier(popperOptions, 'offset'),
         },
       },
       onCreate() {

--- a/src/js/createTippy.js
+++ b/src/js/createTippy.js
@@ -476,20 +476,23 @@ export default function createTippy(reference, collectionProps) {
    * Creates the popper instance for the tip
    */
   function createPopperInstance() {
-    const { tooltip } = tip.popperChildren
     const { popperOptions } = tip.props
+    const { tooltip, arrow } = tip.popperChildren
 
-    const arrowSelector =
-      Selectors[tip.props.arrowType === 'round' ? 'ROUND_ARROW' : 'ARROW']
-    const arrow = tooltip.querySelector(arrowSelector)
-
-    const config = {
+    return new Popper(tip.reference, tip.popper, {
       placement: tip.props.placement,
       ...(popperOptions || {}),
       modifiers: {
         ...(popperOptions ? popperOptions.modifiers : {}),
+        preventOverflow: {
+          boundariesElement: tip.props.boundary,
+          ...(popperOptions && popperOptions.modifiers
+            ? popperOptions.modifiers.preventOverflow
+            : {}),
+        },
         arrow: {
-          element: arrowSelector,
+          element: arrow,
+          enabled: !!arrow,
           ...(popperOptions && popperOptions.modifiers
             ? popperOptions.modifiers.arrow
             : {}),
@@ -534,13 +537,7 @@ export default function createTippy(reference, collectionProps) {
           computeArrowTransform(arrow, tip.props.arrowTransform)
         }
       },
-    }
-
-    if (!popperMutationObserver) {
-      addMutationObserver()
-    }
-
-    return new Popper(tip.reference, tip.popper, config)
+    })
   }
 
   /**
@@ -550,6 +547,7 @@ export default function createTippy(reference, collectionProps) {
   function mount(callback) {
     if (!tip.popperInstance) {
       tip.popperInstance = createPopperInstance()
+      addMutationObserver()
       if (!tip.props.livePlacement || hasFollowCursorBehavior()) {
         tip.popperInstance.disableEventListeners()
       }

--- a/src/js/defaults.js
+++ b/src/js/defaults.js
@@ -7,6 +7,7 @@ export default {
   arrow: false,
   arrowTransform: '',
   arrowType: 'sharp',
+  boundary: 'scrollParent',
   content: '',
   delay: [0, 20],
   distance: 10,
@@ -51,6 +52,7 @@ export default {
  * recreated
  */
 export const POPPER_INSTANCE_RELATED_PROPS = [
+  'arrow',
   'arrowType',
   'distance',
   'flip',

--- a/src/js/utils.js
+++ b/src/js/utils.js
@@ -97,3 +97,14 @@ export function debounce(fn, ms) {
     timeoutId = setTimeout(() => fn.apply(this, arguments), ms)
   }
 }
+
+/**
+ * Prevents errors from being thrown while accessing nested modifier objects
+ * in `popperOptions`
+ * @param {Object} obj
+ * @param {String} key
+ * @return {Object}
+ */
+export function getModifier(obj, key) {
+  return { ...(obj && obj.modifiers ? obj.modifiers[key] : {}) }
+}

--- a/src/js/utils.js
+++ b/src/js/utils.js
@@ -103,8 +103,8 @@ export function debounce(fn, ms) {
  * in `popperOptions`
  * @param {Object} obj
  * @param {String} key
- * @return {Object}
+ * @return {Object|undefined}
  */
 export function getModifier(obj, key) {
-  return obj && obj.modifiers ? obj.modifiers[key] : {}
+  return obj && obj.modifiers && obj.modifiers[key]
 }

--- a/src/js/utils.js
+++ b/src/js/utils.js
@@ -106,5 +106,5 @@ export function debounce(fn, ms) {
  * @return {Object}
  */
 export function getModifier(obj, key) {
-  return { ...(obj && obj.modifiers ? obj.modifiers[key] : {}) }
+  return obj && obj.modifiers ? obj.modifiers[key] : {}
 }

--- a/tests/spec/defaults.test.js
+++ b/tests/spec/defaults.test.js
@@ -524,6 +524,20 @@ describe('popperOptions', () => {
     ).toBe(true)
   })
 
+  it('modifiers.preventOverflow', () => {
+    const { popperInstance } = tippy.one(h(), {
+      lazy: false,
+      popperOptions: {
+        modifiers: {
+          preventOverflow: {
+            test: true,
+          },
+        },
+      },
+    })
+    expect(popperInstance.options.modifiers.preventOverflow.test).toBe(true)
+  })
+
   it('modifiers.arrow', () => {
     const { popperInstance } = tippy.one(h(), {
       lazy: false,
@@ -578,5 +592,17 @@ describe('maxWidth', () => {
   it('auto-adds "px" to a number', () => {
     const numTip = tippy.one(h(), { maxWidth: 100 })
     expect(numTip.popperChildren.tooltip.style.maxWidth).toBe('100px')
+  })
+})
+
+describe('boundary', () => {
+  it('sets the `boundariesElement` property in popperInstance', () => {
+    const { popperInstance } = tippy.one(h(), {
+      lazy: false,
+      boundary: 'example',
+    })
+    expect(
+      popperInstance.options.modifiers.preventOverflow.boundariesElement,
+    ).toBe('example')
   })
 })

--- a/tests/spec/utils.test.js
+++ b/tests/spec/utils.test.js
@@ -192,3 +192,22 @@ describe('focus', () => {
     expect(el).toBe(document.activeElement)
   })
 })
+
+describe('getModifier', () => {
+  it('returns an object nested in `modifiers` object without errors', () => {
+    expect(Utils.getModifier({}, 'flip')).toBe(undefined)
+    expect(Utils.getModifier({ modifiers: {} }, 'flip')).toBe(undefined)
+    expect(
+      Utils.getModifier(
+        {
+          modifiers: {
+            flip: {
+              enabled: true,
+            },
+          },
+        },
+        'flip',
+      ),
+    ).toEqual({ enabled: true })
+  })
+})


### PR DESCRIPTION
Flat-level alias for `popperOptions.modifiers.preventOverflow.boundariesElement` since it's common