### PR TITLE
Change show() checks

### DIFF
--- a/src/createTippy.ts
+++ b/src/createTippy.ts
@@ -930,15 +930,9 @@ export default function createTippy(
       return
     }
 
-    // Destroy tooltip if the reference element is no longer on the DOM
-    if (
-      !hasOwnProperty(instance.reference, 'isVirtual') &&
-      !document.documentElement.contains(instance.reference)
-    ) {
-      return destroy()
-    }
-
-    // Do not show tooltip if the reference element has a `disabled` attribute
+    // Standardize `disabled` behavior across browsers.
+    // Firefox allows events on disabled elements, but Chrome doesn't.
+    // Using a wrapper element (i.e. <span>) is recommended.
     if (instance.reference.hasAttribute('disabled')) {
       return
     }

--- a/test/spec/createTippy.test.js
+++ b/test/spec/createTippy.test.js
@@ -170,14 +170,6 @@ describe('instance.show', () => {
     instance.show()
     expect(instance.state.isVisible).toBe(false)
   })
-
-  it('destroys the instance if the reference is not on the DOM', () => {
-    const ref = h()
-    const instance = createTippy(ref, defaultProps)
-    ref.remove()
-    instance.show()
-    expect(instance.state.isDestroyed).toBe(true)
-  })
 })
 
 describe('instance.hide', () => {


### PR DESCRIPTION
Resolves #423 

- Removes the auto-destroy statement. It causes unexpected behavior and breaks compatibility with shadow DOM. It's not documented anywhere and hides memory leaks so it should be removed. 
- Clarify comment of why we have the `disabled` attribute check