### PR TITLE
Use per-instance hideOnClick handler

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -144,7 +144,6 @@ export interface PopperChildren {
 }
 
 export interface HideAllOptions {
-  checkHideOnClick?: boolean
   duration?: number
   exclude?: Instance | ReferenceElement
 }

--- a/index.d.ts
+++ b/index.d.ts
@@ -19,6 +19,7 @@ export interface PopperElement extends HTMLDivElement {
 export interface VirtualReference extends Popper.ReferenceObject {
   _tippy?: Instance
   parentNode?: Element
+  contains(): void
   setAttribute(key: string, value: any): void
   getAttribute(key: string): string
   removeAttribute(key: string): void

--- a/src/bindGlobalEventListeners.ts
+++ b/src/bindGlobalEventListeners.ts
@@ -1,9 +1,5 @@
-import { PopperElement, ReferenceElement } from './types'
-import { closest, closestCallback } from './ponyfills'
 import { isIOS } from './browser'
-import { hideAll } from './popper'
-import { includes } from './utils'
-import { PASSIVE, IOS_CLASS, POPPER_SELECTOR } from './constants'
+import { PASSIVE, IOS_CLASS } from './constants'
 
 export let isUsingTouch = false
 
@@ -41,44 +37,6 @@ export function onDocumentMouseMove(): void {
   lastMouseMoveTime = now
 }
 
-export function onDocumentClick(event: MouseEvent): void {
-  // Simulated events dispatched on the document
-  if (!(event.target instanceof Element)) {
-    return hideAll()
-  }
-
-  // Clicked on an interactive popper
-  const popper = closest(event.target, POPPER_SELECTOR) as PopperElement
-  if (popper && popper._tippy && popper._tippy.props.interactive) {
-    return
-  }
-
-  // Clicked on a reference
-  const reference: ReferenceElement | null = closestCallback(
-    event.target,
-    (el: ReferenceElement) => el._tippy && el._tippy.reference === el,
-  )
-  if (reference) {
-    const instance = reference._tippy
-
-    if (instance) {
-      const isClickTrigger = includes(instance.props.trigger || '', 'click')
-
-      if (isUsingTouch || isClickTrigger) {
-        return hideAll({ exclude: reference, checkHideOnClick: true })
-      }
-
-      if (instance.props.hideOnClick !== true || isClickTrigger) {
-        return
-      }
-
-      instance.clearDelayTimeouts()
-    }
-  }
-
-  hideAll({ checkHideOnClick: true })
-}
-
 export function onWindowBlur(): void {
   const { activeElement }: { activeElement: any } = document
   if (activeElement && activeElement.blur && activeElement._tippy) {
@@ -90,7 +48,6 @@ export function onWindowBlur(): void {
  * Adds the needed global event listeners
  */
 export default function bindGlobalEventListeners(): void {
-  document.addEventListener('click', onDocumentClick, true)
   document.addEventListener('touchstart', onDocumentTouch, PASSIVE)
   window.addEventListener('blur', onWindowBlur)
 }

--- a/src/createTippy.ts
+++ b/src/createTippy.ts
@@ -923,12 +923,17 @@ export default function createTippy(
     }
 
     // Clicked on an event listeners target
-    if (
-      instance.state.isVisible &&
-      includes(instance.props.trigger, 'click') &&
-      getEventListenersTarget().contains(event.target as Element)
-    ) {
-      return
+    if (getEventListenersTarget().contains(event.target as Element)) {
+      if (isUsingTouch) {
+        return
+      }
+
+      if (
+        instance.state.isVisible &&
+        includes(instance.props.trigger, 'click')
+      ) {
+        return
+      }
     }
 
     if (instance.props.hideOnClick === true) {

--- a/src/createTippy.ts
+++ b/src/createTippy.ts
@@ -914,7 +914,7 @@ export default function createTippy(
    * instance should hide
    */
   function onDocumentClick(event: MouseEvent): void {
-    // Clicked on an interactive tippy
+    // Clicked on interactive popper
     if (
       instance.props.interactive &&
       popper.contains(event.target as Element)
@@ -922,7 +922,7 @@ export default function createTippy(
       return
     }
 
-    // Clicked on an event listeners target
+    // Clicked on the event listeners target
     if (getEventListenersTarget().contains(event.target as Element)) {
       if (isUsingTouch) {
         return

--- a/src/createTippy.ts
+++ b/src/createTippy.ts
@@ -913,7 +913,7 @@ export default function createTippy(
    * Listener to handle clicks on the document to determine if the
    * instance should hide
    */
-  function onDocumentClick(event: MouseEvent) {
+  function onDocumentClick(event: MouseEvent): void {
     // Clicked on an interactive tippy
     if (
       instance.props.interactive &&

--- a/src/createTippy.ts
+++ b/src/createTippy.ts
@@ -72,7 +72,7 @@ export default function createTippy(
   let hideTimeoutId: number
   let animationFrameId: number
   let isScheduledToShow = false
-  let isClickListenerAttached = false
+  let isDocumentClickListenerAttached = false
   let currentParentNode: Element
   let previousPlacement: string
   let wasVisibleDuringPreviousUpdate = false
@@ -201,19 +201,19 @@ export default function createTippy(
   /**
    * Adds the document click event listener for the instance
    */
-  function addClickListener(): void {
-    if (!isClickListenerAttached) {
+  function addDocumentClickListener(): void {
+    if (!isDocumentClickListenerAttached) {
       document.addEventListener('click', onDocumentClick, true)
-      isClickListenerAttached = true
+      isDocumentClickListenerAttached = true
     }
   }
 
   /**
    * Removes the document click event listener for the instance
    */
-  function removeClickListener(): void {
+  function removeDocumentClickListener(): void {
     document.removeEventListener('click', onDocumentClick, true)
-    isClickListenerAttached = false
+    isDocumentClickListenerAttached = false
   }
 
   /**
@@ -867,7 +867,7 @@ export default function createTippy(
       document.addEventListener('mousemove', positionVirtualReferenceNearCursor)
     }
 
-    addClickListener()
+    addDocumentClickListener()
 
     const delay = getValue(instance.props.delay, 0, defaultProps.delay)
 
@@ -1060,7 +1060,7 @@ export default function createTippy(
       return
     }
 
-    addClickListener()
+    addDocumentClickListener()
 
     popper.style.visibility = 'visible'
     instance.state.isVisible = true
@@ -1130,7 +1130,7 @@ export default function createTippy(
       return
     }
 
-    removeClickListener()
+    removeDocumentClickListener()
 
     popper.style.visibility = 'hidden'
     instance.state.isVisible = false

--- a/src/createTippy.ts
+++ b/src/createTippy.ts
@@ -72,6 +72,7 @@ export default function createTippy(
   let hideTimeoutId: number
   let animationFrameId: number
   let isScheduledToShow = false
+  let isClickListenerAttached = false
   let currentParentNode: Element
   let previousPlacement: string
   let wasVisibleDuringPreviousUpdate = false
@@ -195,6 +196,24 @@ export default function createTippy(
    */
   function getEventListenersTarget(): ReferenceElement | VirtualReference {
     return instance.props.triggerTarget || reference
+  }
+
+  /**
+   * Adds the document click event listener for the instance
+   */
+  function addClickListener(): void {
+    if (!isClickListenerAttached) {
+      document.addEventListener('click', onDocumentClick, true)
+      isClickListenerAttached = true
+    }
+  }
+
+  /**
+   * Removes the document click event listener for the instance
+   */
+  function removeClickListener(): void {
+    document.removeEventListener('click', onDocumentClick, true)
+    isClickListenerAttached = false
   }
 
   /**
@@ -848,6 +867,8 @@ export default function createTippy(
       document.addEventListener('mousemove', positionVirtualReferenceNearCursor)
     }
 
+    addClickListener()
+
     const delay = getValue(instance.props.delay, 0, defaultProps.delay)
 
     if (delay) {
@@ -885,6 +906,34 @@ export default function createTippy(
       animationFrameId = requestAnimationFrame(() => {
         hide()
       })
+    }
+  }
+
+  /**
+   * Listener to handle clicks on the document to determine if the
+   * instance should hide
+   */
+  function onDocumentClick(event: MouseEvent) {
+    // Clicked on an interactive tippy
+    if (
+      instance.props.interactive &&
+      popper.contains(event.target as Element)
+    ) {
+      return
+    }
+
+    // Clicked on an event listeners target
+    if (
+      instance.state.isVisible &&
+      includes(instance.props.trigger, 'click') &&
+      getEventListenersTarget().contains(event.target as Element)
+    ) {
+      return
+    }
+
+    if (instance.props.hideOnClick === true) {
+      clearDelayTimeouts()
+      hide()
     }
   }
 
@@ -1011,6 +1060,8 @@ export default function createTippy(
       return
     }
 
+    addClickListener()
+
     popper.style.visibility = 'visible'
     instance.state.isVisible = true
 
@@ -1078,6 +1129,8 @@ export default function createTippy(
     if (instance.props.onHide(instance) === false) {
       return
     }
+
+    removeClickListener()
 
     popper.style.visibility = 'hidden'
     instance.state.isVisible = false

--- a/src/group.ts
+++ b/src/group.ts
@@ -25,10 +25,15 @@ export default function group(
 
   function onShow(instance: GroupedInstance): void {
     instance._originalProps.onShow(instance)
+
     instances.forEach(instance => {
       instance.set({ duration })
-      instance.hide()
+
+      if (instance.state.isVisible) {
+        instance.hide()
+      }
     })
+
     setIsAnyTippyOpen(true)
   }
 

--- a/src/popper.ts
+++ b/src/popper.ts
@@ -294,7 +294,6 @@ export function updatePopperElement(
  * Hides all visible poppers on the document
  */
 export function hideAll({
-  checkHideOnClick,
   exclude: excludedReferenceOrInstance,
   duration,
 }: HideAllOptions = {}): void {
@@ -303,10 +302,6 @@ export function hideAll({
       const instance = popper._tippy
 
       if (instance) {
-        const shouldHideDueToHideOnClickOption = checkHideOnClick
-          ? instance.props.hideOnClick === true
-          : true
-
         let isExcluded = false
         if (excludedReferenceOrInstance) {
           isExcluded = isReferenceElement(excludedReferenceOrInstance)
@@ -314,7 +309,7 @@ export function hideAll({
             : popper === excludedReferenceOrInstance.popper
         }
 
-        if (shouldHideDueToHideOnClickOption && !isExcluded) {
+        if (!isExcluded) {
           instance.hide(duration)
         }
       }

--- a/src/reference.ts
+++ b/src/reference.ts
@@ -42,6 +42,7 @@ export function polyfillElementPrototypeProperties(
   const polyfills: Record<string, any> = {
     isVirtual: true,
     attributes: virtualReference.attributes || {},
+    contains() {},
     setAttribute(key: string, value: any) {
       virtualReference.attributes[key] = value
     },

--- a/src/types.ts
+++ b/src/types.ts
@@ -19,6 +19,7 @@ export interface PopperElement extends HTMLDivElement {
 export interface VirtualReference extends Popper.ReferenceObject {
   _tippy?: Instance
   parentNode?: Element
+  contains(): void
   setAttribute(key: string, value: any): void
   getAttribute(key: string): string
   removeAttribute(key: string): void

--- a/src/types.ts
+++ b/src/types.ts
@@ -140,7 +140,6 @@ export interface PopperChildren {
 }
 
 export interface HideAllOptions {
-  checkHideOnClick?: boolean
   duration?: number
   exclude?: Instance | ReferenceElement
 }

--- a/test/spec/bindGlobalEventListeners.test.js
+++ b/test/spec/bindGlobalEventListeners.test.js
@@ -1,7 +1,7 @@
-import { h, cleanDocumentBody } from '../utils'
+import { cleanDocumentBody } from '../utils'
 
 import tippy from '../../src/index'
-import bindEventListeners, * as Listeners from '../../src/bindGlobalEventListeners'
+import * as Listeners from '../../src/bindGlobalEventListeners'
 
 afterEach(cleanDocumentBody)
 
@@ -9,58 +9,6 @@ describe('onDocumentTouch', () => {
   it('sets isUsingTouch to `true`', () => {
     Listeners.onDocumentTouch()
     expect(Listeners.isUsingTouch).toBe(true)
-  })
-})
-
-describe('onDocumentClick', () => {
-  it('hides all poppers if neither a popper or reference was clicked', done => {
-    const instance = tippy(h())
-    expect(instance.state.isVisible).toBe(false)
-    instance.show()
-    Listeners.onDocumentClick({ target: document.createElement('div') })
-    setTimeout(() => {
-      expect(instance.state.isVisible).toBe(false)
-      done()
-    })
-  })
-
-  it('does not hide poppers if an interactive popper was clicked', done => {
-    const instance = tippy(h(), {
-      interactive: true,
-    })
-    expect(instance.state.isVisible).toBe(false)
-    instance.show()
-    Listeners.onDocumentClick({ target: instance.popper })
-    setTimeout(() => {
-      expect(instance.state.isVisible).toBe(true)
-      done()
-    })
-  })
-
-  it('hides poppers if a non-interactive popper was clicked', done => {
-    const instance = tippy(h(), {
-      interactive: false,
-    })
-    expect(instance.state.isVisible).toBe(false)
-    instance.show()
-    Listeners.onDocumentClick({ target: instance.popper })
-    setTimeout(() => {
-      expect(instance.state.isVisible).toBe(false)
-      done()
-    })
-  })
-
-  it('does not hide poppers if `hideOnClick: false` & clicked trigger-clicked reference', done => {
-    const instance = tippy(h(), {
-      trigger: 'click',
-      hideOnClick: false,
-    })
-    instance.show()
-    Listeners.onDocumentClick({ target: instance.reference })
-    setTimeout(() => {
-      expect(instance.state.isVisible).toBe(true)
-      done()
-    })
   })
 })
 
@@ -76,13 +24,5 @@ describe('onWindowBlur', () => {
     ref.focus()
     Listeners.onWindowBlur()
     expect(called).toBe(true)
-  })
-})
-
-describe('bindEventListeners', () => {
-  it('onDocumentTouch falls back to `pointerdown`', () => {
-    Listeners.supportsTouch = false
-    navigator.maxTouchPoints = 1
-    bindEventListeners()
   })
 })

--- a/test/spec/props.test.js
+++ b/test/spec/props.test.js
@@ -993,3 +993,62 @@ describe('triggerTarget', () => {
     expect(node2._tippy).toBe(undefined)
   })
 })
+
+describe('hideOnClick', () => {
+  it('true: hides if reference element was clicked', () => {
+    const instance = tippy(h(), { hideOnClick: true })
+    instance.show()
+    document.dispatchEvent(new Event('click'), { target: instance.reference })
+    expect(instance.state.isVisible).toBe(false)
+  })
+
+  it('true: does not hide if interactive and popper element child was clicked', () => {
+    const instance = tippy(h(), {
+      hideOnClick: true,
+      interactive: true,
+    })
+    instance.show()
+    instance.popperChildren.tooltip.dispatchEvent(
+      new Event('click', { bubbles: true }),
+    )
+    expect(instance.state.isVisible).toBe(true)
+  })
+
+  it('true: hides if not interactive and popper element was clicked', () => {
+    const instance = tippy(h(), {
+      hideOnClick: true,
+      interactive: false,
+    })
+    instance.show()
+    instance.popperChildren.tooltip.dispatchEvent(
+      new Event('click', { bubbles: true }),
+    )
+    expect(instance.state.isVisible).toBe(false)
+  })
+
+  it('false: never hides if trigger is `click`', () => {
+    const instance = tippy(h(), {
+      trigger: 'click',
+      hideOnClick: false,
+    })
+    instance.show()
+    instance.popperChildren.tooltip.dispatchEvent(
+      new Event('click', { bubbles: true }),
+    )
+    instance.reference.dispatchEvent(new Event('click', { bubbles: true }))
+    document.body.dispatchEvent(new Event('click', { bubbles: true }))
+    expect(instance.state.isVisible).toBe(true)
+  })
+
+  it('"toggle": hides only if reference element was clicked', () => {
+    const instance = tippy(h(), {
+      trigger: 'click',
+      hideOnClick: 'toggle',
+    })
+    instance.show()
+    document.body.dispatchEvent(new Event('click', { bubbles: true }))
+    expect(instance.state.isVisible).toBe(true)
+    instance.reference.dispatchEvent(new Event('click', { bubbles: true }))
+    expect(instance.state.isVisible).toBe(false)
+  })
+})


### PR DESCRIPTION
This removes the global click listener in favor of adding one for each instance. This better supports nesting tooltips (e.g. a popover containing buttons with tooltips on them).

- Needs to be added in both `scheduleShow()` (triggered by event listeners) and `show()` (triggered programmatically)
- Remove `checkHideOnClick` option from HideAllOptions - this was only for internal use due to the global click listener and was not documented for use
- Fix in `group.ts` for supporting this better
