### PR TITLE
Follow cursor additions

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -40,7 +40,13 @@ export interface Props {
   distance?: number
   flip?: boolean
   flipBehavior?: 'flip' | Placement[]
-  followCursor?: boolean | 'vertical' | 'horizontal' | 'initial'
+  followCursor?:
+    | boolean
+    | 'vertical'
+    | 'horizontal'
+    | 'initial'
+    | 'initialVertical'
+    | 'initialHorizontal'
   hideOnClick?: boolean | 'toggle'
   inertia?: boolean
   interactive?: boolean

--- a/src/js/bindGlobalEventListeners.js
+++ b/src/js/bindGlobalEventListeners.js
@@ -2,6 +2,7 @@ import { supportsTouch, isIOS } from './browser'
 import Selectors from './selectors'
 import { hideAllPoppers } from './popper'
 import { closest, closestCallback, arrayFrom } from './ponyfills'
+import { includes } from './utils'
 
 export let isUsingTouch = false
 
@@ -56,7 +57,7 @@ export function onDocumentClick({ target }) {
   )
   if (reference) {
     const tip = reference._tippy
-    const isClickTrigger = tip.props.trigger.indexOf('click') > -1
+    const isClickTrigger = includes(tip.props.trigger, 'click')
 
     if (isUsingTouch || isClickTrigger) {
       return hideAllPoppers(tip)

--- a/src/js/createTippy.js
+++ b/src/js/createTippy.js
@@ -26,6 +26,7 @@ import {
   debounce,
   getValue,
   getModifier,
+  includes,
 } from './utils'
 
 let idCounter = 1
@@ -236,8 +237,11 @@ export default function createTippy(reference, collectionProps) {
 
     const rect = tip.reference.getBoundingClientRect()
     const { followCursor } = tip.props
-    const isHorizontal = followCursor === 'horizontal'
-    const isVertical = followCursor === 'vertical'
+    const isHorizontal = includes(
+      ['horizontal', 'initialHorizontal'],
+      followCursor,
+    )
+    const isVertical = includes(['vertical', 'initialVertical'], followCursor)
 
     tip.popperInstance.reference = {
       getBoundingClientRect: () => ({
@@ -254,7 +258,7 @@ export default function createTippy(reference, collectionProps) {
 
     tip.popperInstance.scheduleUpdate()
 
-    if (followCursor === 'initial' && tip.state.isVisible) {
+    if (includes(String(followCursor), 'initial') && tip.state.isVisible) {
       removeFollowCursorListener()
     }
   }
@@ -297,8 +301,10 @@ export default function createTippy(reference, collectionProps) {
 
     // If the tooltip has a delay, we need to be listening to the mousemove as
     // soon as the trigger event is fired, so that it's in the correct position
-    // upon mount
-    if (hasFollowCursorBehavior()) {
+    // upon mount.
+    // Edge case: if the tooltip is still mounted, but then prepareShow() is
+    // called, it causes a jump.
+    if (hasFollowCursorBehavior() && !tip.state.isMounted) {
       document.addEventListener('mousemove', positionVirtualReferenceNearCursor)
     }
 
@@ -472,7 +478,7 @@ export default function createTippy(reference, collectionProps) {
    * `touchHold` option
    */
   function isEventListenerStopped(event) {
-    const isTouchEvent = event.type.indexOf('touch') > -1
+    const isTouchEvent = includes(event.type, 'touch')
     const caseA =
       supportsTouch && isUsingTouch && tip.props.touchHold && !isTouchEvent
     const caseB = isUsingTouch && !tip.props.touchHold && isTouchEvent
@@ -900,7 +906,7 @@ export default function createTippy(reference, collectionProps) {
         if (
           tip.props.autoFocus &&
           tip.props.interactive &&
-          ['focus', 'click'].indexOf(lastTriggerEvent.type) > -1
+          includes(['focus', 'click'], lastTriggerEvent.type)
         ) {
           focus(tip.popper)
         }
@@ -961,7 +967,7 @@ export default function createTippy(reference, collectionProps) {
       tip.props.autoFocus &&
       tip.props.interactive &&
       !referenceJustProgrammaticallyFocused &&
-      ['focus', 'click'].indexOf(lastTriggerEvent.type) > -1
+      includes(['focus', 'click'], lastTriggerEvent.type)
     ) {
       if (lastTriggerEvent.type === 'focus') {
         referenceJustProgrammaticallyFocused = true

--- a/src/js/createTippy.js
+++ b/src/js/createTippy.js
@@ -220,8 +220,8 @@ export default function createTippy(reference, collectionProps) {
     // overflowing. Maybe Popper.js issue?
     const placement = getPopperPlacement(tip.popper)
     const padding = tip.popperChildren.arrow ? 20 : 5
-    const isVerticalPlacement = placement === 'top' || placement === 'bottom'
-    const isHorizontalPlacement = placement === 'left' || placement === 'right'
+    const isVerticalPlacement = includes(['top', 'bottom'], placement)
+    const isHorizontalPlacement = includes(['left', 'right'], placement)
 
     // Top / left boundary
     let x = isVerticalPlacement ? Math.max(padding, clientX) : clientX

--- a/src/js/deprecated_computeArrowTransform.js
+++ b/src/js/deprecated_computeArrowTransform.js
@@ -1,6 +1,7 @@
 import Selectors from './selectors'
 import { getPopperPlacement } from './popper'
 import { closest } from './ponyfills'
+import { includes } from './utils'
 
 // =============================================================================
 // DEPRECATED
@@ -90,8 +91,8 @@ export function getTransformNumbers(str, regex) {
  */
 function computeArrowTransform(arrow, arrowTransform) {
   const placement = getPopperPlacement(closest(arrow, Selectors.POPPER))
-  const isVertical = placement === 'top' || placement === 'bottom'
-  const isReverse = placement === 'right' || placement === 'bottom'
+  const isVertical = includes(['top', 'bottom'], placement)
+  const isReverse = includes(['right', 'bottom'], placement)
 
   const matches = {
     translate: {

--- a/src/js/utils.js
+++ b/src/js/utils.js
@@ -108,3 +108,13 @@ export function debounce(fn, ms) {
 export function getModifier(obj, key) {
   return obj && obj.modifiers && obj.modifiers[key]
 }
+
+/**
+ * Determines if an array or string includes a value
+ * @param {Array|String} a
+ * @param {any} b
+ * @return {Boolean}
+ */
+export function includes(a, b) {
+  return a.indexOf(b) > -1
+}

--- a/tests/spec/utils.test.js
+++ b/tests/spec/utils.test.js
@@ -211,3 +211,19 @@ describe('getModifier', () => {
     ).toEqual({ enabled: true })
   })
 })
+
+describe('includes', () => {
+  it('includes(string, string)', () => {
+    expect(Utils.includes('test', 'es')).toBe(true)
+    expect(Utils.includes('$128', '$12')).toBe(true)
+    expect(Utils.includes('test', 'tesst')).toBe(false)
+    expect(Utils.includes('$128', '$$')).toBe(false)
+  })
+
+  it('includes(Array, string)', () => {
+    expect(Utils.includes(['test', 'other'], 'other')).toBe(true)
+    expect(Utils.includes(['test', 'other'], 'test')).toBe(true)
+    expect(Utils.includes(['test', 'other'], 'othr')).toBe(false)
+    expect(Utils.includes(['test', 'other'], 'tst')).toBe(false)
+  })
+})


### PR DESCRIPTION
Adding from #398. This PR adds two possible string values to `followCursor`:

- `"initialHorizontal"`
- `"initialVertical"`

If you take a look at Wikipedia's tooltips, they will position themselves near the cursor but only horizontally, which prevents the tooltip from overlapping the text if the cursor entered the anchor link from beneath. `"initial"` does not satisfy that behavior since it behaves on both axes, so we need the ability to specify the axis.

### Patch

Patches an edge case using `followCursor` with `delay`, where if it was transitioning out but the cursor re-entered the reference, it jumps to the new cursor position, it should wait

### Refactor

Replaces `.indexOf(x) > -1` with a utility function `includes()` due to excessive use now