### PR TITLE
Fix flip option

### DIFF
--- a/src/js/createTippy.js
+++ b/src/js/createTippy.js
@@ -488,7 +488,7 @@ export default function createTippy(reference, collectionProps) {
         },
       },
       onUpdate(data) {
-        if (!instance.props.flipOnUpdate) {
+        if (instance.props.flip && !instance.props.flipOnUpdate) {
           if (data.flipped) {
             instance.popperInstance.options.placement = data.placement
           }
@@ -528,7 +528,10 @@ export default function createTippy(reference, collectionProps) {
           instance.popperInstance.enableEventListeners()
         }
       }
-      setFlipModifierEnabled(instance.popperInstance.modifiers, true)
+      setFlipModifierEnabled(
+        instance.popperInstance.modifiers,
+        instance.props.flip,
+      )
     }
 
     // If the instance previously had followCursor behavior, it will be

--- a/test/spec/defaults.test.js
+++ b/test/spec/defaults.test.js
@@ -380,6 +380,14 @@ describe('flip', () => {
       false,
     )
   })
+
+  it('does not change after mounting', () => {
+    const instance = tippy(h(), withTestOptions({ flip: false, duration: 0 }))
+    instance.show()
+    expect(
+      instance.popperInstance.modifiers.find(m => m.name === 'flip').enabled,
+    ).toBe(false)
+  })
 })
 
 describe('flipBehavior', () => {


### PR DESCRIPTION
Although disabling flipping is undesirable and less common now with the new flipping behavior, the new flipping behavior broke `flip: false`