### PR TITLE
Add x-out-of-boundaries attribute to tooltip node

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -4,6 +4,11 @@ export const PASSIVE = { passive: true }
 // Popper `preventOverflow` padding
 export const PADDING = 4
 
+// Popper attributes
+// In Popper v2 these will be `data-*` instead of `x-*` to adhere to HTML5 spec
+export const PLACEMENT_ATTRIBUTE = 'x-placement'
+export const OUT_OF_BOUNDARIES_ATTRIBUTE = 'x-out-of-boundaries'
+
 // Classes
 export const IOS_CLASS = 'tippy-iOS'
 export const ACTIVE_CLASS = 'tippy-active'

--- a/src/createTippy.ts
+++ b/src/createTippy.ts
@@ -18,7 +18,6 @@ import {
   ACTIVE_CLASS,
   POPPER_SELECTOR,
 } from './constants'
-import { PASSIVE, PADDING, ACTIVE_CLASS, POPPER_SELECTOR } from './constants'
 import { isUsingTouch } from './bindGlobalEventListeners'
 import { defaultProps, POPPER_INSTANCE_DEPENDENCIES } from './props'
 import {

--- a/src/createTippy.ts
+++ b/src/createTippy.ts
@@ -13,6 +13,8 @@ import { closest, closestCallback, arrayFrom } from './ponyfills'
 import {
   PASSIVE,
   PADDING,
+  PLACEMENT_ATTRIBUTE,
+  OUT_OF_BOUNDARIES_ATTRIBUTE,
   ACTIVE_CLASS,
   NO_TRANSITION_CLASS,
   POPPER_SELECTOR,
@@ -496,7 +498,14 @@ export default function createTippy(
         setFlipModifierEnabled(instance.popperInstance!.modifiers, false)
       }
 
-      tooltip.setAttribute('x-placement', data.placement)
+      // Apply all of the popper's attributes to the tootip node as well.
+      // Allows users to avoid using the .tippy-popper selector for themes.
+      tooltip.setAttribute(PLACEMENT_ATTRIBUTE, data.placement)
+      if (data.attributes[OUT_OF_BOUNDARIES_ATTRIBUTE] !== false) {
+        tooltip.setAttribute(OUT_OF_BOUNDARIES_ATTRIBUTE, '')
+      } else {
+        tooltip.removeAttribute(OUT_OF_BOUNDARIES_ATTRIBUTE)
+      }
 
       const basePlacement = getPopperPlacement(instance.popper)
       const styles = tooltip.style


### PR DESCRIPTION
The `x-out-of-boundaries` is the other Popper attribute along with `x-placement` that we should migrate to the tooltip node.