### PR TITLE
Implement `touch: 'longPress'` and overloaded `touch` prop

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,6 +1,7 @@
 {
   "presets": ["@babel/env", "@babel/typescript"],
   "plugins": [
+    ["@babel/plugin-transform-destructuring", { "loose": true }, "unique"],
     ["@babel/plugin-transform-template-literals", { "loose": true }, "unique"],
     ["@babel/proposal-object-rest-spread", { "loose": true }, "unique"],
     "dev-expression"

--- a/src/bindGlobalEventListeners.ts
+++ b/src/bindGlobalEventListeners.ts
@@ -71,6 +71,9 @@ export function onWindowBlur(): void {
  * Adds the needed global event listeners
  */
 export default function bindGlobalEventListeners(): void {
-  document.addEventListener('touchstart', onDocumentTouchStart, PASSIVE)
+  document.addEventListener('touchstart', onDocumentTouchStart, {
+    ...PASSIVE,
+    capture: true,
+  })
   window.addEventListener('blur', onWindowBlur)
 }

--- a/src/createTippy.ts
+++ b/src/createTippy.ts
@@ -186,6 +186,16 @@ export default function createTippy(
     )
   }
 
+  function getNormalizedTouchSettings(): [string, number] {
+    const { touch } = instance.props
+    // longPress duration is 500 by default
+    return Array.isArray(touch) ? [touch[0], touch[1]] : [touch, 500]
+  }
+
+  function getIsCustomTouchBehavior(): boolean {
+    return includes(['hold', 'longPress'], getNormalizedTouchSettings()[0])
+  }
+
   function getTransitionableElements(): (HTMLDivElement | null)[] {
     return [tooltip, content, instance.popperChildren.backdrop]
   }
@@ -323,7 +333,7 @@ export default function createTippy(
   }
 
   function addTriggersToEventListenersTarget(): void {
-    if (instance.props.touchHold) {
+    if (getIsCustomTouchBehavior()) {
       on('touchstart', onTrigger, PASSIVE)
       on('touchend', onMouseLeave as EventListener, PASSIVE)
     }
@@ -404,7 +414,17 @@ export default function createTippy(
     ) {
       scheduleHide(event)
     } else {
-      scheduleShow(event)
+      const [value, duration] = getNormalizedTouchSettings()
+
+      if (currentInput.isTouch && value === 'longPress') {
+        // We can hijack the show timeout here, it will be cleared by
+        // `scheduleHide()` when necessary
+        showTimeout = setTimeout(() => {
+          scheduleShow(event)
+        }, duration)
+      } else {
+        scheduleShow(event)
+      }
     }
   }
 
@@ -467,11 +487,14 @@ export default function createTippy(
   function isEventListenerStopped(event: Event): boolean {
     const supportsTouch = 'ontouchstart' in window
     const isTouchEvent = includes(event.type, 'touch')
-    const { touchHold } = instance.props
+    const isCustomTouch = getIsCustomTouchBehavior()
 
     return (
-      (supportsTouch && currentInput.isTouch && touchHold && !isTouchEvent) ||
-      (currentInput.isTouch && !touchHold && isTouchEvent)
+      (supportsTouch &&
+        currentInput.isTouch &&
+        isCustomTouch &&
+        !isTouchEvent) ||
+      (currentInput.isTouch && !isCustomTouch && isTouchEvent)
     )
   }
 

--- a/src/createTippy.ts
+++ b/src/createTippy.ts
@@ -186,10 +186,10 @@ export default function createTippy(
     )
   }
 
-  function getNormalizedTouchSettings(): [string, number] {
+  function getNormalizedTouchSettings(): [string | boolean, number] {
     const { touch } = instance.props
     // longPress duration is 500 by default
-    return Array.isArray(touch) ? [touch[0], touch[1]] : [touch, 500]
+    return Array.isArray(touch) ? touch : [touch, 500]
   }
 
   function getIsCustomTouchBehavior(): boolean {

--- a/src/createTippy.ts
+++ b/src/createTippy.ts
@@ -419,7 +419,7 @@ export default function createTippy(
       if (currentInput.isTouch && value === 'longPress') {
         // We can hijack the show timeout here, it will be cleared by
         // `scheduleHide()` when necessary
-        showTimeout = setTimeout(() => {
+        showTimeout = setTimeout((): void => {
           scheduleShow(event)
         }, duration)
       } else {

--- a/src/props.ts
+++ b/src/props.ts
@@ -43,7 +43,6 @@ export const defaultProps: Props = {
   sticky: false,
   theme: '',
   touch: true,
-  touchHold: false,
   trigger: 'mouseenter focus',
   triggerTarget: null,
   updateDuration: 0,

--- a/src/types.ts
+++ b/src/types.ts
@@ -67,8 +67,7 @@ export interface Props {
   size: 'small' | 'regular' | 'large'
   sticky: boolean
   theme: string
-  touch: boolean
-  touchHold: boolean
+  touch: boolean | 'hold' | 'longPress'
   trigger: string
   triggerTarget: Element | null
   updateDuration: number

--- a/src/types.ts
+++ b/src/types.ts
@@ -67,7 +67,7 @@ export interface Props {
   size: 'small' | 'regular' | 'large'
   sticky: boolean
   theme: string
-  touch: boolean | 'hold' | 'longPress'
+  touch: boolean | 'hold' | 'longPress' | ['longPress', number]
   trigger: string
   triggerTarget: Element | null
   updateDuration: number

--- a/test/integration/props.test.js
+++ b/test/integration/props.test.js
@@ -848,27 +848,16 @@ describe('touch', () => {
     expect(instance.state.isVisible).toBe(false)
     disableTouchEnvironment()
   })
-})
 
-describe('touchHold', () => {
-  it('true: uses `touch` listeners instead', () => {
+  it('"hold": uses `touch` listeners instead', () => {
     enableTouchEnvironment()
     const ref = h()
-    const instance = tippy(ref, { touchHold: true })
+    const instance = tippy(ref, { touch: 'hold' })
     ref.dispatchEvent(new Event('mouseenter'))
     expect(instance.state.isVisible).toBe(false)
     ref.dispatchEvent(new Event('focus'))
     expect(instance.state.isVisible).toBe(false)
     ref.dispatchEvent(new Event('touchstart'))
-    expect(instance.state.isVisible).toBe(true)
-    disableTouchEnvironment()
-  })
-
-  it('false: uses standard listeners', () => {
-    enableTouchEnvironment()
-    const ref = h()
-    const instance = tippy(ref, { touchHold: false })
-    ref.dispatchEvent(new Event('mouseenter'))
     expect(instance.state.isVisible).toBe(true)
     disableTouchEnvironment()
   })

--- a/test/integration/props.test.js
+++ b/test/integration/props.test.js
@@ -833,24 +833,22 @@ describe('showOnCreate', () => {
 })
 
 describe('touch', () => {
+  beforeEach(enableTouchEnvironment)
+  afterEach(disableTouchEnvironment)
+
   it('true: shows tooltips on touch device', () => {
-    enableTouchEnvironment()
     const instance = tippy(h(), { touch: true })
     instance.show()
     expect(instance.state.isVisible).toBe(true)
-    disableTouchEnvironment()
   })
 
   it('false: does not show tooltip on touch device', () => {
-    enableTouchEnvironment()
     const instance = tippy(h(), { touch: false })
     instance.show()
     expect(instance.state.isVisible).toBe(false)
-    disableTouchEnvironment()
   })
 
   it('"hold": uses `touch` listeners instead', () => {
-    enableTouchEnvironment()
     const ref = h()
     const instance = tippy(ref, { touch: 'hold' })
     ref.dispatchEvent(new Event('mouseenter'))
@@ -859,7 +857,47 @@ describe('touch', () => {
     expect(instance.state.isVisible).toBe(false)
     ref.dispatchEvent(new Event('touchstart'))
     expect(instance.state.isVisible).toBe(true)
-    disableTouchEnvironment()
+  })
+
+  it('"hold": hides due to the correct event', () => {
+    const ref = h()
+    const instance = tippy(ref, { touch: 'hold' })
+    ref.dispatchEvent(new Event('touchstart'))
+    expect(instance.state.isVisible).toBe(true)
+    ref.dispatchEvent(new Event('mouseleave'))
+    expect(instance.state.isVisible).toBe(true)
+    ref.dispatchEvent(new Event('touchend'))
+    expect(instance.state.isVisible).toBe(false)
+  })
+
+  it('"longPress": uses `touch` listeners and waits for timeout', () => {
+    const ref = h()
+    const instance = tippy(ref, { touch: 'longPress' })
+    ref.dispatchEvent(new Event('touchstart'))
+    expect(instance.state.isVisible).toBe(false)
+    jest.runAllTimers()
+    expect(instance.state.isVisible).toBe(true)
+  })
+
+  it('"longPress": respects duration', () => {
+    const ref = h()
+    const instance = tippy(ref, { touch: ['longPress', 100] })
+    ref.dispatchEvent(new Event('touchstart'))
+    expect(instance.state.isVisible).toBe(false)
+    jest.advanceTimersByTime(99)
+    expect(instance.state.isVisible).toBe(false)
+    jest.advanceTimersByTime(100)
+    expect(instance.state.isVisible).toBe(true)
+  })
+
+  it('"longPress": timeout is cancelled correctly', () => {
+    const ref = h()
+    const instance = tippy(ref, { touch: ['longPress', 100] })
+    ref.dispatchEvent(new Event('touchstart'))
+    expect(instance.state.isVisible).toBe(false)
+    ref.dispatchEvent(new Event('touchend'))
+    jest.advanceTimersByTime(100)
+    expect(instance.state.isVisible).toBe(false)
   })
 })
 


### PR DESCRIPTION
Resolves #522 

Removes `touchHold` in favor of overloading `touch` prop.

And new value: `'longPress'`, which is like `'hold'` but uses a timeout to wait.