### PR TITLE
Implement `triggerTarget`+ `onTrigger` options

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -78,6 +78,7 @@ export interface Options {
   onMount?(instance: Instance): void
   onShow?(instance: Instance): void | false
   onShown?(instance: Instance): void
+  onTrigger?(instance: Instance, event: Event): void
   placement?: Placement
   popperOptions?: Popper.PopperOptions
   role?: string

--- a/index.d.ts
+++ b/index.d.ts
@@ -18,25 +18,25 @@ export interface PopperElement extends HTMLDivElement {
 
 export interface VirtualReference extends Popper.ReferenceObject {
   _tippy?: Instance
-  setAttribute(): void
-  getAttribute(): string
-  hasAttribute(): boolean
-  removeAttribute(): void
+  parentNode?: Element
+  setAttribute(key: string, value: any): void
+  getAttribute(key: string): string
+  removeAttribute(key: string): void
+  hasAttribute(key: string): boolean
   addEventListener(): void
   removeEventListener(): void
   attributes: {
     [key: string]: any
   }
   classList: {
-    add(): void
-    remove(): void
-    contains(): boolean
+    add(key: string): void
+    remove(key: string): void
+    contains(key: string): boolean
     classNames: {
       [key: string]: boolean
     }
     [key: string]: any
   }
-  parentNode?: Element
 }
 
 export interface PopperInstance extends Popper {

--- a/index.d.ts
+++ b/index.d.ts
@@ -17,15 +17,26 @@ export interface PopperElement extends HTMLDivElement {
 }
 
 export interface VirtualReference extends Popper.ReferenceObject {
+  _tippy?: Instance
+  setAttribute(): void
+  getAttribute(): string
+  hasAttribute(): boolean
+  removeAttribute(): void
+  addEventListener(): void
+  removeEventListener(): void
   attributes: {
     [key: string]: any
   }
   classList: {
+    add(): void
+    remove(): void
+    contains(): boolean
     classNames: {
       [key: string]: boolean
     }
     [key: string]: any
   }
+  parentNode?: Element
 }
 
 export interface PopperInstance extends Popper {
@@ -78,6 +89,7 @@ export interface Options {
   touch?: boolean
   touchHold?: boolean
   trigger?: string
+  triggerTarget: Element | null
   updateDuration?: number
   wait?: ((instance: Instance, event?: Event) => void) | null
   zIndex?: number
@@ -100,9 +112,7 @@ export interface Instance {
   popperChildren: PopperChildren
   popperInstance: PopperInstance | null
   props: Props
-  reference: ReferenceElement
-  scheduleHide(): void
-  scheduleShow(event?: Event): void
+  reference: ReferenceElement | VirtualReference
   set(options: Options): void
   setContent(content: Content): void
   show(duration?: number): void

--- a/src/createTippy.ts
+++ b/src/createTippy.ts
@@ -158,7 +158,9 @@ export default function createTippy(
       instance.state.isVisible &&
       lastTriggerEventType === 'mouseenter'
     ) {
-      scheduleShow(event)
+      // We don't want props.onTrigger() to be called here, since the `event`
+      // object is not related to the reference element
+      scheduleShow(event, true)
     }
   })
   popper.addEventListener('mouseleave', () => {
@@ -461,8 +463,6 @@ export default function createTippy(
           target: '',
           showOnInit: true,
         })
-
-        scheduleShow(event)
       }
     }
   }
@@ -807,7 +807,10 @@ export default function createTippy(
   /**
    * Setup before show() is invoked (delays, etc.)
    */
-  function scheduleShow(event?: Event): void {
+  function scheduleShow(
+    event?: Event,
+    shouldAvoidCallingOnTrigger?: boolean,
+  ): void {
     clearDelayTimeouts()
 
     if (instance.state.isVisible) {
@@ -823,6 +826,10 @@ export default function createTippy(
 
     if (instance.props.wait) {
       return instance.props.wait(instance, event)
+    }
+
+    if (event && !shouldAvoidCallingOnTrigger) {
+      instance.props.onTrigger(instance, event)
     }
 
     // If the tooltip has a delay, we need to be listening to the mousemove as

--- a/src/createTippy.ts
+++ b/src/createTippy.ts
@@ -214,10 +214,7 @@ export default function createTippy(
    * Updates the tooltip's position on each animation frame
    */
   function makeSticky(): void {
-    setTransitionDuration(
-      [instance.popper],
-      isIE ? 0 : instance.props.updateDuration,
-    )
+    setTransitionDuration([popper], isIE ? 0 : instance.props.updateDuration)
 
     function updatePosition(): void {
       if (instance.popperInstance) {
@@ -227,7 +224,7 @@ export default function createTippy(
       if (instance.state.isMounted) {
         requestAnimationFrame(updatePosition)
       } else {
-        setTransitionDuration([instance.popper], 0)
+        setTransitionDuration([popper], 0)
       }
     }
 
@@ -242,7 +239,7 @@ export default function createTippy(
       if (
         !instance.state.isVisible &&
         currentParentNode &&
-        currentParentNode.contains(instance.popper)
+        currentParentNode.contains(popper)
       ) {
         callback()
       }
@@ -292,7 +289,7 @@ export default function createTippy(
     handler: EventListener,
     options: boolean | object = false,
   ): void {
-    instance.reference.addEventListener(eventType, handler, options)
+    reference.addEventListener(eventType, handler, options)
     listeners.push({ eventType, handler, options })
   }
 
@@ -348,7 +345,7 @@ export default function createTippy(
    */
   function removeTriggersFromReference(): void {
     listeners.forEach(({ eventType, handler, options }: Listener) => {
-      instance.reference.removeEventListener(eventType, handler, options)
+      reference.removeEventListener(eventType, handler, options)
     })
     listeners = []
   }
@@ -374,14 +371,14 @@ export default function createTippy(
       return
     }
 
-    const rect = instance.reference.getBoundingClientRect()
+    const rect = reference.getBoundingClientRect()
     const { followCursor } = instance.props
     const isHorizontal = followCursor === 'horizontal'
     const isVertical = followCursor === 'vertical'
 
     // Ensure virtual reference is padded to prevent tooltip from overflowing.
     // Seems to be a Popper.js issue
-    const placement = getBasicPlacement(instance.popper)
+    const placement = getBasicPlacement(popper)
     const isVerticalPlacement = includes(['top', 'bottom'], placement)
     const isHorizontalPlacement = includes(['left', 'right'], placement)
     const padding = { ...currentComputedPadding }
@@ -415,7 +412,7 @@ export default function createTippy(
     // over the reference element
     const isCursorOverReference = closestCallback(
       event.target as Element,
-      (el: Element) => el === instance.reference,
+      (el: Element) => el === reference,
     )
 
     if (isCursorOverReference || !instance.props.interactive) {
@@ -504,9 +501,8 @@ export default function createTippy(
     )
 
     const isCursorOverPopper =
-      closest(event.target as Element, POPPER_SELECTOR) === instance.popper
-    const isCursorOverReference =
-      referenceTheCursorIsOver === instance.reference
+      closest(event.target as Element, POPPER_SELECTOR) === popper
+    const isCursorOverReference = referenceTheCursorIsOver === reference
 
     if (isCursorOverPopper || isCursorOverReference) {
       return
@@ -514,8 +510,8 @@ export default function createTippy(
 
     if (
       isCursorOutsideInteractiveBorder(
-        getBasicPlacement(instance.popper),
-        instance.popper.getBoundingClientRect(),
+        getBasicPlacement(popper),
+        popper.getBoundingClientRect(),
         event,
         instance.props,
       )
@@ -546,14 +542,14 @@ export default function createTippy(
    * Event listener invoked upon blur
    */
   function onBlur(event: FocusEvent): void {
-    if (event.target !== instance.reference) {
+    if (event.target !== reference) {
       return
     }
 
     if (
       instance.props.interactive &&
       event.relatedTarget &&
-      instance.popper.contains(event.relatedTarget as Element)
+      popper.contains(event.relatedTarget as Element)
     ) {
       return
     }
@@ -647,7 +643,7 @@ export default function createTippy(
       previousPlacement = data.placement
       wasVisibleDuringPreviousUpdate = instance.state.isVisible
 
-      const basicPlacement = getBasicPlacement(instance.popper)
+      const basicPlacement = getBasicPlacement(popper)
       const styles = tooltip.style
 
       // Account for the `distance` offset
@@ -726,8 +722,8 @@ export default function createTippy(
     }
 
     instance.popperInstance = new Popper(
-      instance.reference,
-      instance.popper,
+      reference,
+      popper,
       config,
     ) as PopperInstance
   }
@@ -763,7 +759,7 @@ export default function createTippy(
     // If the instance previously had followCursor behavior, it will be
     // positioned incorrectly if triggered by `focus` afterwards.
     // Update the reference back to the real DOM element
-    instance.popperInstance!.reference = instance.reference
+    instance.popperInstance!.reference = reference
     const { arrow } = instance.popperChildren
 
     if (hasFollowCursorBehavior()) {
@@ -793,11 +789,11 @@ export default function createTippy(
 
     currentParentNode =
       appendTo === 'parent'
-        ? instance.reference.parentNode
-        : invokeWithArgsOrReturn(appendTo, [instance.reference])
+        ? reference.parentNode
+        : invokeWithArgsOrReturn(appendTo, [reference])
 
-    if (!currentParentNode.contains(instance.popper)) {
-      currentParentNode.appendChild(instance.popper)
+    if (!currentParentNode.contains(popper)) {
+      currentParentNode.appendChild(popper)
       instance.props.onMount(instance)
       instance.state.isMounted = true
     }
@@ -837,7 +833,7 @@ export default function createTippy(
     validateOptions(options, defaultProps)
 
     const prevProps = instance.props
-    const nextProps = evaluateProps(instance.reference, {
+    const nextProps = evaluateProps(reference, {
       ...instance.props,
       ...options,
       ignoreAttributes: true,
@@ -863,8 +859,8 @@ export default function createTippy(
       )
     }
 
-    updatePopperElement(instance.popper, prevProps, nextProps)
-    instance.popperChildren = getChildren(instance.popper)
+    updatePopperElement(popper, prevProps, nextProps)
+    instance.popperChildren = getChildren(popper)
 
     if (instance.popperInstance) {
       instance.popperInstance.update()
@@ -989,7 +985,7 @@ export default function createTippy(
     // Standardize `disabled` behavior across browsers.
     // Firefox allows events on disabled elements, but Chrome doesn't.
     // Using a wrapper element (i.e. <span>) is recommended.
-    if (instance.reference.hasAttribute('disabled')) {
+    if (reference.hasAttribute('disabled')) {
       return
     }
 
@@ -997,16 +993,16 @@ export default function createTippy(
       return
     }
 
-    instance.popper.style.visibility = 'visible'
+    popper.style.visibility = 'visible'
     instance.state.isVisible = true
 
     if (instance.props.interactive) {
-      instance.reference.classList.add(ACTIVE_CLASS)
+      reference.classList.add(ACTIVE_CLASS)
     }
 
     // Prevent a transition if the popper is at the opposite placement
     const transitionableElements = getTransitionableElements()
-    setTransitionDuration(transitionableElements.concat(instance.popper), 0)
+    setTransitionDuration(transitionableElements.concat(popper), 0)
 
     currentMountCallback = () => {
       if (!instance.state.isVisible) {
@@ -1027,16 +1023,13 @@ export default function createTippy(
         makeSticky()
       }
 
-      setTransitionDuration([instance.popper], props.updateDuration)
+      setTransitionDuration([popper], props.updateDuration)
       setTransitionDuration(transitionableElements, duration)
       setVisibilityState(transitionableElements, 'visible')
 
       onTransitionedIn(duration, () => {
         if (instance.props.aria) {
-          instance.reference.setAttribute(
-            `aria-${instance.props.aria}`,
-            instance.popper.id,
-          )
+          reference.setAttribute(`aria-${instance.props.aria}`, popper.id)
         }
 
         instance.props.onShown(instance)
@@ -1065,13 +1058,13 @@ export default function createTippy(
       return
     }
 
-    instance.popper.style.visibility = 'hidden'
+    popper.style.visibility = 'hidden'
     instance.state.isVisible = false
     instance.state.isShown = false
     wasVisibleDuringPreviousUpdate = false
 
     if (instance.props.interactive) {
-      instance.reference.classList.remove(ACTIVE_CLASS)
+      reference.classList.remove(ACTIVE_CLASS)
     }
 
     const transitionableElements = getTransitionableElements()
@@ -1084,13 +1077,13 @@ export default function createTippy(
       }
 
       if (instance.props.aria) {
-        instance.reference.removeAttribute(`aria-${instance.props.aria}`)
+        reference.removeAttribute(`aria-${instance.props.aria}`)
       }
 
       instance.popperInstance!.disableEventListeners()
       instance.popperInstance!.options.placement = instance.props.placement
 
-      currentParentNode.removeChild(instance.popper)
+      currentParentNode.removeChild(popper)
       instance.props.onHidden(instance)
       instance.state.isMounted = false
     })
@@ -1112,16 +1105,16 @@ export default function createTippy(
 
     removeTriggersFromReference()
 
-    delete instance.reference._tippy
+    delete reference._tippy
 
     if (instance.props.target && destroyTargetInstances) {
-      arrayFrom(
-        instance.reference.querySelectorAll(instance.props.target),
-      ).forEach((child: ReferenceElement) => {
-        if (child._tippy) {
-          child._tippy.destroy()
-        }
-      })
+      arrayFrom(reference.querySelectorAll(instance.props.target)).forEach(
+        (child: ReferenceElement) => {
+          if (child._tippy) {
+            child._tippy.destroy()
+          }
+        },
+      )
     }
 
     if (instance.popperInstance) {

--- a/src/props.ts
+++ b/src/props.ts
@@ -33,6 +33,7 @@ export const defaultProps: Props = {
   onMount() {},
   onShow() {},
   onShown() {},
+  onTrigger() {},
   placement: 'top',
   popperOptions: {},
   role: 'tooltip',

--- a/src/props.ts
+++ b/src/props.ts
@@ -44,6 +44,7 @@ export const defaultProps: Props = {
   touch: true,
   touchHold: false,
   trigger: 'mouseenter focus',
+  triggerTarget: null,
   updateDuration: 0,
   wait: null,
   zIndex: 9999,

--- a/src/reference.ts
+++ b/src/reference.ts
@@ -6,7 +6,9 @@ const keys = Object.keys(defaultProps)
 /**
  * Returns an object of optional props from data-tippy-* attributes
  */
-export function getDataAttributeOptions(reference: ReferenceElement): Props {
+export function getDataAttributeOptions(
+  reference: ReferenceElement | VirtualReference,
+): Props {
   return keys.reduce((acc: any, key) => {
     const valueAsString = (
       reference.getAttribute(`data-tippy-${key}`) || ''

--- a/src/types.ts
+++ b/src/types.ts
@@ -17,19 +17,30 @@ export interface PopperElement extends HTMLDivElement {
 }
 
 export interface VirtualReference extends Popper.ReferenceObject {
+  _tippy?: Instance
+  setAttribute(): void
+  getAttribute(): string
+  hasAttribute(): boolean
+  removeAttribute(): void
+  addEventListener(): void
+  removeEventListener(): void
   attributes: {
     [key: string]: any
   }
   classList: {
+    add(): void
+    remove(): void
+    contains(): boolean
     classNames: {
       [key: string]: boolean
     }
     [key: string]: any
   }
+  parentNode?: Element
 }
 
 export interface PopperInstance extends Popper {
-  reference: ReferenceElement
+  reference: ReferenceElement | VirtualReference
   popper: PopperElement
   modifiers: { name: string; padding: object | number }[]
 }
@@ -78,6 +89,7 @@ export interface Props {
   touch: boolean
   touchHold: boolean
   trigger: string
+  triggerTarget: Element | null
   updateDuration: number
   wait: ((instance: Instance, event?: Event) => void) | null
   zIndex: number
@@ -96,9 +108,7 @@ export interface Instance {
   popperChildren: PopperChildren
   popperInstance: PopperInstance | null
   props: Props
-  reference: ReferenceElement
-  scheduleHide(): void
-  scheduleShow(event?: Event): void
+  reference: ReferenceElement | VirtualReference
   set(options: Options): void
   setContent(content: Content): void
   show(duration?: number): void

--- a/src/types.ts
+++ b/src/types.ts
@@ -18,25 +18,25 @@ export interface PopperElement extends HTMLDivElement {
 
 export interface VirtualReference extends Popper.ReferenceObject {
   _tippy?: Instance
-  setAttribute(): void
-  getAttribute(): string
-  hasAttribute(): boolean
-  removeAttribute(): void
+  parentNode?: Element
+  setAttribute(key: string, value: any): void
+  getAttribute(key: string): string
+  removeAttribute(key: string): void
+  hasAttribute(key: string): boolean
   addEventListener(): void
   removeEventListener(): void
   attributes: {
     [key: string]: any
   }
   classList: {
-    add(): void
-    remove(): void
-    contains(): boolean
+    add(key: string): void
+    remove(key: string): void
+    contains(key: string): boolean
     classNames: {
       [key: string]: boolean
     }
     [key: string]: any
   }
-  parentNode?: Element
 }
 
 export interface PopperInstance extends Popper {

--- a/src/types.ts
+++ b/src/types.ts
@@ -78,6 +78,7 @@ export interface Props {
   onMount(instance: Instance): void
   onShow(instance: Instance): void | false
   onShown(instance: Instance): void
+  onTrigger(instance: Instance, event: Event): void
   placement: Placement
   popperOptions: Popper.PopperOptions
   role: string

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -99,12 +99,17 @@ export function includes(a: any[] | string, b: any): boolean {
 }
 
 /**
+ * Determines if the value is a real element
+ */
+export function isRealElement(value: any): value is Element {
+  return value instanceof Element
+}
+
+/**
  * Determines if the value is singular-like
  */
 export function isSingular(value: any): value is VirtualReference | Element {
-  return (
-    !!(value && hasOwnProperty(value, 'isVirtual')) || value instanceof Element
-  )
+  return !!(value && hasOwnProperty(value, 'isVirtual')) || isRealElement(value)
 }
 
 /**
@@ -181,7 +186,7 @@ export function setVisibilityState(
  * disabling conflicting options where necessary
  */
 export function evaluateProps(
-  reference: ReferenceElement,
+  reference: ReferenceElement | VirtualReference,
   props: Props,
 ): Props {
   const out = {

--- a/test/spec/props.test.js
+++ b/test/spec/props.test.js
@@ -609,6 +609,22 @@ describe('onHidden', () => {
   })
 })
 
+describe('onTrigger', () => {
+  it('is called upon an event triggering, passed correct arguments', () => {
+    const spy = jest.fn()
+    const instance = tippy(h(), { onTrigger: spy })
+    const event = new MouseEvent('mouseenter')
+    instance.reference.dispatchEvent(event)
+    expect(spy).toHaveBeenCalledWith(instance, event)
+  })
+
+  it('is not called without an event to pass (showOnInit)', () => {
+    const spy = jest.fn()
+    tippy(h(), { onTrigger: spy, showOnInit: true })
+    expect(spy).not.toHaveBeenCalled()
+  })
+})
+
 describe('wait', () => {
   it('waits until the user manually shows the tooltip', () => {
     const ref = h()

--- a/test/spec/props.test.js
+++ b/test/spec/props.test.js
@@ -936,3 +936,25 @@ describe('sticky', () => {
     })
   })
 })
+
+describe('triggerTarget', () => {
+  it('acts as the trigger for the tooltip instead of the reference', () => {
+    const node = h('div')
+    const instance = tippy(h(), { triggerTarget: node })
+    instance.reference.dispatchEvent(new Event('mouseenter'))
+    expect(instance.state.isVisible).toBe(false)
+    node.dispatchEvent(new Event('mouseenter'))
+    expect(instance.state.isVisible).toBe(true)
+  })
+
+  it('updates accordingly with instance.set()', () => {
+    const node = h('div')
+    const node2 = h('button')
+    const instance = tippy(h(), { triggerTarget: node })
+    instance.set({ triggerTarget: node2 })
+    node.dispatchEvent(new Event('mouseenter'))
+    expect(instance.state.isVisible).toBe(false)
+    node2.dispatchEvent(new Event('mouseenter'))
+    expect(instance.state.isVisible).toBe(true)
+  })
+})


### PR DESCRIPTION
Much needed options for virtual references and for #471

- `triggerTarget` will apply the event listeners (`trigger`) to the the `triggerTarget` node, while the reference is used for positioning instead.
- `onTrigger()` gets invoked upon a real event triggering the tooltip to show, allowing the user to make mutations to the virtual reference element and reposition it based on the event.

### Tweaks

- Types fixed to account for `VirtualReference` properly
- Revert #461, this change makes exposing those methods needless as this is the better way to do it
- `reference` and `popper` are both unchanging static variables, so no need to prefix them with `instance.` - saves some bytes to offset this change

## Virtual References

`reference` is used for positioning, `triggerTarget` is what the event listeners get applied to:

```js
tippy(virtualReference, {
  triggerTarget: someElement,
  onTrigger(instance, event) {
    Object.assign(virtualReference, {
      getBoundingClientRect: () => ({
        // Use event properties, etc
      })
    })
  }
})
```

## #471 example:

```js
tippy(img, {
  triggerTarget: outerButtonElement
})
```