### PR TITLE
Fix distance option when setting it as default

### DIFF
--- a/src/js/createTippy.js
+++ b/src/js/createTippy.js
@@ -490,7 +490,7 @@ export default function createTippy(reference, collectionProps) {
       onCreate() {
         tooltip.style[
           getPopperPlacement(instance.popper)
-        ] = getOffsetDistanceInPx(instance.props.distance, Defaults.distance)
+        ] = getOffsetDistanceInPx(instance.props.distance)
       },
       onUpdate(data) {
         if (data && !instance.props.flipOnUpdate) {
@@ -507,7 +507,6 @@ export default function createTippy(reference, collectionProps) {
         styles.right = ''
         styles[getPopperPlacement(instance.popper)] = getOffsetDistanceInPx(
           instance.props.distance,
-          Defaults.distance,
         )
       },
     })

--- a/src/js/popper.js
+++ b/src/js/popper.js
@@ -398,11 +398,10 @@ export function isCursorOutsideInteractiveBorder(
 
 /**
  * Returns the distance offset, taking into account the default offset due to
- * the transform: translate() rule in CSS
+ * the transform: translate() rule (10px) in CSS
  * @param {Number} distance
- * @param {Number} defaultDistance
- * @return {Boolean}
+ * @return {String}
  */
-export function getOffsetDistanceInPx(distance, defaultDistance) {
-  return -(distance - defaultDistance) + 'px'
+export function getOffsetDistanceInPx(distance) {
+  return -(distance - 10) + 'px'
 }

--- a/test/spec/popper.test.js
+++ b/test/spec/popper.test.js
@@ -654,24 +654,20 @@ describe('isCursorOutsideInteractiveBorder', () => {
 })
 
 describe('getOffsetDistanceInPx', () => {
-  const DISTANCE_IN_CSS = 10
-
   it('returns 0px by default', () => {
-    expect(getOffsetDistanceInPx(Defaults.distance, DISTANCE_IN_CSS)).toBe(
-      '0px',
-    )
+    expect(getOffsetDistanceInPx(Defaults.distance)).toBe('0px')
   })
 
   it('returns -10px if the distance is 20', () => {
-    expect(getOffsetDistanceInPx(20, DISTANCE_IN_CSS)).toBe('-10px')
+    expect(getOffsetDistanceInPx(20)).toBe('-10px')
   })
 
   it('returns 5px if the distance is 5', () => {
-    expect(getOffsetDistanceInPx(5, DISTANCE_IN_CSS)).toBe('5px')
+    expect(getOffsetDistanceInPx(5)).toBe('5px')
   })
 
   it('returns 18px if the distance is -8', () => {
-    expect(getOffsetDistanceInPx(-8, DISTANCE_IN_CSS)).toBe('18px')
+    expect(getOffsetDistanceInPx(-8)).toBe('18px')
   })
 })
 


### PR DESCRIPTION
Fixes #428 

The CSS transform is hardcoded as `10px`, so we should only use the hardcoded value (10)