### PR TITLE
Fix #513

### DIFF
--- a/src/createTippy.ts
+++ b/src/createTippy.ts
@@ -407,14 +407,18 @@ export default function createTippy(
       getBasicPlacement(popper),
     )
     const fullPlacement = popper.getAttribute(PLACEMENT_ATTRIBUTE)
-    const isVariation = !!(fullPlacement ? fullPlacement.split('-')[1] : false)
+    const isVariation = fullPlacement ? !!fullPlacement.split('-')[1] : false
     const size = isVerticalPlacement ? popper.offsetWidth : popper.offsetHeight
     const halfSize = size / 2
     const verticalIncrease = isVerticalPlacement
       ? 0
-      : halfSize + (isVariation ? halfSize : 0)
+      : isVariation
+      ? size
+      : halfSize
     const horizontalIncrease = isVerticalPlacement
-      ? halfSize + (isVariation ? halfSize : 0)
+      ? isVariation
+        ? size
+        : halfSize
       : 0
 
     if (isCursorOverReference || !instance.props.interactive) {

--- a/src/createTippy.ts
+++ b/src/createTippy.ts
@@ -407,7 +407,7 @@ export default function createTippy(
       getBasicPlacement(popper),
     )
     const fullPlacement = popper.getAttribute('x-placement')
-    const isVariation = fullPlacement ? fullPlacement.split('-')[1] : false
+    const isVariation = !!(fullPlacement ? fullPlacement.split('-')[1] : false)
     const size = isVerticalPlacement ? popper.offsetWidth : popper.offsetHeight
     const halfSize = size / 2
     const verticalIncrease = isVerticalPlacement

--- a/src/createTippy.ts
+++ b/src/createTippy.ts
@@ -406,7 +406,7 @@ export default function createTippy(
       ['top', 'bottom'],
       getBasicPlacement(popper),
     )
-    const fullPlacement = popper.getAttribute('x-placement')
+    const fullPlacement = popper.getAttribute(PLACEMENT_ATTRIBUTE)
     const isVariation = !!(fullPlacement ? fullPlacement.split('-')[1] : false)
     const size = isVerticalPlacement ? popper.offsetWidth : popper.offsetHeight
     const halfSize = size / 2

--- a/src/createTippy.ts
+++ b/src/createTippy.ts
@@ -402,14 +402,20 @@ export default function createTippy(
     const isVertical = followCursor === 'vertical'
 
     // The virtual reference needs some size to prevent itself from overflowing
-    const fakeSize = 100
-    const halfFakeSize = fakeSize / 2
     const isVerticalPlacement = includes(
       ['top', 'bottom'],
       getBasicPlacement(popper),
     )
-    const verticalIncrease = isVerticalPlacement ? 0 : halfFakeSize
-    const horizontalIncrease = isVerticalPlacement ? halfFakeSize : 0
+    const fullPlacement = popper.getAttribute('x-placement')
+    const isVariation = fullPlacement ? fullPlacement.split('-')[1] : false
+    const size = isVerticalPlacement ? popper.offsetWidth : popper.offsetHeight
+    const halfSize = size / 2
+    const verticalIncrease = isVerticalPlacement
+      ? 0
+      : halfSize + (isVariation ? halfSize : 0)
+    const horizontalIncrease = isVerticalPlacement
+      ? halfSize + (isVariation ? halfSize : 0)
+      : 0
 
     if (isCursorOverReference || !instance.props.interactive) {
       instance.popperInstance!.reference = {
@@ -418,8 +424,8 @@ export default function createTippy(
         clientWidth: 0,
         clientHeight: 0,
         getBoundingClientRect: (): DOMRect | ClientRect => ({
-          width: isVerticalPlacement ? fakeSize : 0,
-          height: isVerticalPlacement ? 0 : fakeSize,
+          width: isVerticalPlacement ? size : 0,
+          height: isVerticalPlacement ? 0 : size,
           top: (isHorizontal ? rect.top : y) - verticalIncrease,
           bottom: (isHorizontal ? rect.bottom : y) + verticalIncrease,
           left: (isVertical ? rect.left : x) - horizontalIncrease,

--- a/test/spec/props.test.js
+++ b/test/spec/props.test.js
@@ -1145,8 +1145,8 @@ describe('followCursor', () => {
   // should be within that
   const first = { clientX: 317, clientY: 119 }
   const second = { clientX: 240, clientY: 500 }
-  const fakeSize = 100
-  const halfFakeSize = fakeSize / 2
+  const size = 0
+  const halfSize = size / 2
 
   const firstMouseMoveEvent = new MouseEvent('mousemove', {
     ...first,
@@ -1168,8 +1168,8 @@ describe('followCursor', () => {
     const isVerticalPlacement = ['top', 'bottom'].includes(
       getBasicPlacement(instance.popper),
     )
-    const verticalIncrease = isVerticalPlacement ? 0 : halfFakeSize
-    const horizontalIncrease = isVerticalPlacement ? halfFakeSize : 0
+    const verticalIncrease = isVerticalPlacement ? 0 : halfSize
+    const horizontalIncrease = isVerticalPlacement ? halfSize : 0
 
     expect(rect.left).toBe(receivedRect.left - horizontalIncrease)
     expect(rect.right).toBe(receivedRect.right + horizontalIncrease)


### PR DESCRIPTION
This fixes the problem where the tippy gets offset incorrectly from the cursor position

However, the reversal of the placement variation is now actually correct with the new behavior... but it's unexpected when considering it's a patch release. Unfortunately I don't think that can be changed back now.

- The size of the virtual reference should match the popper element's size
- The variation needs to be taken into consideration

@lozinsky can you verify