### PR TITLE
Backport v5 fixes to v4

### DIFF
--- a/src/createTippy.ts
+++ b/src/createTippy.ts
@@ -72,7 +72,6 @@ export default function createTippy(
   let hideTimeoutId: number
   let animationFrameId: number
   let isScheduledToShow = false
-  let currentParentNode: Element
   let previousPlacement: string
   let wasVisibleDuringPreviousUpdate = false
   let hasMountCallbackRun = false
@@ -226,13 +225,14 @@ export default function createTippy(
   }
 
   /**
-   * Determines if the instance is in `followCursor` mode
+   * Determines if the instance is in `followCursor` mode.
+   * NOTE: in v5, touch devices will use `initial` behavior no matter the value.
    */
-  function hasFollowCursorBehavior(): boolean {
+  function getIsInLooseFollowCursorMode(): boolean {
+    const { followCursor } = instance.props
     return (
-      instance.props.followCursor &&
-      !isUsingTouch &&
-      lastTriggerEventType !== 'focus'
+      (followCursor && lastTriggerEventType !== 'focus') ||
+      (isUsingTouch && followCursor === 'initial')
     )
   }
 
@@ -262,8 +262,8 @@ export default function createTippy(
     onTransitionEnd(duration, () => {
       if (
         !instance.state.isVisible &&
-        currentParentNode &&
-        currentParentNode.contains(popper)
+        popper.parentNode &&
+        popper.parentNode.contains(popper)
       ) {
         callback()
       }
@@ -375,86 +375,55 @@ export default function createTippy(
   }
 
   /**
-   * Returns corrected preventOverflow padding if the instance has an arrow
-   */
-  function getCorrectedPadding(placement: string): number {
-    return instance.props.arrow
-      ? currentComputedPadding[placement] +
-          (instance.props.arrowType === 'round' ? 18 : 16)
-      : currentComputedPadding[placement]
-  }
-
-  /**
    * Positions the virtual reference near the cursor
    */
   function positionVirtualReferenceNearCursor(event: MouseEvent): void {
-    const { clientX, clientY } = (lastMouseMoveEvent = event)
+    const { clientX: x, clientY: y } = (lastMouseMoveEvent = event)
 
     // Gets set once popperInstance `onCreate` has been called
     if (!currentComputedPadding) {
       return
     }
 
+    // If the instance is interactive, avoid updating the position unless it's
+    // over the reference element
+    const isCursorOverReference = closestCallback(
+      event.target as Element,
+      (el: Element): boolean => el === reference,
+    )
+
     const rect = reference.getBoundingClientRect()
     const { followCursor } = instance.props
     const isHorizontal = followCursor === 'horizontal'
     const isVertical = followCursor === 'vertical'
 
-    // Ensure virtual reference is padded to prevent tooltip from overflowing.
-    // Seems to be a Popper.js issue
-    const placement = getBasicPlacement(popper)
-    const isVerticalPlacement = includes(['top', 'bottom'], placement)
-    const isHorizontalPlacement = includes(['left', 'right'], placement)
-    const padding = { ...currentComputedPadding }
-
-    if (isVerticalPlacement) {
-      padding.left = getCorrectedPadding('left')
-      padding.right = getCorrectedPadding('right')
-    }
-
-    if (isHorizontalPlacement) {
-      padding.top = getCorrectedPadding('top')
-      padding.bottom = getCorrectedPadding('bottom')
-    }
-
-    // TODO: Remove the following later if Popper.js changes/fixes the
-    // behavior
-
-    // Top / left boundary
-    let x = isVerticalPlacement ? Math.max(padding.left, clientX) : clientX
-    let y = isHorizontalPlacement ? Math.max(padding.top, clientY) : clientY
-
-    // Bottom / right boundary
-    if (isVerticalPlacement && x > padding.right) {
-      x = Math.min(clientX, window.innerWidth - padding.right)
-    }
-    if (isHorizontalPlacement && y > padding.bottom) {
-      y = Math.min(clientY, window.innerHeight - padding.bottom)
-    }
-
-    // If the instance is interactive, avoid updating the position unless it's
-    // over the reference element
-    const isCursorOverReference = closestCallback(
-      event.target as Element,
-      (el: Element) => el === reference,
+    // The virtual reference needs some size to prevent itself from overflowing
+    const fakeSize = 100
+    const halfFakeSize = fakeSize / 2
+    const isVerticalPlacement = includes(
+      ['top', 'bottom'],
+      getBasicPlacement(popper),
     )
+    const verticalIncrease = isVerticalPlacement ? 0 : halfFakeSize
+    const horizontalIncrease = isVerticalPlacement ? halfFakeSize : 0
 
     if (isCursorOverReference || !instance.props.interactive) {
       instance.popperInstance!.reference = {
         ...instance.popperInstance!.reference,
-        getBoundingClientRect: () => ({
-          width: 0,
-          height: 0,
-          top: isHorizontal ? rect.top : y,
-          bottom: isHorizontal ? rect.bottom : y,
-          left: isVertical ? rect.left : x,
-          right: isVertical ? rect.right : x,
-        }),
+        // These `client` values don't get used by Popper.js if they are 0
         clientWidth: 0,
         clientHeight: 0,
+        getBoundingClientRect: (): DOMRect | ClientRect => ({
+          width: isVerticalPlacement ? fakeSize : 0,
+          height: isVerticalPlacement ? 0 : fakeSize,
+          top: (isHorizontal ? rect.top : y) - verticalIncrease,
+          bottom: (isHorizontal ? rect.bottom : y) + verticalIncrease,
+          left: (isVertical ? rect.left : x) - horizontalIncrease,
+          right: (isVertical ? rect.right : x) + horizontalIncrease,
+        }),
       }
 
-      instance.popperInstance!.scheduleUpdate()
+      instance.popperInstance!.update()
     }
 
     if (followCursor === 'initial' && instance.state.isVisible) {
@@ -616,7 +585,6 @@ export default function createTippy(
   function runMountCallback(): void {
     if (!hasMountCallbackRun && currentMountCallback) {
       hasMountCallbackRun = true
-      reflow(popper)
       currentMountCallback()
     }
   }
@@ -728,16 +696,16 @@ export default function createTippy(
         },
       },
       onCreate(data: Popper.Data) {
-        runMountCallback()
         applyMutations(data)
+        runMountCallback()
 
         if (popperOptions && popperOptions.onCreate) {
           popperOptions.onCreate(data)
         }
       },
       onUpdate(data: Popper.Data) {
-        runMountCallback()
         applyMutations(data)
+        runMountCallback()
 
         if (popperOptions && popperOptions.onUpdate) {
           popperOptions.onUpdate(data)
@@ -758,73 +726,26 @@ export default function createTippy(
   function mount(): void {
     hasMountCallbackRun = false
 
-    const shouldEnableListeners =
-      !hasFollowCursorBehavior() &&
-      !(instance.props.followCursor === 'initial' && isUsingTouch)
+    const isInLooseFollowCursorMode = getIsInLooseFollowCursorMode()
 
-    if (!instance.popperInstance) {
-      createPopperInstance()
-
-      if (shouldEnableListeners) {
-        instance.popperInstance!.enableEventListeners()
-      }
-    } else {
-      if (!hasFollowCursorBehavior()) {
-        instance.popperInstance.scheduleUpdate()
-
-        if (shouldEnableListeners) {
-          instance.popperInstance.enableEventListeners()
-        }
-      }
-
+    if (instance.popperInstance) {
       setFlipModifierEnabled(
         instance.popperInstance.modifiers,
         instance.props.flip,
       )
-    }
 
-    // If the instance previously had followCursor behavior, it will be
-    // positioned incorrectly if triggered by `focus` afterwards.
-    // Update the reference back to the real DOM element
-    instance.popperInstance!.reference = reference
-    const { arrow } = instance.popperChildren
-
-    if (hasFollowCursorBehavior()) {
-      if (arrow) {
-        arrow.style.margin = '0'
+      if (!isInLooseFollowCursorMode) {
+        instance.popperInstance.reference = reference
+        instance.popperInstance.enableEventListeners()
       }
 
-      if (lastMouseMoveEvent) {
-        positionVirtualReferenceNearCursor(lastMouseMoveEvent)
+      instance.popperInstance.scheduleUpdate()
+    } else {
+      createPopperInstance()
+
+      if (!isInLooseFollowCursorMode) {
+        instance.popperInstance!.enableEventListeners()
       }
-    } else if (arrow) {
-      arrow.style.margin = ''
-    }
-
-    // Allow followCursor: 'initial' on touch devices
-    if (
-      isUsingTouch &&
-      lastMouseMoveEvent &&
-      instance.props.followCursor === 'initial'
-    ) {
-      positionVirtualReferenceNearCursor(lastMouseMoveEvent)
-
-      if (arrow) {
-        arrow.style.margin = '0'
-      }
-    }
-
-    const { appendTo } = instance.props
-
-    currentParentNode =
-      appendTo === 'parent'
-        ? reference.parentNode
-        : invokeWithArgsOrReturn(appendTo, [reference])
-
-    if (!currentParentNode.contains(popper)) {
-      currentParentNode.appendChild(popper)
-      instance.props.onMount(instance)
-      instance.state.isMounted = true
     }
   }
 
@@ -861,7 +782,7 @@ export default function createTippy(
     // upon mount.
     // Edge case: if the tooltip is still mounted, but then scheduleShow() is
     // called, it causes a jump.
-    if (hasFollowCursorBehavior() && !instance.state.isMounted) {
+    if (getIsInLooseFollowCursorMode() && !instance.state.isMounted) {
       if (!instance.popperInstance) {
         createPopperInstance()
       }
@@ -1074,39 +995,63 @@ export default function createTippy(
     const transitionableElements = getTransitionableElements()
     setTransitionDuration(transitionableElements.concat(popper), 0)
 
-    currentMountCallback = () => {
+    currentMountCallback = (): void => {
       if (!instance.state.isVisible) {
         return
       }
 
-      // Double update will apply correct mutations
-      if (!hasFollowCursorBehavior()) {
+      const { appendTo } = instance.props
+      const parentNode =
+        appendTo === 'parent'
+          ? reference.parentNode
+          : invokeWithArgsOrReturn(appendTo, [reference])
+
+      if (!parentNode.contains(popper)) {
+        parentNode.appendChild(popper)
+        instance.props.onMount(instance)
+        instance.state.isMounted = true
+      }
+
+      const isInLooseFollowCursorMode = getIsInLooseFollowCursorMode()
+
+      if (isInLooseFollowCursorMode && lastMouseMoveEvent) {
+        positionVirtualReferenceNearCursor(lastMouseMoveEvent)
+      } else if (!isInLooseFollowCursorMode) {
+        // Double update will apply correct mutations
         instance.popperInstance!.update()
       }
 
-      if (instance.popperChildren.backdrop) {
-        instance.popperChildren.content.style.transitionDelay =
-          Math.round(duration / 12) + 'ms'
-      }
+      // Wait for the next tick
+      requestAnimationFrame(() => {
+        reflow(popper)
 
-      if (instance.props.sticky) {
-        makeSticky()
-      }
-
-      setTransitionDuration([popper], instance.props.updateDuration)
-      setTransitionDuration(transitionableElements, duration)
-      setVisibilityState(transitionableElements, 'visible')
-
-      onTransitionedIn(duration, () => {
-        if (instance.props.aria) {
-          getEventListenersTarget().setAttribute(
-            `aria-${instance.props.aria}`,
-            popper.id,
-          )
+        if (instance.popperChildren.backdrop) {
+          instance.popperChildren.content.style.transitionDelay =
+            Math.round(duration / 12) + 'ms'
         }
 
-        instance.props.onShown(instance)
-        instance.state.isShown = true
+        if (instance.props.sticky) {
+          makeSticky()
+        }
+
+        setTransitionDuration([popper], instance.props.updateDuration)
+        setTransitionDuration(transitionableElements, duration)
+        setVisibilityState(transitionableElements, 'visible')
+
+        onTransitionedIn(
+          duration,
+          (): void => {
+            if (instance.props.aria) {
+              getEventListenersTarget().setAttribute(
+                `aria-${instance.props.aria}`,
+                popper.id,
+              )
+            }
+
+            instance.props.onShown(instance)
+            instance.state.isShown = true
+          },
+        )
       })
     }
 
@@ -1158,7 +1103,7 @@ export default function createTippy(
       instance.popperInstance!.disableEventListeners()
       instance.popperInstance!.options.placement = instance.props.placement
 
-      currentParentNode.removeChild(popper)
+      popper.parentNode!.removeChild(popper)
       instance.props.onHidden(instance)
       instance.state.isMounted = false
     })

--- a/src/createTippy.ts
+++ b/src/createTippy.ts
@@ -72,7 +72,7 @@ export default function createTippy(
   let lastMouseMoveEvent: MouseEvent
   let showTimeoutId: number
   let hideTimeoutId: number
-  let animationFrameId: number
+  let scheduleHideAnimationFrameId: number
   let startTransitionAnimationFrameId: number
   let isScheduledToShow = false
   let isBeingDestroyed = false
@@ -838,7 +838,7 @@ export default function createTippy(
     } else {
       // Fixes a `transitionend` problem when it fires 1 frame too
       // late sometimes, we don't want hide() to be called.
-      animationFrameId = requestAnimationFrame(() => {
+      scheduleHideAnimationFrameId = requestAnimationFrame(() => {
         hide()
       })
     }
@@ -898,7 +898,7 @@ export default function createTippy(
   function clearDelayTimeouts(): void {
     clearTimeout(showTimeoutId)
     clearTimeout(hideTimeoutId)
-    cancelAnimationFrame(animationFrameId)
+    cancelAnimationFrame(scheduleHideAnimationFrameId)
   }
 
   /**

--- a/src/createTippy.ts
+++ b/src/createTippy.ts
@@ -72,6 +72,7 @@ export default function createTippy(
   let hideTimeoutId: number
   let animationFrameId: number
   let isScheduledToShow = false
+  let isBeingDestroyed = false
   let previousPlacement: string
   let wasVisibleDuringPreviousUpdate = false
   let hasMountCallbackRun = false
@@ -1068,11 +1069,14 @@ export default function createTippy(
       (defaultProps.duration as [number, number])[1],
     ),
   ): void {
-    if (instance.state.isDestroyed || !instance.state.isEnabled) {
+    if (
+      instance.state.isDestroyed ||
+      (!instance.state.isEnabled && !isBeingDestroyed)
+    ) {
       return
     }
 
-    if (instance.props.onHide(instance) === false) {
+    if (instance.props.onHide(instance) === false && !isBeingDestroyed) {
       return
     }
 
@@ -1117,6 +1121,8 @@ export default function createTippy(
       return
     }
 
+    isBeingDestroyed = true
+
     // If the popper is currently mounted to the DOM, we want to ensure it gets
     // hidden and unmounted instantly upon destruction
     if (instance.state.isMounted) {
@@ -1142,6 +1148,7 @@ export default function createTippy(
       instance.popperInstance.destroy()
     }
 
+    isBeingDestroyed = false
     instance.state.isDestroyed = true
   }
 }

--- a/src/createTippy.ts
+++ b/src/createTippy.ts
@@ -73,6 +73,7 @@ export default function createTippy(
   let showTimeoutId: number
   let hideTimeoutId: number
   let animationFrameId: number
+  let startTransitionAnimationFrameId: number
   let isScheduledToShow = false
   let isBeingDestroyed = false
   let previousPlacement: string
@@ -1030,7 +1031,7 @@ export default function createTippy(
       }
 
       // Wait for the next tick
-      requestAnimationFrame(() => {
+      startTransitionAnimationFrameId = requestAnimationFrame(() => {
         reflow(popper)
 
         if (instance.popperChildren.backdrop) {
@@ -1086,6 +1087,8 @@ export default function createTippy(
     if (instance.props.onHide(instance) === false && !isBeingDestroyed) {
       return
     }
+
+    cancelAnimationFrame(startTransitionAnimationFrameId)
 
     removeDocumentClickListener()
 

--- a/src/scss/index.scss
+++ b/src/scss/index.scss
@@ -141,7 +141,7 @@
   &[data-interactive] {
     pointer-events: auto;
 
-    path {
+    .#{$namespace-prefix}-roundarrow path {
       pointer-events: auto;
     }
   }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -73,15 +73,26 @@ export function getValue(value: any, index: number, defaultValue: any): any {
 }
 
 /**
- * Debounce utility
+ * Debounce utility. To avoid bloating bundle size, we're only passing 1
+ * argument here, a more generic function would pass all arguments. Only
+ * `onMouseMove` uses this which takes the event object for now.
  */
-export function debounce(fn: Function, ms: number): () => void {
-  let timeoutId: number
+export function debounce<T>(
+  fn: (arg: T) => void,
+  ms: number,
+): (arg: T) => void {
+  // Avoid wrapping in `setTimeout` if ms is 0 anyway
+  if (ms === 0) {
+    return fn
+  }
 
-  return function() {
-    clearTimeout(timeoutId)
-    // @ts-ignore
-    timeoutId = setTimeout(() => fn.apply(this, arguments), ms)
+  let timeout: any
+
+  return (arg): void => {
+    clearTimeout(timeout)
+    timeout = setTimeout((): void => {
+      fn(arg)
+    }, ms)
   }
 }
 

--- a/test/spec/createTippy.test.js
+++ b/test/spec/createTippy.test.js
@@ -133,6 +133,7 @@ describe('instance.show', () => {
   it('mounts the popper to the DOM', () => {
     instance = createTippy(h(), defaultProps)
     instance.show()
+    jest.runAllTimers()
     expect(document.querySelector(POPPER_SELECTOR)).toBe(instance.popper)
   })
 
@@ -182,6 +183,7 @@ describe('instance.hide', () => {
       ...defaultProps,
     })
     instance.show(0)
+    jest.runAllTimers()
     expect(document.querySelector(POPPER_SELECTOR)).toBe(instance.popper)
     instance.hide(0)
     jest.runAllTimers()
@@ -194,6 +196,7 @@ describe('instance.hide', () => {
       duration: 100,
     })
     instance.show(0)
+    jest.runAllTimers()
     instance.hide(9)
     expect(instance.popperChildren.tooltip.style.transitionDuration).toBe('9ms')
     instance.destroy()

--- a/test/spec/createTippy.test.js
+++ b/test/spec/createTippy.test.js
@@ -121,6 +121,15 @@ describe('instance.destroy', () => {
     ref._tippy.destroy(true)
     expect(p._tippy).toBeUndefined()
   })
+
+  it('still unmounts the tippy if the instance is disabled', () => {
+    instance = createTippy(h(), defaultProps)
+    instance.show()
+    jest.runAllTimers()
+    instance.disable()
+    instance.destroy()
+    expect(instance.state.isMounted).toBe(false)
+  })
 })
 
 describe('instance.show', () => {

--- a/test/spec/popper.test.js
+++ b/test/spec/popper.test.js
@@ -27,6 +27,8 @@ import {
   ROUND_ARROW_SELECTOR,
 } from '../../src/constants'
 
+jest.useFakeTimers()
+
 tippy.setDefaults({ duration: 0, delay: 0 })
 
 afterEach(cleanDocumentBody)
@@ -38,6 +40,7 @@ describe('hideAll', () => {
     instances.forEach(instance => {
       expect(instance.state.isVisible).toBe(true)
     })
+    jest.runAllTimers()
     hideAll()
     instances.forEach(instance => {
       expect(instance.state.isVisible).toBe(false)
@@ -47,6 +50,7 @@ describe('hideAll', () => {
   it('respects `duration` option', () => {
     const options = { showOnInit: true, duration: 100 }
     const instances = [...Array(3)].map(() => tippy(h(), options))
+    jest.runAllTimers()
     hideAll({ duration: 0 })
     instances.forEach(instance => {
       expect(instance.state.isMounted).toBe(false)
@@ -56,6 +60,7 @@ describe('hideAll', () => {
   it('respects `exclude` option', () => {
     const options = { showOnInit: true }
     const instances = [...Array(3)].map(() => tippy(h(), options))
+    jest.runAllTimers()
     hideAll({ exclude: instances[0] })
     instances.forEach(instance => {
       expect(instance.state.isVisible).toBe(
@@ -69,6 +74,7 @@ describe('hideAll', () => {
     const ref = h()
     tippy(ref, options)
     tippy(ref, options)
+    jest.runAllTimers()
     hideAll({ exclude: ref })
     const instances = [...document.querySelectorAll(POPPER_SELECTOR)].map(
       popper => popper._tippy,

--- a/test/spec/utils.test.js
+++ b/test/spec/utils.test.js
@@ -153,6 +153,21 @@ describe('debounce', () => {
     jest.advanceTimersByTime(10)
     expect(fn).toHaveBeenCalledTimes(1)
   })
+
+  it('is called with arguments', () => {
+    const fn = jest.fn()
+    const ms = 50
+    const debouncedFn = Utils.debounce(fn, ms)
+    debouncedFn('string')
+    jest.advanceTimersByTime(ms)
+    expect(fn).toHaveBeenCalledWith('string')
+  })
+
+  it('does not wrap with new function if ms = 0', () => {
+    const fn = jest.fn()
+    const debouncedFn = Utils.debounce(fn, 0)
+    expect(debouncedFn).toBe(fn)
+  })
 })
 
 describe('getModifier', () => {


### PR DESCRIPTION
The first commit has the async behavior change when mounting, which if they were testing, could break their tests. But I think this is an implementation detail of tippy, no?

(edited: it does work correctly on IE11)

### Fixes

- Mounting behavior (IE11 scrollbar flicker) (fix #509)
- `followCursor` fixes (respects `boundary` & fix regression where `initial` was not placed correctly on touch devices on first show)
- Ensure `destroy()`'s unmounting of the tippy can never be impeded
- Fix the longstanding interactive scrolling issue
- Fix `path` selector having `pointer-events: auto` (fix #504)