### PR TITLE
Clear timeouts on destroy

### DIFF
--- a/src/createTippy.ts
+++ b/src/createTippy.ts
@@ -1051,6 +1051,7 @@ export default function createTippy(
 
     isBeingDestroyed = true;
 
+    instance.clearDelayTimeouts();
     instance.hide(0);
 
     removeListenersFromTriggerTarget();

--- a/test/integration/createTippy.test.js
+++ b/test/integration/createTippy.test.js
@@ -163,6 +163,23 @@ describe('instance.destroy()', () => {
 
     expect(instance.state.isMounted).toBe(false);
   });
+
+  it('clears pending timeouts', () => {
+    instance = createTippy(h(), {...defaultProps, delay: 500});
+
+    // show() will warn about memory leak
+    const spy = jest.spyOn(console, 'warn');
+
+    instance.reference.dispatchEvent(MOUSEENTER);
+
+    instance.destroy();
+
+    jest.advanceTimersByTime(500);
+
+    expect(spy).not.toHaveBeenCalled();
+
+    spy.mockRestore();
+  });
 });
 
 describe('instance.show()', () => {


### PR DESCRIPTION
Discovered via `createSingleton()` – we were never clearing timeouts on destroy that may have been pending. Though `show()` would not have been called anyway due to the `state.isDestroyed` check.