### PR TITLE
Add data attribute to style tag

### DIFF
--- a/src/css.ts
+++ b/src/css.ts
@@ -8,6 +8,7 @@ export function injectCSS(css: string): void {
     const style = document.createElement('style')
     style.type = 'text/css'
     style.textContent = css
+    style.setAttribute('data-tippy-stylesheet', '')
     const head = document.head
     const { firstChild } = head
     if (firstChild) {


### PR DESCRIPTION
See https://github.com/atomiks/tippyjs/issues/482

Decided on using a data attribute instead, after seeing styled-components using `<style data-styled />` in their build.