### PR TITLE
Typings improvements

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -61,7 +61,7 @@ export interface Props {
   size?: 'small' | 'regular' | 'large'
   sticky?: boolean
   target?: string
-  theme?: string
+  theme?: 'dark' | 'light' | 'light-border' | 'google' | string
   touch?: boolean
   touchHold?: boolean
   trigger?: string

--- a/index.d.ts
+++ b/index.d.ts
@@ -64,7 +64,7 @@ export interface Props {
   theme?: string
   touch?: boolean
   touchHold?: boolean
-  trigger?: 'mouseenter' | 'focus' | 'click' | 'manual'
+  trigger?: string
   updateDuration?: number
   wait?(instance: Instance, event: Event): void
   zIndex?: number

--- a/index.d.ts
+++ b/index.d.ts
@@ -49,9 +49,9 @@ export interface Props {
   multiple?: boolean
   offset?: number | string
   onHidden?(instance: Instance): void
-  onHide?(instance: Instance): void
+  onHide?(instance: Instance): void | false
   onMount?(instance: Instance): void
-  onShow?(instance: Instance): void
+  onShow?(instance: Instance): void | false
   onShown?(instance: Instance): void
   performance?: boolean
   placement?: Placement


### PR DESCRIPTION
Previous value allows only one trigger to be available, you couldn't create string combinations like: `mouseenter focus` etc.

This is a quick fix, the best option is to include props descriptions copied from the docs.