### PR TITLE
Remove WholeProps from index.d.ts

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -43,66 +43,60 @@ export interface PopperInstance extends Popper {
   modifiers: { name: string; padding: object | number }[]
 }
 
-/**
- * This interface will be called `Props` in the next major.
- * Exists for backwards-compat after TypeScript rewrite.
- */
-export interface WholeProps {
-  a11y: boolean
-  allowHTML: boolean
-  animateFill: boolean
-  animation: 'fade' | 'scale' | 'shift-toward' | 'perspective' | 'shift-away'
-  appendTo: 'parent' | Element | ((ref: Element) => Element)
-  aria: 'describedby' | 'labelledby' | null
-  arrow: boolean
-  arrowType: 'sharp' | 'round'
-  boundary: 'scrollParent' | 'window' | 'viewport' | HTMLElement
-  content: Content
-  delay: number | [number, number]
-  distance: number
-  duration: number | [number, number]
-  flip: boolean
-  flipBehavior: 'flip' | Placement[]
-  flipOnUpdate: boolean
-  followCursor: boolean | 'vertical' | 'horizontal' | 'initial'
-  hideOnClick: boolean | 'toggle'
-  ignoreAttributes: boolean
-  inertia: boolean
-  interactive: boolean
-  interactiveBorder: number
-  interactiveDebounce: number
-  lazy: boolean
-  maxWidth: number | string
-  multiple: boolean
-  offset: number | string
-  onHidden(instance: Instance): void
-  onHide(instance: Instance): void | false
-  onMount(instance: Instance): void
-  onShow(instance: Instance): void | false
-  onShown(instance: Instance): void
-  placement: Placement
-  popperOptions: Popper.PopperOptions
-  role: string
-  showOnInit: boolean
-  size: 'small' | 'regular' | 'large'
-  sticky: boolean
-  target: string
-  theme: 'dark' | 'light' | 'light-border' | 'google' | string
-  touch: boolean
-  touchHold: boolean
-  trigger: string
-  updateDuration: number
-  wait: ((instance: Instance, event?: Event) => void) | null
-  zIndex: number
+export interface Options {
+  a11y?: boolean
+  allowHTML?: boolean
+  animateFill?: boolean
+  animation?: 'fade' | 'scale' | 'shift-toward' | 'perspective' | 'shift-away'
+  appendTo?: 'parent' | Element | ((ref: Element) => Element)
+  aria?: 'describedby' | 'labelledby' | null
+  arrow?: boolean
+  arrowType?: 'sharp' | 'round'
+  boundary?: 'scrollParent' | 'window' | 'viewport' | HTMLElement
+  content?: Content
+  delay?: number | [number, number]
+  distance?: number
+  duration?: number | [number, number]
+  flip?: boolean
+  flipBehavior?: 'flip' | Placement[]
+  flipOnUpdate?: boolean
+  followCursor?: boolean | 'vertical' | 'horizontal' | 'initial'
+  hideOnClick?: boolean | 'toggle'
+  ignoreAttributes?: boolean
+  inertia?: boolean
+  interactive?: boolean
+  interactiveBorder?: number
+  interactiveDebounce?: number
+  lazy?: boolean
+  maxWidth?: number | string
+  multiple?: boolean
+  offset?: number | string
+  onHidden?(instance: Instance): void
+  onHide?(instance: Instance): void | false
+  onMount?(instance: Instance): void
+  onShow?(instance: Instance): void | false
+  onShown?(instance: Instance): void
+  placement?: Placement
+  popperOptions?: Popper.PopperOptions
+  role?: string
+  showOnInit?: boolean
+  size?: 'small' | 'regular' | 'large'
+  sticky?: boolean
+  target?: string
+  theme?: 'dark' | 'light' | 'light-border' | 'google' | string
+  touch?: boolean
+  touchHold?: boolean
+  trigger?: string
+  updateDuration?: number
+  wait?: ((instance: Instance, event?: Event) => void) | null
+  zIndex?: number
 }
 
 /**
  * @deprecated
  * Use `Options` instead.
  */
-export type Props = Partial<WholeProps>
-
-export type Options = Partial<WholeProps>
+export type Props = Partial<Options>
 
 export interface Instance {
   clearDelayTimeouts(): void

--- a/index.d.ts
+++ b/index.d.ts
@@ -96,7 +96,7 @@ export interface Options {
  * @deprecated
  * Use `Options` instead.
  */
-export type Props = Partial<Options>
+export type Props = Options
 
 export interface Instance {
   clearDelayTimeouts(): void


### PR DESCRIPTION
Ref: https://github.com/atomiks/tippyjs/pull/441#issuecomment-471278734

---

You can use custom `Required<T>` type as suggested [here](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-2-8.html#improved-control-over-mapped-type-modifiers).

```ts
import {Options} from 'tippy.js'

type Props = Required<Options>
```