### PR TITLE
Expose schedule{Hide,Show} methods

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -101,6 +101,8 @@ export interface Instance {
   popperInstance: PopperInstance | null
   props: Props
   reference: ReferenceElement
+  scheduleHide(): void
+  scheduleShow(event?: Event): void
   set(options: Options): void
   setContent(content: Content): void
   show(duration?: number): void

--- a/src/createTippy.ts
+++ b/src/createTippy.ts
@@ -114,6 +114,8 @@ export default function createTippy(
     setContent,
     show,
     hide,
+    scheduleShow,
+    scheduleHide,
     enable,
     disable,
     destroy,
@@ -753,76 +755,6 @@ export default function createTippy(
     }
   }
 
-  /**
-   * Setup before show() is invoked (delays, etc.)
-   */
-  function scheduleShow(event?: Event): void {
-    clearDelayTimeouts()
-
-    if (instance.state.isVisible) {
-      return
-    }
-
-    // Is a delegate, create an instance for the child target
-    if (instance.props.target) {
-      return createDelegateChildTippy(event)
-    }
-
-    isScheduledToShow = true
-
-    if (instance.props.wait) {
-      return instance.props.wait(instance, event)
-    }
-
-    // If the tooltip has a delay, we need to be listening to the mousemove as
-    // soon as the trigger event is fired, so that it's in the correct position
-    // upon mount.
-    // Edge case: if the tooltip is still mounted, but then scheduleShow() is
-    // called, it causes a jump.
-    if (hasFollowCursorBehavior() && !instance.state.isMounted) {
-      document.addEventListener('mousemove', positionVirtualReferenceNearCursor)
-    }
-
-    const delay = getValue(instance.props.delay, 0, defaultProps.delay)
-
-    if (delay) {
-      showTimeoutId = setTimeout(() => {
-        show()
-      }, delay)
-    } else {
-      show()
-    }
-  }
-
-  /**
-   * Setup before hide() is invoked (delays, etc.)
-   */
-  function scheduleHide(): void {
-    clearDelayTimeouts()
-
-    if (!instance.state.isVisible) {
-      return removeFollowCursorListener()
-    }
-
-    isScheduledToShow = false
-
-    const delay = getValue(instance.props.delay, 1, defaultProps.delay)
-
-    if (delay) {
-      hideTimeoutId = setTimeout(() => {
-        if (instance.state.isVisible) {
-          hide()
-        }
-      }, delay)
-    } else {
-      // Fixes a `transitionend` problem when it fires 1 frame too
-      // late sometimes, we don't want hide() to be called.
-      animationFrameId = requestAnimationFrame(() => {
-        hide()
-      })
-    }
-  }
-
   /* ======================= 🔑 Public methods 🔑 ======================= */
   /**
    * Enables the instance to allow it to show or hide
@@ -915,6 +847,76 @@ export default function createTippy(
    */
   function setContent(content: Content): void {
     set({ content })
+  }
+
+  /**
+   * Setup before show() is invoked (delays, etc.)
+   */
+  function scheduleShow(event?: Event): void {
+    clearDelayTimeouts()
+
+    if (instance.state.isVisible) {
+      return
+    }
+
+    // Is a delegate, create an instance for the child target
+    if (instance.props.target) {
+      return createDelegateChildTippy(event)
+    }
+
+    isScheduledToShow = true
+
+    if (instance.props.wait) {
+      return instance.props.wait(instance, event)
+    }
+
+    // If the tooltip has a delay, we need to be listening to the mousemove as
+    // soon as the trigger event is fired, so that it's in the correct position
+    // upon mount.
+    // Edge case: if the tooltip is still mounted, but then scheduleShow() is
+    // called, it causes a jump.
+    if (hasFollowCursorBehavior() && !instance.state.isMounted) {
+      document.addEventListener('mousemove', positionVirtualReferenceNearCursor)
+    }
+
+    const delay = getValue(instance.props.delay, 0, defaultProps.delay)
+
+    if (delay) {
+      showTimeoutId = setTimeout(() => {
+        show()
+      }, delay)
+    } else {
+      show()
+    }
+  }
+
+  /**
+   * Setup before hide() is invoked (delays, etc.)
+   */
+  function scheduleHide(): void {
+    clearDelayTimeouts()
+
+    if (!instance.state.isVisible) {
+      return removeFollowCursorListener()
+    }
+
+    isScheduledToShow = false
+
+    const delay = getValue(instance.props.delay, 1, defaultProps.delay)
+
+    if (delay) {
+      hideTimeoutId = setTimeout(() => {
+        if (instance.state.isVisible) {
+          hide()
+        }
+      }, delay)
+    } else {
+      // Fixes a `transitionend` problem when it fires 1 frame too
+      // late sometimes, we don't want hide() to be called.
+      animationFrameId = requestAnimationFrame(() => {
+        hide()
+      })
+    }
   }
 
   /**

--- a/src/types.ts
+++ b/src/types.ts
@@ -97,6 +97,8 @@ export interface Instance {
   popperInstance: PopperInstance | null
   props: Props
   reference: ReferenceElement
+  scheduleHide(): void
+  scheduleShow(event?: Event): void
   set(options: Options): void
   setContent(content: Content): void
   show(duration?: number): void


### PR DESCRIPTION
As surfaced by #460, `delay` / `wait` don't work for virtual references when calling `.show()` / `.hide()` since they are immediate. Like the internal event handlers, users should be calling the schedule methods instead for virtual references

TODO:

- Should they accept a `duration` argument like `show/hide`?