### PR TITLE
Adjust mount callback workaround

### DIFF
--- a/src/createTippy.ts
+++ b/src/createTippy.ts
@@ -23,12 +23,12 @@ import { defaultProps, POPPER_INSTANCE_DEPENDENCIES } from './props'
 import {
   createPopperElement,
   updatePopperElement,
-  afterPopperPositionUpdates,
   getChildren,
   getBasicPlacement,
   updateTransitionEndListener,
   isCursorOutsideInteractiveBorder,
   getOffsetDistanceInPx,
+  reflow,
 } from './popper'
 import {
   hasOwnProperty,
@@ -73,6 +73,8 @@ export default function createTippy(
   let currentParentNode: Element
   let previousPlacement: string
   let wasVisibleDuringPreviousUpdate = false
+  let isFirstMount = false
+  let currentMountCallback: () => void
   let currentTransitionEndListener: (event: TransitionEvent) => void
   let listeners: Listener[] = []
   let debouncedOnMouseMove =
@@ -552,6 +554,17 @@ export default function createTippy(
   }
 
   /**
+   * Runs the first mounting callback
+   */
+  function onFirstMount() {
+    if (isFirstMount) {
+      isFirstMount = false
+      reflow(popper)
+      currentMountCallback()
+    }
+  }
+
+  /**
    * Creates the popper instance for the instance
    */
   function createPopperInstance(): void {
@@ -653,19 +666,16 @@ export default function createTippy(
           ...getModifier(popperOptions, 'offset'),
         },
       },
-      // This gets invoked when calling `.set()` and updating a popper
-      // instance dependency, since a new popper instance gets created
       onCreate(data: Popper.Data) {
+        onFirstMount()
         applyMutations(data)
 
         if (popperOptions && popperOptions.onCreate) {
           popperOptions.onCreate(data)
         }
       },
-      // This gets invoked on initial create and show()/scroll/resize update.
-      // This is due to `afterPopperPositionUpdates` overwriting onCreate()
-      // with onUpdate()
       onUpdate(data: Popper.Data) {
+        onFirstMount()
         applyMutations(data)
 
         if (popperOptions && popperOptions.onUpdate) {
@@ -682,10 +692,11 @@ export default function createTippy(
   }
 
   /**
-   * Mounts the tooltip to the DOM, callback to show tooltip is run **after**
-   * popper's position has updated
+   * Mounts the tooltip to the DOM
    */
-  function mount(callback: () => void): void {
+  function mount(): void {
+    isFirstMount = true
+
     const shouldEnableListeners =
       !hasFollowCursorBehavior() &&
       !(instance.props.followCursor === 'initial' && isUsingTouch)
@@ -736,8 +747,6 @@ export default function createTippy(
         arrow.style.margin = '0'
       }
     }
-
-    afterPopperPositionUpdates(instance.popperInstance!, callback)
 
     const { appendTo } = instance.props
 
@@ -953,12 +962,11 @@ export default function createTippy(
       instance.reference.classList.add(ACTIVE_CLASS)
     }
 
-    const transitionableElements = getTransitionableElements()
-
     // Prevent a transition if the popper is at the opposite placement
+    const transitionableElements = getTransitionableElements()
     setTransitionDuration(transitionableElements.concat(instance.popper), 0)
 
-    mount(() => {
+    currentMountCallback = () => {
       if (!instance.state.isVisible) {
         return
       }
@@ -992,7 +1000,9 @@ export default function createTippy(
         instance.props.onShown(instance)
         instance.state.isShown = true
       })
-    })
+    }
+
+    mount()
   }
 
   /**

--- a/src/createTippy.ts
+++ b/src/createTippy.ts
@@ -73,7 +73,7 @@ export default function createTippy(
   let currentParentNode: Element
   let previousPlacement: string
   let wasVisibleDuringPreviousUpdate = false
-  let isFirstMount = false
+  let hasMountCallbackRun = false
   let currentMountCallback: () => void
   let currentTransitionEndListener: (event: TransitionEvent) => void
   let listeners: Listener[] = []
@@ -554,11 +554,11 @@ export default function createTippy(
   }
 
   /**
-   * Runs the first mounting callback
+   * Runs the mount callback
    */
-  function onFirstMount() {
-    if (isFirstMount) {
-      isFirstMount = false
+  function runMountCallback() {
+    if (!hasMountCallbackRun && currentMountCallback) {
+      hasMountCallbackRun = true
       reflow(popper)
       currentMountCallback()
     }
@@ -667,7 +667,7 @@ export default function createTippy(
         },
       },
       onCreate(data: Popper.Data) {
-        onFirstMount()
+        runMountCallback()
         applyMutations(data)
 
         if (popperOptions && popperOptions.onCreate) {
@@ -675,7 +675,7 @@ export default function createTippy(
         }
       },
       onUpdate(data: Popper.Data) {
-        onFirstMount()
+        runMountCallback()
         applyMutations(data)
 
         if (popperOptions && popperOptions.onUpdate) {
@@ -695,7 +695,7 @@ export default function createTippy(
    * Mounts the tooltip to the DOM
    */
   function mount(): void {
-    isFirstMount = true
+    hasMountCallbackRun = false
 
     const shouldEnableListeners =
       !hasFollowCursorBehavior() &&

--- a/src/createTippy.ts
+++ b/src/createTippy.ts
@@ -556,7 +556,7 @@ export default function createTippy(
   /**
    * Runs the mount callback
    */
-  function runMountCallback() {
+  function runMountCallback(): void {
     if (!hasMountCallbackRun && currentMountCallback) {
       hasMountCallbackRun = true
       reflow(popper)

--- a/src/popper.ts
+++ b/src/popper.ts
@@ -1,11 +1,9 @@
-import Popper from 'popper.js'
 import {
   PopperElement,
   Props,
   PopperChildren,
   HideAllOptions,
   BasicPlacement,
-  PopperInstance,
 } from './types'
 import { arrayFrom } from './ponyfills'
 import { innerHTML, div } from './utils'
@@ -289,31 +287,6 @@ export function updatePopperElement(
   if (prevProps.theme !== nextProps.theme) {
     updateTheme(tooltip, 'remove', prevProps.theme)
     updateTheme(tooltip, 'add', nextProps.theme)
-  }
-}
-
-/**
- * Runs the callback after the popper's position has been updated
- * update() is debounced with Promise.resolve() or setTimeout()
- * scheduleUpdate() is update() wrapped in requestAnimationFrame()
- */
-export function afterPopperPositionUpdates(
-  popperInstance: PopperInstance,
-  callback: () => void,
-): void {
-  const { popper, options } = popperInstance
-  const { onCreate, onUpdate } = options
-
-  options.onCreate = options.onUpdate = (data: Popper.Data) => {
-    reflow(popper)
-    callback()
-
-    if (onUpdate) {
-      onUpdate(data)
-    }
-
-    options.onCreate = onCreate
-    options.onUpdate = onUpdate
   }
 }
 

--- a/test/spec/popper.test.js
+++ b/test/spec/popper.test.js
@@ -4,7 +4,6 @@ import { defaultProps } from '../../src/props'
 import {
   createPopperElement,
   updatePopperElement,
-  afterPopperPositionUpdates,
   createArrowElement,
   createBackdropElement,
   hideAll,
@@ -331,32 +330,6 @@ describe('updatePopperElement', () => {
     expect(getChildren(popper).tooltip.classList.contains('other-theme')).toBe(
       true,
     )
-  })
-})
-
-describe('afterPopperPositionUpdates', () => {
-  it('is called by popper if not already updated', done => {
-    const tip = tippy(h(), { lazy: false })
-    // popper calls scheduleUpdate() on init
-    const fn = jest.fn()
-    afterPopperPositionUpdates(tip.popperInstance, fn)
-    setTimeout(() => {
-      expect(fn.mock.calls.length).toBe(1)
-      done()
-    }, 20)
-  })
-
-  it('is not called by popper if already updated', done => {
-    const tip = tippy(h(), { lazy: false })
-    // popper calls scheduleUpdate() on init
-    setTimeout(() => {
-      const fn = jest.fn()
-      afterPopperPositionUpdates(tip.popperInstance, fn, true)
-      setTimeout(() => {
-        expect(fn.mock.calls.length).toBe(0)
-        done()
-      }, 20)
-    }, 20)
   })
 })
 


### PR DESCRIPTION
(Note: this is a workaround due to Popper's lack of `update` callback in v1, which v2 will have [as a promise])

This previous workaround made `onCreate` / `onUpdate` run at odd times due to being overwritten, this workaround seems to be better.