### PR TITLE
Handle case of weird head tag layout

### DIFF
--- a/src/css.ts
+++ b/src/css.ts
@@ -10,7 +10,7 @@ export function injectCSS(css: string): void {
     style.textContent = css
     style.setAttribute('data-__NAMESPACE_PREFIX__-stylesheet', '')
     const head = document.head
-    const firstStyleOrLinkTag = head.querySelector('style,link')
+    const firstStyleOrLinkTag = document.querySelector('head>style,head>link')
 
     if (firstStyleOrLinkTag) {
       head.insertBefore(style, firstStyleOrLinkTag)


### PR DESCRIPTION
The PR handles cases of weird layout of <head> tag when styling tags (link, style) aren't children of <head> tag, but they're children of other children of <head> tag. The fix makes firstStyleOrLinkTag variable to ignore such weird cases.

That's the exact case I'm going to handle:

![](https://i.imgur.com/7XvDYKD.png)

Unfortunately I don't have access to change this code and tippy initialization throws `Uncaught DOMException: Failed to execute 'insertBefore' on 'Node': The node before which the new node is to be inserted is not a child of this node.`