### PR TITLE
Fix UC Browser support

### DIFF
--- a/src/js/browser.js
+++ b/src/js/browser.js
@@ -1,4 +1,8 @@
 export const isBrowser = typeof window !== 'undefined'
-export const isIE = isBrowser && /MSIE |Trident\//.test(navigator.userAgent)
+
+const ua = isBrowser && navigator.userAgent
+
+export const isIE = /MSIE |Trident\//.test(ua)
+export const isUCBrowser = /UCBrowser\//.test(ua)
 export const isIOS =
   isBrowser && /iPhone|iPad|iPod/.test(navigator.platform) && !window.MSStream

--- a/src/js/css.js
+++ b/src/js/css.js
@@ -9,6 +9,12 @@ export function injectCSS(css) {
     const style = document.createElement('style')
     style.type = 'text/css'
     style.textContent = css
-    document.head.insertBefore(style, document.head.firstChild)
+    const head = document.head
+    const { firstChild } = head
+    if (firstChild) {
+      head.insertBefore(style, firstChild)
+    } else {
+      head.appendChild(style)
+    }
   }
 }

--- a/src/js/popper.js
+++ b/src/js/popper.js
@@ -1,6 +1,7 @@
 import Selectors from './selectors'
 import { arrayFrom } from './ponyfills'
 import { innerHTML } from './utils'
+import { isUCBrowser } from './browser'
 
 /**
  * Returns a new `div` element
@@ -131,7 +132,8 @@ export function applyTransitionDuration(els, value) {
  * @param {Function} listener
  */
 export function toggleTransitionEndListener(tooltip, action, listener) {
-  tooltip[action + 'EventListener']('transitionend', listener)
+  const eventName = isUCBrowser ? 'webkitTransitionEnd' : 'transitionend'
+  tooltip[action + 'EventListener'](eventName, listener)
 }
 
 /**

--- a/src/js/props.js
+++ b/src/js/props.js
@@ -1,5 +1,6 @@
 import { getDataAttributeOptions } from './reference'
 import { hasOwnProperty, evaluateValue } from './utils'
+import { isUCBrowser } from './browser'
 
 /**
  * Evaluates the props object by merging data attributes and
@@ -15,7 +16,7 @@ export function evaluateProps(reference, props) {
     ...(props.ignoreAttributes ? {} : getDataAttributeOptions(reference)),
   }
 
-  if (out.arrow) {
+  if (out.arrow || isUCBrowser) {
     out.animateFill = false
   }
 


### PR DESCRIPTION
So had some "fun" debugging why it wasn't working on the great UC Browser through Browserstack 😒 

- `animateFill` effect doesn't work, probably a rendering glitch. The tooltip text is unreadable because white text on white background without the backdrop. Let's disable it if we detect UC Browser
- `transitionend` does not fire because it uses `webkitTransitionEnd` _despite_ supporting unprefixed `transitions` (in the CSS, only transforms use prefixes. Unprefixed transitions have wider support). I can only hope they don't remove `webkitTransitionEnd` 

- Also a check in case the `<head>` doesn't have any nodes in it, we'll use `.appendChild` instead of inserting it before the first node