### PR TITLE
Linting

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,0 +1,5 @@
+node_modules
+coverage
+esm
+umd
+website

--- a/.eslintrc
+++ b/.eslintrc
@@ -16,6 +16,17 @@
   "parserOptions": {
     "project": "./tsconfig.json"
   },
+  "overrides": [{
+    "files": ["website/**"],
+    "rules": {
+      "@typescript-eslint/camelcase": "off",
+      "@typescript-eslint/no-unused-vars": "off",
+      "@typescript-eslint/no-use-before-define": "off",
+      "@typescript-eslint/no-var-requires": "off",
+      "react/prop-types": "off",
+      "react/no-unescaped-entities": "off"
+    }
+  }],
   "rules": {
     "@typescript-eslint/no-use-before-define": [
       "error",
@@ -23,6 +34,6 @@
     ],
     "@typescript-eslint/no-non-null-assertion": "off",
     "@typescript-eslint/no-explicit-any": "off",
-    "@typescript-eslint/array-type": ["off"]
+    "@typescript-eslint/array-type": "off"
   }
 }

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,28 +1,25 @@
-{
-  "env": {
-    "browser": true,
-    "node": true,
-    "jest": true,
-    "es6": true
+module.exports = {
+  env: {
+    browser: true,
+    node: true,
+    jest: true,
+    es6: true,
   },
-  "extends": [
-    "eslint:recommended",
-    "plugin:@typescript-eslint/recommended",
-    "prettier",
-    "prettier/@typescript-eslint"
+  extends: [
+    'eslint:recommended',
+    'plugin:@typescript-eslint/recommended',
+    'prettier',
+    'prettier/@typescript-eslint',
   ],
-  "plugins": ["@typescript-eslint"],
-  "parser": "@typescript-eslint/parser",
-  "parserOptions": {
-    "project": "./tsconfig.json"
+  plugins: ['@typescript-eslint'],
+  parser: '@typescript-eslint/parser',
+  parserOptions: {
+    project: './tsconfig.json',
   },
-  "rules": {
-    "@typescript-eslint/no-use-before-define": [
-      "error",
-      { "functions": false }
-    ],
-    "@typescript-eslint/no-non-null-assertion": "off",
-    "@typescript-eslint/no-explicit-any": "off",
-    "@typescript-eslint/array-type": "off"
-  }
+  rules: {
+    '@typescript-eslint/no-use-before-define': ['error', { functions: false }],
+    '@typescript-eslint/no-non-null-assertion': 'off',
+    '@typescript-eslint/no-explicit-any': 'off',
+    '@typescript-eslint/array-type': 'off',
+  },
 }

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -16,17 +16,6 @@
   "parserOptions": {
     "project": "./tsconfig.json"
   },
-  "overrides": [{
-    "files": ["website/**"],
-    "rules": {
-      "@typescript-eslint/camelcase": "off",
-      "@typescript-eslint/no-unused-vars": "off",
-      "@typescript-eslint/no-use-before-define": "off",
-      "@typescript-eslint/no-var-requires": "off",
-      "react/prop-types": "off",
-      "react/no-unescaped-entities": "off"
-    }
-  }],
   "rules": {
     "@typescript-eslint/no-use-before-define": [
       "error",

--- a/demo/index.html
+++ b/demo/index.html
@@ -4,6 +4,7 @@
     <title>Tippy Dev</title>
     <script src="./index.js" defer></script>
     <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <link rel="shortcut icon" href="data:image/x-icon;," type="image/x-icon" />
     <style>
       body {
         font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto,

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "tippy.js",
-  "version": "4.2.0",
+  "version": "4.2.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -14,27 +14,94 @@
       }
     },
     "@babel/core": {
-      "version": "7.2.2",
-      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.2.2.tgz",
-      "integrity": "sha512-59vB0RWt09cAct5EIe58+NzGP4TFSD3Bz//2/ELy3ZeTeKF6VTD1AXlH8BGGbCX0PuobZBsIzO7IAI9PH67eKw==",
+      "version": "7.4.0",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.4.0.tgz",
+      "integrity": "sha512-Dzl7U0/T69DFOTwqz/FJdnOSWS57NpjNfCwMKHABr589Lg8uX1RrlBIJ7L5Dubt/xkLsx0xH5EBFzlBVes1ayA==",
       "dev": true,
       "requires": {
         "@babel/code-frame": "^7.0.0",
-        "@babel/generator": "^7.2.2",
-        "@babel/helpers": "^7.2.0",
-        "@babel/parser": "^7.2.2",
-        "@babel/template": "^7.2.2",
-        "@babel/traverse": "^7.2.2",
-        "@babel/types": "^7.2.2",
+        "@babel/generator": "^7.4.0",
+        "@babel/helpers": "^7.4.0",
+        "@babel/parser": "^7.4.0",
+        "@babel/template": "^7.4.0",
+        "@babel/traverse": "^7.4.0",
+        "@babel/types": "^7.4.0",
         "convert-source-map": "^1.1.0",
         "debug": "^4.1.0",
         "json5": "^2.1.0",
-        "lodash": "^4.17.10",
+        "lodash": "^4.17.11",
         "resolve": "^1.3.2",
         "semver": "^5.4.1",
         "source-map": "^0.5.0"
       },
       "dependencies": {
+        "@babel/generator": {
+          "version": "7.4.0",
+          "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.4.0.tgz",
+          "integrity": "sha512-/v5I+a1jhGSKLgZDcmAUZ4K/VePi43eRkUs3yePW1HB1iANOD5tqJXwGSG4BZhSksP8J9ejSlwGeTiiOFZOrXQ==",
+          "dev": true,
+          "requires": {
+            "@babel/types": "^7.4.0",
+            "jsesc": "^2.5.1",
+            "lodash": "^4.17.11",
+            "source-map": "^0.5.0",
+            "trim-right": "^1.0.1"
+          }
+        },
+        "@babel/helper-split-export-declaration": {
+          "version": "7.4.0",
+          "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.4.0.tgz",
+          "integrity": "sha512-7Cuc6JZiYShaZnybDmfwhY4UYHzI6rlqhWjaIqbsJGsIqPimEYy5uh3akSRLMg65LSdSEnJ8a8/bWQN6u2oMGw==",
+          "dev": true,
+          "requires": {
+            "@babel/types": "^7.4.0"
+          }
+        },
+        "@babel/parser": {
+          "version": "7.4.2",
+          "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.4.2.tgz",
+          "integrity": "sha512-9fJTDipQFvlfSVdD/JBtkiY0br9BtfvW2R8wo6CX/Ej2eMuV0gWPk1M67Mt3eggQvBqYW1FCEk8BN7WvGm/g5g==",
+          "dev": true
+        },
+        "@babel/template": {
+          "version": "7.4.0",
+          "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.4.0.tgz",
+          "integrity": "sha512-SOWwxxClTTh5NdbbYZ0BmaBVzxzTh2tO/TeLTbF6MO6EzVhHTnff8CdBXx3mEtazFBoysmEM6GU/wF+SuSx4Fw==",
+          "dev": true,
+          "requires": {
+            "@babel/code-frame": "^7.0.0",
+            "@babel/parser": "^7.4.0",
+            "@babel/types": "^7.4.0"
+          }
+        },
+        "@babel/traverse": {
+          "version": "7.4.0",
+          "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.4.0.tgz",
+          "integrity": "sha512-/DtIHKfyg2bBKnIN+BItaIlEg5pjAnzHOIQe5w+rHAw/rg9g0V7T4rqPX8BJPfW11kt3koyjAnTNwCzb28Y1PA==",
+          "dev": true,
+          "requires": {
+            "@babel/code-frame": "^7.0.0",
+            "@babel/generator": "^7.4.0",
+            "@babel/helper-function-name": "^7.1.0",
+            "@babel/helper-split-export-declaration": "^7.4.0",
+            "@babel/parser": "^7.4.0",
+            "@babel/types": "^7.4.0",
+            "debug": "^4.1.0",
+            "globals": "^11.1.0",
+            "lodash": "^4.17.11"
+          }
+        },
+        "@babel/types": {
+          "version": "7.4.0",
+          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.4.0.tgz",
+          "integrity": "sha512-aPvkXyU2SPOnztlgo8n9cEiXW755mgyvueUPcpStqdzoSPm0fjO0vQBjLkt3JKJW7ufikfcnMTTPsN1xaTsBPA==",
+          "dev": true,
+          "requires": {
+            "esutils": "^2.0.2",
+            "lodash": "^4.17.11",
+            "to-fast-properties": "^2.0.0"
+          }
+        },
         "json5": {
           "version": "2.1.0",
           "resolved": "https://registry.npmjs.org/json5/-/json5-2.1.0.tgz",
@@ -268,14 +335,83 @@
       }
     },
     "@babel/helpers": {
-      "version": "7.3.1",
-      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.3.1.tgz",
-      "integrity": "sha512-Q82R3jKsVpUV99mgX50gOPCWwco9Ec5Iln/8Vyu4osNIOQgSrd9RFrQeUvmvddFNoLwMyOUWU+5ckioEKpDoGA==",
+      "version": "7.4.2",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.4.2.tgz",
+      "integrity": "sha512-gQR1eQeroDzFBikhrCccm5Gs2xBjZ57DNjGbqTaHo911IpmSxflOQWMAHPw/TXk8L3isv7s9lYzUkexOeTQUYg==",
       "dev": true,
       "requires": {
-        "@babel/template": "^7.1.2",
-        "@babel/traverse": "^7.1.5",
-        "@babel/types": "^7.3.0"
+        "@babel/template": "^7.4.0",
+        "@babel/traverse": "^7.4.0",
+        "@babel/types": "^7.4.0"
+      },
+      "dependencies": {
+        "@babel/generator": {
+          "version": "7.4.0",
+          "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.4.0.tgz",
+          "integrity": "sha512-/v5I+a1jhGSKLgZDcmAUZ4K/VePi43eRkUs3yePW1HB1iANOD5tqJXwGSG4BZhSksP8J9ejSlwGeTiiOFZOrXQ==",
+          "dev": true,
+          "requires": {
+            "@babel/types": "^7.4.0",
+            "jsesc": "^2.5.1",
+            "lodash": "^4.17.11",
+            "source-map": "^0.5.0",
+            "trim-right": "^1.0.1"
+          }
+        },
+        "@babel/helper-split-export-declaration": {
+          "version": "7.4.0",
+          "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.4.0.tgz",
+          "integrity": "sha512-7Cuc6JZiYShaZnybDmfwhY4UYHzI6rlqhWjaIqbsJGsIqPimEYy5uh3akSRLMg65LSdSEnJ8a8/bWQN6u2oMGw==",
+          "dev": true,
+          "requires": {
+            "@babel/types": "^7.4.0"
+          }
+        },
+        "@babel/parser": {
+          "version": "7.4.2",
+          "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.4.2.tgz",
+          "integrity": "sha512-9fJTDipQFvlfSVdD/JBtkiY0br9BtfvW2R8wo6CX/Ej2eMuV0gWPk1M67Mt3eggQvBqYW1FCEk8BN7WvGm/g5g==",
+          "dev": true
+        },
+        "@babel/template": {
+          "version": "7.4.0",
+          "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.4.0.tgz",
+          "integrity": "sha512-SOWwxxClTTh5NdbbYZ0BmaBVzxzTh2tO/TeLTbF6MO6EzVhHTnff8CdBXx3mEtazFBoysmEM6GU/wF+SuSx4Fw==",
+          "dev": true,
+          "requires": {
+            "@babel/code-frame": "^7.0.0",
+            "@babel/parser": "^7.4.0",
+            "@babel/types": "^7.4.0"
+          }
+        },
+        "@babel/traverse": {
+          "version": "7.4.0",
+          "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.4.0.tgz",
+          "integrity": "sha512-/DtIHKfyg2bBKnIN+BItaIlEg5pjAnzHOIQe5w+rHAw/rg9g0V7T4rqPX8BJPfW11kt3koyjAnTNwCzb28Y1PA==",
+          "dev": true,
+          "requires": {
+            "@babel/code-frame": "^7.0.0",
+            "@babel/generator": "^7.4.0",
+            "@babel/helper-function-name": "^7.1.0",
+            "@babel/helper-split-export-declaration": "^7.4.0",
+            "@babel/parser": "^7.4.0",
+            "@babel/types": "^7.4.0",
+            "debug": "^4.1.0",
+            "globals": "^11.1.0",
+            "lodash": "^4.17.11"
+          }
+        },
+        "@babel/types": {
+          "version": "7.4.0",
+          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.4.0.tgz",
+          "integrity": "sha512-aPvkXyU2SPOnztlgo8n9cEiXW755mgyvueUPcpStqdzoSPm0fjO0vQBjLkt3JKJW7ufikfcnMTTPsN1xaTsBPA==",
+          "dev": true,
+          "requires": {
+            "esutils": "^2.0.2",
+            "lodash": "^4.17.11",
+            "to-fast-properties": "^2.0.0"
+          }
+        }
       }
     },
     "@babel/highlight": {
@@ -12356,6 +12492,129 @@
         "ws": "^5.1.1"
       },
       "dependencies": {
+        "@babel/core": {
+          "version": "7.3.4",
+          "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.3.4.tgz",
+          "integrity": "sha512-jRsuseXBo9pN197KnDwhhaaBzyZr2oIcLHHTt2oDdQrej5Qp57dCCJafWx5ivU8/alEYDpssYqv1MUqcxwQlrA==",
+          "dev": true,
+          "requires": {
+            "@babel/code-frame": "^7.0.0",
+            "@babel/generator": "^7.3.4",
+            "@babel/helpers": "^7.2.0",
+            "@babel/parser": "^7.3.4",
+            "@babel/template": "^7.2.2",
+            "@babel/traverse": "^7.3.4",
+            "@babel/types": "^7.3.4",
+            "convert-source-map": "^1.1.0",
+            "debug": "^4.1.0",
+            "json5": "^2.1.0",
+            "lodash": "^4.17.11",
+            "resolve": "^1.3.2",
+            "semver": "^5.4.1",
+            "source-map": "^0.5.0"
+          },
+          "dependencies": {
+            "@babel/generator": {
+              "version": "7.4.0",
+              "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.4.0.tgz",
+              "integrity": "sha512-/v5I+a1jhGSKLgZDcmAUZ4K/VePi43eRkUs3yePW1HB1iANOD5tqJXwGSG4BZhSksP8J9ejSlwGeTiiOFZOrXQ==",
+              "dev": true,
+              "requires": {
+                "@babel/types": "^7.4.0",
+                "jsesc": "^2.5.1",
+                "lodash": "^4.17.11",
+                "source-map": "^0.5.0",
+                "trim-right": "^1.0.1"
+              }
+            },
+            "@babel/parser": {
+              "version": "7.4.2",
+              "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.4.2.tgz",
+              "integrity": "sha512-9fJTDipQFvlfSVdD/JBtkiY0br9BtfvW2R8wo6CX/Ej2eMuV0gWPk1M67Mt3eggQvBqYW1FCEk8BN7WvGm/g5g==",
+              "dev": true
+            },
+            "@babel/traverse": {
+              "version": "7.4.0",
+              "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.4.0.tgz",
+              "integrity": "sha512-/DtIHKfyg2bBKnIN+BItaIlEg5pjAnzHOIQe5w+rHAw/rg9g0V7T4rqPX8BJPfW11kt3koyjAnTNwCzb28Y1PA==",
+              "dev": true,
+              "requires": {
+                "@babel/code-frame": "^7.0.0",
+                "@babel/generator": "^7.4.0",
+                "@babel/helper-function-name": "^7.1.0",
+                "@babel/helper-split-export-declaration": "^7.4.0",
+                "@babel/parser": "^7.4.0",
+                "@babel/types": "^7.4.0",
+                "debug": "^4.1.0",
+                "globals": "^11.1.0",
+                "lodash": "^4.17.11"
+              }
+            },
+            "@babel/types": {
+              "version": "7.4.0",
+              "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.4.0.tgz",
+              "integrity": "sha512-aPvkXyU2SPOnztlgo8n9cEiXW755mgyvueUPcpStqdzoSPm0fjO0vQBjLkt3JKJW7ufikfcnMTTPsN1xaTsBPA==",
+              "dev": true,
+              "requires": {
+                "esutils": "^2.0.2",
+                "lodash": "^4.17.11",
+                "to-fast-properties": "^2.0.0"
+              }
+            },
+            "debug": {
+              "version": "4.1.1",
+              "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+              "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+              "dev": true,
+              "requires": {
+                "ms": "^2.1.1"
+              }
+            },
+            "json5": {
+              "version": "2.1.0",
+              "resolved": "https://registry.npmjs.org/json5/-/json5-2.1.0.tgz",
+              "integrity": "sha512-8Mh9h6xViijj36g7Dxi+Y4S6hNGV96vcJZr/SrlHh1LR/pEn/8j/+qIBbs44YKl69Lrfctp4QD+AdWLTMqEZAQ==",
+              "dev": true,
+              "requires": {
+                "minimist": "^1.2.0"
+              }
+            },
+            "ms": {
+              "version": "2.1.1",
+              "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
+              "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
+              "dev": true
+            },
+            "source-map": {
+              "version": "0.5.7",
+              "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+              "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+              "dev": true
+            }
+          }
+        },
+        "@babel/helper-split-export-declaration": {
+          "version": "7.4.0",
+          "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.4.0.tgz",
+          "integrity": "sha512-7Cuc6JZiYShaZnybDmfwhY4UYHzI6rlqhWjaIqbsJGsIqPimEYy5uh3akSRLMg65LSdSEnJ8a8/bWQN6u2oMGw==",
+          "dev": true,
+          "requires": {
+            "@babel/types": "^7.4.0"
+          },
+          "dependencies": {
+            "@babel/types": {
+              "version": "7.4.0",
+              "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.4.0.tgz",
+              "integrity": "sha512-aPvkXyU2SPOnztlgo8n9cEiXW755mgyvueUPcpStqdzoSPm0fjO0vQBjLkt3JKJW7ufikfcnMTTPsN1xaTsBPA==",
+              "dev": true,
+              "requires": {
+                "esutils": "^2.0.2",
+                "lodash": "^4.17.11",
+                "to-fast-properties": "^2.0.0"
+              }
+            }
+          }
+        },
         "arr-diff": {
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-4.0.0.tgz",
@@ -12700,6 +12959,12 @@
             "snapdragon": "^0.8.1",
             "to-regex": "^3.0.2"
           }
+        },
+        "minimist": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+          "dev": true
         },
         "ms": {
           "version": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,13 @@
   "unpkg": "./umd/index.all.min.js",
   "types": "index.d.ts",
   "author": "atomiks",
+  "contributors": [
+    "Brett Zamir"
+  ],
   "license": "MIT",
+  "bugs": "https://github.com/atomiks/tippyjs/issues",
+  "homepage": "https://atomiks.github.io/tippyjs/",
+  "engines": {},
   "keywords": [
     "tooltip",
     "popover",
@@ -31,7 +37,7 @@
     "test": "jest --coverage",
     "test:browser": "parcel test/browser/index.html -d .devserver --open",
     "check-types": "tsc",
-    "lint": "eslint \"src/**/*.ts\"",
+    "lint": "eslint --report-unused-disable-directives .",
     "clean": "rimraf umd esm themes coverage .devserver .cache ./index.css",
     "prepare": "npm run clean && npm run build"
   },

--- a/package.json
+++ b/package.json
@@ -13,7 +13,6 @@
   "license": "MIT",
   "bugs": "https://github.com/atomiks/tippyjs/issues",
   "homepage": "https://atomiks.github.io/tippyjs/",
-  "engines": {},
   "keywords": [
     "tooltip",
     "popover",

--- a/rollup.build.js
+++ b/rollup.build.js
@@ -1,3 +1,4 @@
+/* eslint-disable no-console, @typescript-eslint/no-var-requires */
 const fs = require('fs')
 const pkg = require('./package.json')
 const { rollup } = require('rollup')
@@ -8,7 +9,7 @@ const postcss = require('postcss')
 const autoprefixer = require('autoprefixer')
 const cssnano = require('cssnano')
 const resolve = require('rollup-plugin-node-resolve')
-const commonjs = require('rollup-plugin-commonjs')
+// const commonjs = require('rollup-plugin-commonjs')
 const json = require('rollup-plugin-json')
 const cssOnly = require('rollup-plugin-css-only')
 const { green, blue } = require('colorette')

--- a/test/spec/createTippy.test.js
+++ b/test/spec/createTippy.test.js
@@ -113,7 +113,7 @@ describe('instance.destroy', () => {
     const ref = h()
     const p = document.createElement('p')
     ref.append(p)
-    const instance = createTippy(ref, { ...defaultProps, target: 'p' })
+    /* const instance = */ createTippy(ref, { ...defaultProps, target: 'p' })
     p._tippy = createTippy(p, defaultProps)
     expect(p._tippy).toBeDefined()
     ref._tippy.destroy(true)
@@ -180,7 +180,7 @@ describe('instance.hide', () => {
     instance.destroy()
   })
 
-  it('removes the popper element from the DOM after hiding', () => {
+  it('removes the popper element from the DOM after hiding', done => {
     const instance = createTippy(h(), {
       ...defaultProps,
     })

--- a/test/spec/createTippy.test.js
+++ b/test/spec/createTippy.test.js
@@ -113,7 +113,7 @@ describe('instance.destroy', () => {
     const ref = h()
     const p = document.createElement('p')
     ref.append(p)
-    /* const instance = */ createTippy(ref, { ...defaultProps, target: 'p' })
+    createTippy(ref, { ...defaultProps, target: 'p' })
     p._tippy = createTippy(p, defaultProps)
     expect(p._tippy).toBeDefined()
     ref._tippy.destroy(true)

--- a/test/spec/popper.test.js
+++ b/test/spec/popper.test.js
@@ -348,7 +348,7 @@ describe('afterPopperPositionUpdates', () => {
 
   it('is not called by popper if already updated', done => {
     const tip = tippy(h(), { lazy: false })
-    const fn = jest.fn()
+    /* const fn = */ jest.fn()
     // popper calls scheduleUpdate() on init
     setTimeout(() => {
       const fn = jest.fn()

--- a/test/spec/popper.test.js
+++ b/test/spec/popper.test.js
@@ -348,7 +348,6 @@ describe('afterPopperPositionUpdates', () => {
 
   it('is not called by popper if already updated', done => {
     const tip = tippy(h(), { lazy: false })
-    /* const fn = */ jest.fn()
     // popper calls scheduleUpdate() on init
     setTimeout(() => {
       const fn = jest.fn()

--- a/test/spec/utils.test.js
+++ b/test/spec/utils.test.js
@@ -122,6 +122,7 @@ describe('getValue', () => {
   })
 
   it('uses the default duration if the value is undefined', () => {
+    /* eslint-disable no-sparse-arrays */
     expect(Utils.getValue([, 5], 0, defaultProps.duration[0])).toBe(
       defaultProps.duration[0],
     )
@@ -132,6 +133,7 @@ describe('getValue', () => {
       defaultProps.delay,
     )
     expect(Utils.getValue([5], 1, defaultProps.delay)).toBe(defaultProps.delay)
+    /* eslint-enable no-sparse-arrays */
   })
 })
 

--- a/test/spec/utils.test.js
+++ b/test/spec/utils.test.js
@@ -122,18 +122,18 @@ describe('getValue', () => {
   })
 
   it('uses the default duration if the value is undefined', () => {
-    /* eslint-disable no-sparse-arrays */
-    expect(Utils.getValue([, 5], 0, defaultProps.duration[0])).toBe(
+    expect(Utils.getValue([undefined, 5], 0, defaultProps.duration[0])).toBe(
       defaultProps.duration[0],
     )
-    expect(Utils.getValue([5], 1, defaultProps.duration[1])).toBe(
+    expect(Utils.getValue([5, undefined], 1, defaultProps.duration[1])).toBe(
       defaultProps.duration[1],
     )
-    expect(Utils.getValue([, 5], 0, defaultProps.delay)).toBe(
+    expect(Utils.getValue([undefined, 5], 0, defaultProps.delay)).toBe(
       defaultProps.delay,
     )
-    expect(Utils.getValue([5], 1, defaultProps.delay)).toBe(defaultProps.delay)
-    /* eslint-enable no-sparse-arrays */
+    expect(Utils.getValue([5, undefined], 1, defaultProps.delay)).toBe(
+      defaultProps.delay,
+    )
   })
 })
 

--- a/website/src/prism-extensions.js
+++ b/website/src/prism-extensions.js
@@ -1,3 +1,4 @@
+/* globals Prism */
 // __gatsby-monkey-patch-start
 Prism.languages.insertBefore('javascript', 'keyword', {
   module: {
@@ -166,7 +167,7 @@ Prism.languages.insertBefore('css', 'property', {
 
 Prism.languages.insertBefore('css', 'function', {
   operator: {
-    pattern: /(\s)[+\-*\/](?=\s)/,
+    pattern: /(\s)[+\-*/](?=\s)/,
     lookbehind: true,
   },
   hexcode: /#[\da-f]{3,8}/i,

--- a/website/src/prism-extensions.js
+++ b/website/src/prism-extensions.js
@@ -1,4 +1,3 @@
-/* globals Prism */
 // __gatsby-monkey-patch-start
 Prism.languages.insertBefore('javascript', 'keyword', {
   module: {


### PR DESCRIPTION
- Linting (ESLint): Add `.eslintignore` (Useful for IDE to avoid flagging when browsing files)
- Linting (ESLint): Apply ESLint to `rollup.build.js`
- Linting (ESLint): Fix error of missing `done` in test file (though `test` is in the ignore file to avoid flagging lesser errors)
- Linting (npm): Add linter-recommended `contributors`, `bugs`, `homepage`, and `engines` properties (some of these used on npmjs.com)
- Linting (HTML): Avoid favicon request in console

As far as the `test` linting errors, I personally think it would be better to ensure you are catching any errors there (if not in `website` too), but as it didn't appear to be your intent to lint them, I've added `test` and `website` to `.eslintignore` as well as the `dist` paths.

See above for the other rationales of inclusion.

I plan to provide a more substantive PR for modules after this.