### PR TITLE
Fix multiple tippys if using touch

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -134,7 +134,7 @@ export interface PopperChildren {
 export interface HideAllOptions {
   checkHideOnClick?: boolean
   duration?: number
-  exclude?: any
+  exclude?: Instance | ReferenceElement
 }
 
 export interface Tippy {

--- a/index.d.ts
+++ b/index.d.ts
@@ -134,7 +134,7 @@ export interface PopperChildren {
 export interface HideAllOptions {
   checkHideOnClick?: boolean
   duration?: number
-  exclude?: Instance
+  exclude?: any
 }
 
 export interface Tippy {

--- a/src/bindGlobalEventListeners.ts
+++ b/src/bindGlobalEventListeners.ts
@@ -65,7 +65,7 @@ export function onDocumentClick(event: MouseEvent): void {
       const isClickTrigger = includes(instance.props.trigger || '', 'click')
 
       if (isUsingTouch || isClickTrigger) {
-        return hideAll({ exclude: instance, checkHideOnClick: true })
+        return hideAll({ exclude: reference, checkHideOnClick: true })
       }
 
       if (instance.props.hideOnClick !== true || isClickTrigger) {

--- a/src/bindGlobalEventListeners.ts
+++ b/src/bindGlobalEventListeners.ts
@@ -1,4 +1,4 @@
-import { ReferenceElement } from './types'
+import { PopperElement, ReferenceElement } from './types'
 import { closest, closestCallback } from './ponyfills'
 import { isIOS } from './browser'
 import { hideAll } from './popper'
@@ -48,7 +48,7 @@ export function onDocumentClick(event: MouseEvent): void {
   }
 
   // Clicked on an interactive popper
-  const popper: ReferenceElement = closest(event.target, POPPER_SELECTOR)
+  const popper = closest(event.target, POPPER_SELECTOR) as PopperElement
   if (popper && popper._tippy && popper._tippy.props.interactive) {
     return
   }

--- a/src/popper.ts
+++ b/src/popper.ts
@@ -295,18 +295,28 @@ export function updatePopperElement(
  */
 export function hideAll({
   checkHideOnClick,
-  exclude,
+  exclude: excludedReferenceOrInstance,
   duration,
 }: HideAllOptions = {}): void {
   arrayFrom(document.querySelectorAll(POPPER_SELECTOR)).forEach(
     (popper: PopperElement) => {
       const instance = popper._tippy
-      if (
-        instance &&
-        (checkHideOnClick ? instance.props.hideOnClick === true : true) &&
-        (!exclude || popper !== exclude.popper)
-      ) {
-        instance.hide(duration)
+
+      if (instance) {
+        const shouldHideDueToHideOnClickOption = checkHideOnClick
+          ? instance.props.hideOnClick === true
+          : true
+
+        let isExcluded = false
+        if (excludedReferenceOrInstance) {
+          isExcluded = excludedReferenceOrInstance._tippy
+            ? instance.reference === excludedReferenceOrInstance
+            : popper === excludedReferenceOrInstance.popper
+        }
+
+        if (shouldHideDueToHideOnClickOption && !isExcluded) {
+          instance.hide(duration)
+        }
       }
     },
   )

--- a/src/popper.ts
+++ b/src/popper.ts
@@ -6,7 +6,7 @@ import {
   BasicPlacement,
 } from './types'
 import { arrayFrom } from './ponyfills'
-import { innerHTML, div } from './utils'
+import { innerHTML, div, isReferenceElement } from './utils'
 import { isUCBrowser } from './browser'
 import {
   TOOLTIP_SELECTOR,
@@ -309,7 +309,7 @@ export function hideAll({
 
         let isExcluded = false
         if (excludedReferenceOrInstance) {
-          isExcluded = excludedReferenceOrInstance._tippy
+          isExcluded = isReferenceElement(excludedReferenceOrInstance)
             ? instance.reference === excludedReferenceOrInstance
             : popper === excludedReferenceOrInstance.popper
         }

--- a/src/types.ts
+++ b/src/types.ts
@@ -130,7 +130,7 @@ export interface PopperChildren {
 export interface HideAllOptions {
   checkHideOnClick?: boolean
   duration?: number
-  exclude?: any
+  exclude?: Instance | ReferenceElement
 }
 
 export interface Listener {

--- a/src/types.ts
+++ b/src/types.ts
@@ -130,7 +130,7 @@ export interface PopperChildren {
 export interface HideAllOptions {
   checkHideOnClick?: boolean
   duration?: number
-  exclude?: Instance
+  exclude?: any
 }
 
 export interface Listener {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -8,6 +8,7 @@ import {
 import { arrayFrom, matches } from './ponyfills'
 import { isUCBrowser } from './browser'
 import { getDataAttributeOptions } from './reference'
+import { POPPER_SELECTOR } from './constants'
 
 /**
  * Determines if a value is a "bare" virtual element (before mutations done
@@ -19,6 +20,13 @@ export function isBareVirtualElement(value: any): boolean {
   return (
     {}.toString.call(value) === '[object Object]' && !value.addEventListener
   )
+}
+
+/**
+ * Determines if the value is a reference element
+ */
+export function isReferenceElement(value: any): value is ReferenceElement {
+  return !!value._tippy && !matches.call(value, POPPER_SELECTOR)
 }
 
 /**

--- a/test/spec/popper.test.js
+++ b/test/spec/popper.test.js
@@ -63,6 +63,20 @@ describe('hideAll', () => {
       )
     })
   })
+
+  it('respects `exclude` option as type ReferenceElement for multiple tippys', () => {
+    const options = { showOnInit: true, multiple: true }
+    const ref = h()
+    tippy(ref, options)
+    tippy(ref, options)
+    hideAll({ exclude: ref })
+    const instances = [...document.querySelectorAll(POPPER_SELECTOR)].map(
+      popper => popper._tippy,
+    )
+    instances.forEach(instance => {
+      expect(instance.state.isVisible).toBe(true)
+    })
+  })
 })
 
 describe('createPopperElement', () => {


### PR DESCRIPTION
When using a touch device with `hideOnClick: true`, only a single tippy displays when multiple tippys are attached to the reference element