### PR TITLE
followCursor fixes

### DIFF
--- a/src/bindGlobalEventListeners.ts
+++ b/src/bindGlobalEventListeners.ts
@@ -54,7 +54,7 @@ export function onDocumentClick(event: MouseEvent): void {
   }
 
   // Clicked on a reference
-  const reference: ReferenceElement | undefined = closestCallback(
+  const reference: ReferenceElement | null = closestCallback(
     event.target,
     (el: ReferenceElement) => el._tippy && el._tippy.reference === el,
   )

--- a/src/createTippy.ts
+++ b/src/createTippy.ts
@@ -66,7 +66,6 @@ export default function createTippy(
   /* ======================= 🔒 Private members 🔒 ======================= */
   let lastTriggerEventType: string
   let lastMouseMoveEvent: MouseEvent
-  let lastVirtualReference: ReferenceElement
   let showTimeoutId: number
   let hideTimeoutId: number
   let animationFrameId: number
@@ -420,7 +419,7 @@ export default function createTippy(
     )
 
     if (isCursorOverReference || !instance.props.interactive) {
-      lastVirtualReference = {
+      instance.popperInstance!.reference = {
         ...instance.popperInstance!.reference,
         getBoundingClientRect: () => ({
           width: 0,
@@ -434,7 +433,6 @@ export default function createTippy(
         clientHeight: 0,
       }
 
-      instance.popperInstance!.reference = lastVirtualReference
       instance.popperInstance!.scheduleUpdate()
     }
 

--- a/src/ponyfills.ts
+++ b/src/ponyfills.ts
@@ -19,20 +19,8 @@ export function arrayFrom(value: ArrayLike<any>): any[] {
 /**
  * Ponyfill for Element.prototype.closest
  */
-export function closest(element: Element, parentSelector: string): Element {
-  return (
-    elementProto.closest ||
-    function(selector: string) {
-      // @ts-ignore
-      let el = this
-      while (el) {
-        if (matches.call(el, selector)) {
-          return el
-        }
-        el = el.parentElement
-      }
-    }
-  ).call(element, parentSelector)
+export function closest(element: Element, selector: string): Element | null {
+  return closestCallback(element, (el: Element) => matches.call(el, selector))
 }
 
 /**
@@ -41,11 +29,12 @@ export function closest(element: Element, parentSelector: string): Element {
 export function closestCallback(
   element: Element | null,
   callback: Function,
-): Element | undefined {
+): Element | null {
   while (element) {
     if (callback(element)) {
       return element
     }
     element = element.parentElement
   }
+  return null
 }

--- a/test/browser/index.html
+++ b/test/browser/index.html
@@ -16,4 +16,6 @@
 <button id="followCursor-initial">followCursor: 'initial'</button>
 <button id="followCursor-initial-delay">followCursor: 'initial' + delay</button>
 <hr />
+<button id="followCursor-padding">followCursor padding (50px)</button>
+<hr />
 <button id="notransition-flip-updates">notransition flip updates</button>

--- a/test/browser/index.html
+++ b/test/browser/index.html
@@ -16,6 +16,6 @@
 <button id="followCursor-initial">followCursor: 'initial'</button>
 <button id="followCursor-initial-delay">followCursor: 'initial' + delay</button>
 <hr />
-<button id="followCursor-padding">followCursor padding (50px)</button>
+<button id="followCursor-padding">followCursor padding (40px)</button>
 <hr />
 <button id="notransition-flip-updates">notransition flip updates</button>

--- a/test/browser/index.js
+++ b/test/browser/index.js
@@ -56,6 +56,17 @@ tippy('#followCursor-initial-delay', {
   delay: 200,
 })
 
+tippy('#followCursor-padding', {
+  followCursor: 'horizontal',
+  popperOptions: {
+    modifiers: {
+      preventOverflow: {
+        padding: 40,
+      },
+    },
+  },
+})
+
 tippy('#notransition-flip-updates', {
   flipOnUpdate: true,
 })


### PR DESCRIPTION
- `followCursor` currently does not respect `popperOptions.modifiers.preventOverflow.padding` and instead only uses the hardcoded `PADDING` constant, this change makes it respect it
- Resolves #469, prevents the tooltip from moving while the cursor is on top of it. This changes the behavior slightly if the tippy is interactive, since it won't continue to follow the cursor while it's still hiding (unlike it currently does)

Since this change adds some size, found a way to also cut back on the `closest` polyfill by reusing the `closestCallback` function

cc @fractaledmind - I don't think this behavior is exactly what you suggested (to only follow if it's over the parent/popper node) as it only follows if it's over the reference element now.