### PR TITLE
Change distance technique

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,7 +1,5 @@
 export const PASSIVE = {passive: true};
 
-export const PREVENT_OVERFLOW_PADDING = 5;
-
 export const ROUND_ARROW =
   '<svg viewBox="0 0 18 7" xmlns="http://www.w3.org/2000/svg"><path d="M0 7s2.021-.015 5.253-4.218C6.584 1.051 7.797.007 9 0c1.203-.007 2.416 1.035 3.761 2.782C16.012 7.005 18 7 18 7H0z"/></svg>';
 

--- a/src/popper.ts
+++ b/src/popper.ts
@@ -262,41 +262,16 @@ export function updatePopperElement(
  * region
  */
 export function isCursorOutsideInteractiveBorder(
-  popperPlacement: BasePlacement,
   popperRect: ClientRect,
   event: MouseEvent,
-  props: Props,
+  interactiveBorder: Props['interactiveBorder'],
 ): boolean {
-  if (!popperPlacement) {
-    return true;
-  }
+  const {clientX, clientY} = event;
 
-  const {clientX: x, clientY: y} = event;
-  const {interactiveBorder, distance} = props;
-
-  const exceedsTop =
-    popperRect.top - y >
-    (popperPlacement === 'top'
-      ? interactiveBorder + distance
-      : interactiveBorder);
-
-  const exceedsBottom =
-    y - popperRect.bottom >
-    (popperPlacement === 'bottom'
-      ? interactiveBorder + distance
-      : interactiveBorder);
-
-  const exceedsLeft =
-    popperRect.left - x >
-    (popperPlacement === 'left'
-      ? interactiveBorder + distance
-      : interactiveBorder);
-
-  const exceedsRight =
-    x - popperRect.right >
-    (popperPlacement === 'right'
-      ? interactiveBorder + distance
-      : interactiveBorder);
+  const exceedsTop = popperRect.top > clientY + interactiveBorder;
+  const exceedsBottom = popperRect.bottom < clientY - interactiveBorder;
+  const exceedsLeft = popperRect.left > clientX + interactiveBorder;
+  const exceedsRight = popperRect.right < clientX - interactiveBorder;
 
   return exceedsTop || exceedsBottom || exceedsLeft || exceedsRight;
 }

--- a/src/scss/index.scss
+++ b/src/scss/index.scss
@@ -11,6 +11,7 @@
   pointer-events: none;
   max-width: calc(100% - 10px);
   transition-timing-function: cubic-bezier(0.165, 0.84, 0.44, 1);
+  transition-property: transform;
 }
 
 .#{$namespace-prefix}-tooltip {

--- a/test/integration/props.test.js
+++ b/test/integration/props.test.js
@@ -901,49 +901,6 @@ describe('popperOptions', () => {
     expect(popperInstance.options.modifiers.preventOverflow.test).toBe(true);
   });
 
-  it('modifiers.preventOverflow.padding is not overwritten', () => {
-    const paddings = [15, {top: 15, bottom: -5, left: 50, right: 0}];
-    const placements = ['top', 'bottom', 'left', 'right'];
-
-    placements.forEach(placement => {
-      paddings.forEach(padding => {
-        const instance = tippy(h(), {
-          placement,
-          lazy: false,
-          popperOptions: {
-            modifiers: {
-              preventOverflow: {
-                padding,
-              },
-            },
-          },
-        });
-
-        jest.runAllTimers();
-
-        const preventOverflowPadding = instance.popperInstance.modifiers.find(
-          m => m.name === 'preventOverflow',
-        ).padding;
-
-        const paddingObject =
-          typeof padding === 'number'
-            ? {
-                top: padding,
-                right: padding,
-                bottom: padding,
-                left: padding,
-                [placement]: padding + 10,
-              }
-            : {
-                ...padding,
-                [placement]: padding[placement] + 10,
-              };
-
-        expect(preventOverflowPadding).toEqual(paddingObject);
-      });
-    });
-  });
-
   it('modifiers.arrow', () => {
     const {popperInstance} = tippy(h(), {
       lazy: false,

--- a/test/unit/popper.test.js
+++ b/test/unit/popper.test.js
@@ -428,145 +428,37 @@ describe('setInnerHTML', () => {
 });
 
 describe('isCursorOutsideInteractiveBorder', () => {
-  const props = {interactiveBorder: 5, distance: 10};
+  const interactiveBorder = 5;
   const popperRect = {top: 100, left: 100, right: 110, bottom: 110};
 
-  it('no popper placement returns true', () => {
-    expect(isCursorOutsideInteractiveBorder(null, {}, {}, {})).toBe(true);
-  });
+  const inside = [
+    {clientX: 95, clientY: 95},
+    {clientX: 115, clientY: 115},
+    {clientX: 115, clientY: 95},
+    {clientX: 95, clientY: 115},
+  ];
 
-  // TOP: bounded by x(95, 115) and y(95, 115)
-  it('PLACEMENT=top: inside', () => {
-    const mockEvents = [
-      {clientX: 95, clientY: 95},
-      {clientX: 115, clientY: 115},
-      {clientX: 115, clientY: 95},
-      {clientX: 95, clientY: 115},
-    ];
+  const outside = [
+    {clientX: 94, clientY: 94},
+    {clientX: 116, clientY: 116},
+    {clientX: 94, clientY: 100},
+    {clientX: 100, clientY: 94},
+    {clientX: 100, clientY: 116},
+    {clientX: 116, clientY: 100},
+  ];
 
-    mockEvents.forEach(coords => {
+  it('inside', () => {
+    inside.forEach(coords => {
       expect(
-        isCursorOutsideInteractiveBorder('top', popperRect, coords, props),
+        isCursorOutsideInteractiveBorder(popperRect, coords, interactiveBorder),
       ).toBe(false);
     });
   });
 
-  // TOP: bounded by x(95, 115) and y(95, 115)
-  it('PLACEMENT=top: outside', () => {
-    const mockEvents = [
-      {clientX: 94, clientY: 84},
-      {clientX: 94, clientY: 126},
-      {clientX: 100, clientY: 84},
-      {clientX: 100, clientY: 126},
-      {clientX: 94, clientY: 100},
-      {clientX: 116, clientY: 100},
-    ];
-
-    mockEvents.forEach(coords => {
+  it('outside', () => {
+    outside.forEach(coords => {
       expect(
-        isCursorOutsideInteractiveBorder('top', popperRect, coords, props),
-      ).toBe(true);
-    });
-  });
-
-  // BOTTOM: bounded by x(95, 115) and y(95, 125])
-  it('PLACEMENT=bottom: inside', () => {
-    const mockEvents = [
-      {clientX: 95, clientY: 95},
-      {clientX: 115, clientY: 125},
-      {clientX: 115, clientY: 125},
-      {clientX: 95, clientY: 125},
-    ];
-
-    mockEvents.forEach(coords => {
-      expect(
-        isCursorOutsideInteractiveBorder('bottom', popperRect, coords, props),
-      ).toBe(false);
-    });
-  });
-
-  // BOTTOM: bounded by x(95, 115) and y(95, 125)
-  it('PLACEMENT=bottom: outside', () => {
-    const mockEvents = [
-      {clientX: 94, clientY: 94},
-      {clientX: 94, clientY: 126},
-      {clientX: 100, clientY: 94},
-      {clientX: 100, clientY: 126},
-      {clientX: 94, clientY: 100},
-      {clientX: 116, clientY: 100},
-    ];
-
-    mockEvents.forEach(coords => {
-      expect(
-        isCursorOutsideInteractiveBorder('bottom', popperRect, coords, props),
-      ).toBe(true);
-    });
-  });
-
-  // LEFT: bounded by x(85, 115) and y(95, 115)
-  it('PLACEMENT=left: inside', () => {
-    const mockEvents = [
-      {clientX: 85, clientY: 95},
-      {clientX: 115, clientY: 95},
-      {clientX: 85, clientY: 115},
-      {clientX: 115, clientY: 115},
-    ];
-
-    mockEvents.forEach(coords => {
-      expect(
-        isCursorOutsideInteractiveBorder('left', popperRect, coords, props),
-      ).toBe(false);
-    });
-  });
-
-  // LEFT: bounded by x(85, 115) and y(95, 115)
-  it('PLACEMENT=left: outside', () => {
-    const mockEvents = [
-      {clientX: 84, clientY: 94},
-      {clientX: 84, clientY: 116},
-      {clientX: 100, clientY: 94},
-      {clientX: 100, clientY: 116},
-      {clientX: 84, clientY: 100},
-      {clientX: 116, clientY: 100},
-    ];
-
-    mockEvents.forEach(coords => {
-      expect(
-        isCursorOutsideInteractiveBorder('left', popperRect, coords, props),
-      ).toBe(true);
-    });
-  });
-
-  // RIGHT: bounded by x(95, 125) and y(95, 115)
-  it('PLACEMENT=right: inside', () => {
-    const mockEvents = [
-      {clientX: 95, clientY: 95},
-      {clientX: 125, clientY: 95},
-      {clientX: 95, clientY: 115},
-      {clientX: 125, clientY: 115},
-    ];
-
-    mockEvents.forEach(coords => {
-      expect(
-        isCursorOutsideInteractiveBorder('right', popperRect, coords, props),
-      ).toBe(false);
-    });
-  });
-
-  // RIGHT: bounded by x(95, 125) and y(95, 115)
-  it('PLACEMENT=right: outside', () => {
-    const mockEvents = [
-      {clientX: 94, clientY: 94},
-      {clientX: 94, clientY: 126},
-      {clientX: 100, clientY: 94},
-      {clientX: 100, clientY: 126},
-      {clientX: 94, clientY: 100},
-      {clientX: 126, clientY: 100},
-    ];
-
-    mockEvents.forEach(coords => {
-      expect(
-        isCursorOutsideInteractiveBorder('right', popperRect, coords, props),
+        isCursorOutsideInteractiveBorder(popperRect, coords, interactiveBorder),
       ).toBe(true);
     });
   });


### PR DESCRIPTION
The prev technique had basically been implemented since v0 and hacks were added progressively to account for edge cases over versions, but it was never the right way to do it.

The new technique is to use padding on the popper element instead  of top/left offsets on tooltip for `distance`. So distance = `popper.style.padding`, instead of `tooltip.style.top` in px. 

This removes the need for an internal custom modifier to compute preventOverflow padding + flip padding, and reduces the complexity of `isCursorOutsideInteractiveBorder`, since the popperRect is accurate.

Updated FLIP demos to account for this (not a public API and super obscure what I was doing with it – so safe to change, & it doesn't really affect anything anyway)

Saves 0.2 kB gzipped