### PR TITLE
Fix obscure Chrome setTimeout issue

### DIFF
--- a/src/createTippy.ts
+++ b/src/createTippy.ts
@@ -65,10 +65,10 @@ export default function createTippy(
   let lastMouseMoveEvent: MouseEvent
 
   // Timeout created by the show delay
-  let showTimeoutId = 0
+  let showTimeoutId: number
 
   // Timeout created by the hide delay
-  let hideTimeoutId = 0
+  let hideTimeoutId: number
 
   // Frame created by scheduleHide()
   let animationFrameId: number

--- a/src/createTippy.ts
+++ b/src/createTippy.ts
@@ -315,7 +315,11 @@ export default function createTippy(
         }
       }, delay)
     } else {
-      hide()
+      // Fixes a `transitionend` problem when it fires 1 frame too
+      // late sometimes, we don't want hide() to be called.
+      requestAnimationFrame(() => {
+        hide()
+      })
     }
   }
 

--- a/src/createTippy.ts
+++ b/src/createTippy.ts
@@ -70,6 +70,9 @@ export default function createTippy(
   // Timeout created by the hide delay
   let hideTimeoutId = 0
 
+  // Frame created by scheduleHide()
+  let animationFrameId: number
+
   // Flag to determine if the tippy is scheduled to show due to the show timeout
   let isScheduledToShow = false
 
@@ -317,7 +320,7 @@ export default function createTippy(
     } else {
       // Fixes a `transitionend` problem when it fires 1 frame too
       // late sometimes, we don't want hide() to be called.
-      requestAnimationFrame(() => {
+      animationFrameId = requestAnimationFrame(() => {
         hide()
       })
     }
@@ -807,6 +810,7 @@ export default function createTippy(
   function clearDelayTimeouts(): void {
     clearTimeout(showTimeoutId)
     clearTimeout(hideTimeoutId)
+    cancelAnimationFrame(animationFrameId)
   }
 
   /**

--- a/src/props.ts
+++ b/src/props.ts
@@ -11,7 +11,7 @@ export const defaultProps: Props = {
   arrowType: 'sharp',
   boundary: 'scrollParent',
   content: '',
-  delay: [0, 20],
+  delay: 0,
   distance: 10,
   duration: [325, 275],
   flip: true,

--- a/test/spec/createTippy.test.js
+++ b/test/spec/createTippy.test.js
@@ -48,7 +48,7 @@ describe('createTippy', () => {
     expect(tips[1].id).toBe(tips[2].id - 1)
   })
 
-  it('adds correct listeners to the reference element based on `trigger`', () => {
+  it('adds correct listeners to the reference element based on `trigger`', done => {
     const instance = createTippy(h(), {
       ...defaultProps,
       trigger: 'mouseenter focus click',
@@ -56,17 +56,22 @@ describe('createTippy', () => {
     instance.reference.dispatchEvent(new Event('mouseenter'))
     expect(instance.state.isVisible).toBe(true)
     instance.reference.dispatchEvent(new Event('mouseleave'))
-    expect(instance.state.isVisible).toBe(false)
-
-    instance.reference.dispatchEvent(new Event('focus'))
-    expect(instance.state.isVisible).toBe(true)
-    instance.reference.dispatchEvent(new Event('blur'))
-    expect(instance.state.isVisible).toBe(false)
-
-    instance.reference.dispatchEvent(new Event('click'))
-    expect(instance.state.isVisible).toBe(true)
-    instance.reference.dispatchEvent(new Event('click'))
-    expect(instance.state.isVisible).toBe(false)
+    requestAnimationFrame(() => {
+      expect(instance.state.isVisible).toBe(false)
+      instance.reference.dispatchEvent(new Event('focus'))
+      expect(instance.state.isVisible).toBe(true)
+      instance.reference.dispatchEvent(new Event('blur'))
+      requestAnimationFrame(() => {
+        expect(instance.state.isVisible).toBe(false)
+        instance.reference.dispatchEvent(new Event('click'))
+        expect(instance.state.isVisible).toBe(true)
+        instance.reference.dispatchEvent(new Event('click'))
+        requestAnimationFrame(() => {
+          expect(instance.state.isVisible).toBe(false)
+          done()
+        })
+      })
+    })
   })
 })
 

--- a/test/spec/props.test.js
+++ b/test/spec/props.test.js
@@ -232,44 +232,58 @@ describe('content', () => {
 })
 
 describe('trigger', () => {
-  it('default: many triggers', () => {
+  it('default: many triggers', done => {
     const ref = h()
     const { state } = tippy(ref)
     ref.dispatchEvent(new Event('mouseenter'))
     expect(state.isVisible).toBe(true)
     ref.dispatchEvent(new Event('mouseleave'))
-    expect(state.isVisible).toBe(false)
-    ref.dispatchEvent(new Event('focus'))
-    expect(state.isVisible).toBe(true)
-    ref.dispatchEvent(new Event('blur'))
-    expect(state.isVisible).toBe(false)
+    requestAnimationFrame(() => {
+      expect(state.isVisible).toBe(false)
+      ref.dispatchEvent(new Event('focus'))
+      expect(state.isVisible).toBe(true)
+      ref.dispatchEvent(new Event('blur'))
+      requestAnimationFrame(() => {
+        expect(state.isVisible).toBe(false)
+        done()
+      })
+    })
   })
 
-  it('mouseenter', () => {
+  it('mouseenter', done => {
     const ref = h()
     const { state } = tippy(ref, { trigger: 'mouseenter' })
     ref.dispatchEvent(new Event('mouseenter'))
     expect(state.isVisible).toBe(true)
     ref.dispatchEvent(new Event('mouseleave'))
-    expect(state.isVisible).toBe(false)
+    requestAnimationFrame(() => {
+      expect(state.isVisible).toBe(false)
+      done()
+    })
   })
 
-  it('focus', () => {
+  it('focus', done => {
     const ref = h()
     const { state } = tippy(ref, { trigger: 'focus' })
     ref.dispatchEvent(new Event('focus'))
     expect(state.isVisible).toBe(true)
     ref.dispatchEvent(new Event('blur'))
-    expect(state.isVisible).toBe(false)
+    requestAnimationFrame(() => {
+      expect(state.isVisible).toBe(false)
+      done()
+    })
   })
 
-  it('click', () => {
+  it('click', done => {
     const ref = h()
     const { state } = tippy(ref, { trigger: 'click' })
     ref.dispatchEvent(new Event('click'))
     expect(state.isVisible).toBe(true)
     ref.dispatchEvent(new Event('click'))
-    expect(state.isVisible).toBe(false)
+    requestAnimationFrame(() => {
+      expect(state.isVisible).toBe(false)
+      done()
+    })
   })
 
   it('manual', () => {


### PR DESCRIPTION
Ok so this is weird..

I originally used `delay: [0, 20]` as the default because Chrome had this `transitionend` issue where it fires 1 frame too late sometimes.  It's not a memory leak or bug, just an aesthetic thing. 

Using a delay of 20ms fixed the following: When mousing out of the element 1 frame before the tooltip fully showed, it would instantly be unmounted without transitioning out. When mousing in and out of the tooltip quickly it would sometimes unmount instantly rather than smoothly transition out (like interruptible animations should). It's not that big of a deal but kind of bothered me.

However now there's this strange bug where the hide `setTimeout` gets fired _really_ late despite only being 20ms by default. Like 1500ms+ and it leaves the tooltip stuck on the UI for a bit. And it's really hard to reproduce because it only happens 1/50 times or so, requires a page refresh, etc. It might even be something to do with Gatsby. 

I tested and confirmed that the timeout callback is being fired very late. I only found this issue https://stackoverflow.com/questions/35102791/stuck-settimeouts-chrome

---

What this change does is remove `setTimeout` scheduling by default and instead use `requestAnimationFrame` which doesn't seem to suffer from the late scheduling problem. This won't fix the late scheduling when you set a non-zero hide delay though...