### PR TITLE
Fix additional mounting caveat

### DIFF
--- a/src/popper.ts
+++ b/src/popper.ts
@@ -183,6 +183,9 @@ export function createPopperElement(id: number, props: Props): PopperElement {
   popper.className = POPPER_CLASS
   popper.id = `__NAMESPACE_PREFIX__-${id}`
   popper.style.zIndex = '' + props.zIndex
+  popper.style.position = 'absolute'
+  popper.style.top = '0'
+  popper.style.left = '0'
 
   if (props.role) {
     popper.setAttribute('role', props.role)

--- a/test/spec/props.test.js
+++ b/test/spec/props.test.js
@@ -1025,8 +1025,6 @@ describe('sticky', () => {
       })
     instance.show()
 
-    jest.runAllTimers()
-
     expect(calls).toBe(1)
 
     requestAnimationFrame(() => {


### PR DESCRIPTION
- Resolves the caveat if the element was near the scrollbar in IE11 (#509) - now there are zero flickers anywhere
- Also restores mounting behavior back to 4.3.1 since the new behavior was unneeded

All that needed to be done was to initially apply styles to the popper before popperInstance is created so it sits in the top left of the page when it gets appended to the body, causing no overflow due to its size. 

Hopefully the mounting behavior is fully fixed now 😅 