### PR TITLE
Change notransition technique

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -7,7 +7,6 @@ export const PADDING = 4
 // Classes
 export const IOS_CLASS = 'tippy-iOS'
 export const ACTIVE_CLASS = 'tippy-active'
-export const NO_TRANSITION_CLASS = 'tippy-notransition'
 
 // Selectors
 export const POPPER_SELECTOR = '.tippy-popper'

--- a/src/createTippy.ts
+++ b/src/createTippy.ts
@@ -10,13 +10,7 @@ import {
 } from './types'
 import { isIE } from './browser'
 import { closest, closestCallback, arrayFrom } from './ponyfills'
-import {
-  PASSIVE,
-  PADDING,
-  ACTIVE_CLASS,
-  NO_TRANSITION_CLASS,
-  POPPER_SELECTOR,
-} from './constants'
+import { PASSIVE, PADDING, ACTIVE_CLASS, POPPER_SELECTOR } from './constants'
 import { isUsingTouch } from './bindGlobalEventListeners'
 import { defaultProps, POPPER_INSTANCE_DEPENDENCIES } from './props'
 import {
@@ -95,6 +89,11 @@ export default function createTippy(
 
   // Node the tippy is currently appended to
   let parentNode: Element
+
+  // The tippy's previous placement
+  let previousPlacement: string
+
+  let wasVisibleDuringPreviousUpdate = false
 
   /* ======================= 🔑 Public members 🔑 ======================= */
   // id used for the `aria-describedby` / `aria-labelledby` attribute
@@ -495,6 +494,21 @@ export default function createTippy(
         }
         setFlipModifierEnabled(instance.popperInstance!.modifiers, false)
       }
+
+      // Prevents a transition when changing placements (while tippy is visible)
+      // for scroll/resize updates
+      if (
+        previousPlacement &&
+        previousPlacement !== data.placement &&
+        wasVisibleDuringPreviousUpdate
+      ) {
+        tooltip.style.transition = 'none'
+        requestAnimationFrame(() => {
+          tooltip.style.transition = ''
+        })
+      }
+      previousPlacement = data.placement
+      wasVisibleDuringPreviousUpdate = instance.state.isVisible
 
       tooltip.setAttribute('x-placement', data.placement)
 
@@ -983,8 +997,6 @@ export default function createTippy(
       setVisibilityState(getInnerElements(), 'visible')
 
       onTransitionedIn(duration, () => {
-        instance.popperChildren.tooltip.classList.add(NO_TRANSITION_CLASS)
-
         if (instance.props.aria) {
           instance.reference.setAttribute(
             `aria-${instance.props.aria}`,
@@ -1016,8 +1028,6 @@ export default function createTippy(
       return
     }
 
-    instance.popperChildren.tooltip.classList.remove(NO_TRANSITION_CLASS)
-
     if (instance.props.interactive) {
       instance.reference.classList.remove(ACTIVE_CLASS)
     }
@@ -1025,6 +1035,7 @@ export default function createTippy(
     instance.popper.style.visibility = 'hidden'
     instance.state.isVisible = false
     instance.state.isShown = false
+    wasVisibleDuringPreviousUpdate = false
 
     applyTransitionDuration(getInnerElements(), duration)
 

--- a/src/createTippy.ts
+++ b/src/createTippy.ts
@@ -90,7 +90,6 @@ export default function createTippy(
   // Node the tippy is currently appended to
   let parentNode: Element
 
-  // The tippy's previous placement
   let previousPlacement: string
 
   let wasVisibleDuringPreviousUpdate = false

--- a/src/scss/index.scss
+++ b/src/scss/index.scss
@@ -5,10 +5,6 @@
   cursor: pointer !important;
 }
 
-.tippy-notransition {
-  transition: none;
-}
-
 .tippy-popper {
   transition-timing-function: cubic-bezier(0.165, 0.84, 0.44, 1);
   max-width: calc(100% - 8px);


### PR DESCRIPTION
Fixes https://github.com/atomiks/tippy.js-react/issues/67

Changes the "notransition" technique which fixes undesirable transitions when the tippy changes placements on updates.

**Before**: add a `transition: none` CSS class on the tippy once `onShown()` completes

**After**: use some instance flags to check if the previous placement is the same and if the previous update happened while the tippy was visible. If so, disable transitions for a single frame before painting. This is a better way to do it anyway and it fixes the problem linked

(going to be deleting the comments describing the variables after this as they're quite redundant, that's why I didn't add any here)

