### PR TITLE
Avoid setting aria attribute for falsy values

### DIFF
--- a/src/js/createTippy.js
+++ b/src/js/createTippy.js
@@ -905,7 +905,9 @@ export default function createTippy(reference, collectionProps) {
           focus(tip.popper)
         }
 
-        tip.reference.setAttribute(`aria-${tip.props.aria}`, tip.popper.id)
+        if (tip.props.aria) {
+          tip.reference.setAttribute(`aria-${tip.props.aria}`, tip.popper.id)
+        }
 
         tip.props.onShown(tip)
         tip.state.isShown = true
@@ -974,7 +976,9 @@ export default function createTippy(reference, collectionProps) {
         removeFollowCursorListener()
       }
 
-      tip.reference.removeAttribute(`aria-${tip.props.aria}`)
+      if (tip.props.aria) {
+        tip.reference.removeAttribute(`aria-${tip.props.aria}`)
+      }
 
       tip.popperInstance.disableEventListeners()
 

--- a/tests/spec/defaults.test.js
+++ b/tests/spec/defaults.test.js
@@ -642,6 +642,15 @@ describe('aria', () => {
     tip.hide()
     expect(ref.getAttribute('aria-labelledby')).toBe(null)
   })
+
+  it('does not set attribute for falsy/null value', async () => {
+    const ref = h()
+    const tip = tippy.one(ref, { aria: null, duration: 0 })
+    tip.show()
+    await wait(1)
+    expect(ref.getAttribute('aria-null')).toBe(null)
+    expect(ref.getAttribute('aria-describedby')).toBe(null)
+  })
 })
 
 describe('boundary', () => {


### PR DESCRIPTION
@jburghardt going to leave off validation, the docs state the two string values that should be used

Resolves #401 