### PR TITLE
Fix iframe support

### DIFF
--- a/src/createTippy.ts
+++ b/src/createTippy.ts
@@ -97,9 +97,11 @@ export default function createTippy(
   let debouncedOnMouseMove = debounce(onMouseMove, props.interactiveDebounce);
 
   // Support iframe contexts
-  // The reference must never change its document context after the instance
-  // is created, since this is a static reference
-  const doc = reference.ownerDocument || document;
+  // Static check that assumes any of the `triggerTarget` or `reference`
+  // nodes will never change documents, even when they are updated
+  const doc =
+    normalizeToArray(props.triggerTarget || reference)[0].ownerDocument ||
+    document;
 
   /* ======================= 🔑 Public members 🔑 ======================= */
   const id = idCounter++;

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,9 +6,9 @@ import bindGlobalEventListeners, {
 } from './bindGlobalEventListeners';
 import {
   arrayFrom,
-  isRealElement,
   getArrayOfElements,
   isReferenceElement,
+  isElement,
 } from './utils';
 import {warnWhen, validateTargets, validateProps} from './validation';
 import {POPPER_SELECTOR} from './constants';
@@ -42,7 +42,7 @@ function tippy(
   const elements = getArrayOfElements(targets);
 
   if (__DEV__) {
-    const isSingleContentElement = isRealElement(props.content);
+    const isSingleContentElement = isElement(props.content);
     const isMoreThanOneReferenceElement = elements.length > 1;
     warnWhen(
       isSingleContentElement && isMoreThanOneReferenceElement,
@@ -71,7 +71,7 @@ function tippy(
     [],
   );
 
-  return isRealElement(targets) ? instances[0] : instances;
+  return isElement(targets) ? instances[0] : instances;
 }
 
 tippy.version = version;

--- a/src/plugins/followCursor.ts
+++ b/src/plugins/followCursor.ts
@@ -5,7 +5,13 @@ import {
   Placement,
   Instance,
 } from '../types';
-import {includes, closestCallback, useIfDefined, isMouseEvent} from '../utils';
+import {
+  includes,
+  closestCallback,
+  useIfDefined,
+  isMouseEvent,
+  normalizeToArray,
+} from '../utils';
 import {getBasePlacement} from '../popper';
 import {currentInput} from '../bindGlobalEventListeners';
 
@@ -14,7 +20,13 @@ export default {
   defaultValue: false,
   fn(instance: Instance): Partial<LifecycleHooks> {
     const {reference, popper} = instance;
-    const doc = reference.ownerDocument || document;
+
+    // Support iframe contexts
+    // Static check that assumes any of the `triggerTarget` or `reference`
+    // nodes will never change documents, even when they are updated
+    const doc =
+      normalizeToArray(instance.props.triggerTarget || reference)[0]
+        .ownerDocument || document;
 
     // Internal state
     let lastMouseMoveEvent: MouseEvent;

--- a/src/plugins/followCursor.ts
+++ b/src/plugins/followCursor.ts
@@ -5,7 +5,7 @@ import {
   Placement,
   Instance,
 } from '../types';
-import {includes, closestCallback, useIfDefined} from '../utils';
+import {includes, closestCallback, useIfDefined, isMouseEvent} from '../utils';
 import {getBasePlacement} from '../popper';
 import {currentInput} from '../bindGlobalEventListeners';
 
@@ -14,6 +14,7 @@ export default {
   defaultValue: false,
   fn(instance: Instance): Partial<LifecycleHooks> {
     const {reference, popper} = instance;
+    const doc = reference.ownerDocument || document;
 
     // Internal state
     let lastMouseMoveEvent: MouseEvent;
@@ -55,7 +56,7 @@ export default {
     function getIsEnabled(): boolean {
       return (
         instance.props.followCursor &&
-        triggerEvent instanceof MouseEvent &&
+        isMouseEvent(triggerEvent) &&
         !(triggerEvent.clientX === 0 && triggerEvent.clientY === 0)
       );
     }
@@ -96,11 +97,11 @@ export default {
     }
 
     function addListener(): void {
-      document.addEventListener('mousemove', onMouseMove);
+      doc.addEventListener('mousemove', onMouseMove);
     }
 
     function removeListener(): void {
-      document.removeEventListener('mousemove', onMouseMove);
+      doc.removeEventListener('mousemove', onMouseMove);
     }
 
     function onMouseMove(event: MouseEvent): void {
@@ -186,7 +187,7 @@ export default {
 
         triggerEvent = event;
 
-        if (event instanceof MouseEvent) {
+        if (isMouseEvent(event)) {
           lastMouseMoveEvent = event;
         }
 

--- a/src/popper.ts
+++ b/src/popper.ts
@@ -5,7 +5,7 @@ import {
   BasePlacement,
   Placement,
 } from './types';
-import {innerHTML, div, isRealElement, splitBySpaces} from './utils';
+import {innerHTML, div, isElement, splitBySpaces} from './utils';
 import {isUCBrowser} from './browser';
 import {
   POPPER_CLASS,
@@ -23,7 +23,7 @@ import {
  * Sets the innerHTML of an element
  */
 export function setInnerHTML(element: Element, html: string | Element): void {
-  element[innerHTML()] = isRealElement(html) ? html[innerHTML()] : html;
+  element[innerHTML()] = isElement(html) ? html[innerHTML()] : html;
 }
 
 /**
@@ -33,7 +33,7 @@ export function setContent(
   contentEl: PopperChildren['content'],
   props: Props,
 ): void {
-  if (isRealElement(props.content)) {
+  if (isElement(props.content)) {
     setInnerHTML(contentEl, '');
     contentEl.appendChild(props.content);
   } else if (typeof props.content !== 'function') {
@@ -82,7 +82,7 @@ export function createArrowElement(arrow: Props['arrow']): HTMLDivElement {
   } else {
     arrowElement.className = SVG_ARROW_CLASS;
 
-    if (isRealElement(arrow)) {
+    if (isElement(arrow)) {
       arrowElement.appendChild(arrow);
     } else {
       setInnerHTML(arrowElement, arrow as string);

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -20,11 +20,11 @@ export function hasOwnProperty(obj: object, key: string): boolean {
  * Returns an array of elements based on the value
  */
 export function getArrayOfElements(value: Targets): Element[] {
-  if (isRealElement(value)) {
+  if (isElement(value)) {
     return [value];
   }
 
-  if (value instanceof NodeList) {
+  if (isNodeList(value)) {
     return arrayFrom(value);
   }
 
@@ -64,10 +64,32 @@ export function getModifier(obj: any, key: string): any {
 }
 
 /**
- * Determines if the value is a real element
+ * Determines if the value is of type
  */
-export function isRealElement(value: any): value is Element {
-  return value instanceof Element;
+export function isType(value: any, type: string): boolean {
+  const str = {}.toString.call(value);
+  return str.indexOf('[object') === 0 && str.indexOf(`${type}]`) > -1;
+}
+
+/**
+ * Determines if the value is of type Element
+ */
+export function isElement(value: any): value is Element {
+  return isType(value, 'Element');
+}
+
+/**
+ * Determines if the value is of type NodeList
+ */
+export function isNodeList(value: any): value is NodeList {
+  return isType(value, 'NodeList');
+}
+
+/**
+ * Determines if the value is of type MouseEvent
+ */
+export function isMouseEvent(value: any): value is MouseEvent {
+  return isType(value, 'MouseEvent');
 }
 
 /**

--- a/test/unit/utils.test.js
+++ b/test/unit/utils.test.js
@@ -324,3 +324,29 @@ describe('splitBySpaces', () => {
     expect(Utils.splitBySpaces(' one  two ')).toMatchObject(['one', 'two']);
   });
 });
+
+describe('isType', () => {
+  it('correctly determines types of Elements', () => {
+    expect(Utils.isType(document.createElement('div'), 'Element')).toBe(true);
+    expect(
+      Utils.isType(
+        document.createElementNS('http://www.w3.org/2000/svg', 'svg'),
+        'Element',
+      ),
+    ).toBe(true);
+    expect(Utils.isType({}, 'Element')).toBe(false);
+    expect(Utils.isType('button', 'Element')).toBe(false);
+    expect(Utils.isType(document.querySelectorAll('a'), 'Element')).toBe(false);
+  });
+
+  it('correctly determines type of MouseEvents', () => {
+    expect(Utils.isType(new MouseEvent('mouseenter'), 'MouseEvent')).toBe(true);
+    expect(Utils.isType(new FocusEvent('focus'), 'MouseEvent')).toBe(false);
+  });
+
+  it('correctly determines type of NodeLists', () => {
+    expect(Utils.isType(document.querySelectorAll('a'), 'NodeList')).toBe(true);
+    expect(Utils.isType(document.createElement('div'), 'NodeList')).toBe(false);
+    expect(Utils.isType({}, 'NodeList')).toBe(false);
+  });
+});


### PR DESCRIPTION
Fixes https://github.com/atomiks/tippy.js-react/issues/121

Tippy has never supported iframes where the script was in a different document (i.e. not CodePen/CodeSandbox iframes), this adds support as discovered by the referenced issue.

- All `instanceof` checks have to be replaced by `{}.toString.call(value)` checks
- All `document` references in instance-based listeners changed to `reference.ownerDocument` (global ones remain)

The reference should never leave its iframe context while the instance is still alive, since it's a static variable reference. Also, the popper should probably be in the same document as the reference too (via `appendTo`, not sure how much this matters though). `triggerTarget` nodes must also be in the same document as the `reference`. I'm sure users of iframes know this however.

I tested this with `react-frame-component`, and it fixes support for it, actual tests seem like they could be tricky so we'll work on that in the future.