### PR TITLE
Add support for plugins in addons

### DIFF
--- a/src/addons/createSingleton.ts
+++ b/src/addons/createSingleton.ts
@@ -1,4 +1,4 @@
-import {Instance, Props} from '../types';
+import {Instance, Props, Plugin} from '../types';
 import tippy from '..';
 import {preserveInvocation, useIfDefined} from '../utils';
 import {defaultProps} from '../props';
@@ -11,6 +11,7 @@ import {throwErrorWhen} from '../validation';
 export default function createSingleton(
   tippyInstances: Instance[],
   optionalProps?: Partial<Props>,
+  plugins: Plugin[] = [],
 ): Instance {
   if (__DEV__) {
     throwErrorWhen(
@@ -57,7 +58,7 @@ export default function createSingleton(
 
   const references = tippyInstances.map(instance => instance.reference);
 
-  const singleton = tippy(document.createElement('div'), {
+  const props: Partial<Props> = {
     ...optionalProps,
     aria: null,
     triggerTarget: references,
@@ -133,7 +134,7 @@ export default function createSingleton(
         instance.enable();
       });
     },
-  }) as Instance;
+  };
 
-  return singleton;
+  return tippy(document.createElement('div'), props, plugins) as Instance;
 }

--- a/src/addons/delegate.ts
+++ b/src/addons/delegate.ts
@@ -1,4 +1,4 @@
-import {Targets, Instance, Props} from '../types';
+import {Targets, Instance, Props, Plugin} from '../types';
 import tippy from '..';
 import {throwErrorWhen} from '../validation';
 import {removeProperties, splitBySpaces} from '../utils';
@@ -18,6 +18,7 @@ interface ListenerObj {
 export default function delegate(
   targets: Targets,
   props: Partial<Props> & {target: string},
+  plugins: Plugin[] = [],
 ): Instance | Instance[] {
   if (__DEV__) {
     throwErrorWhen(
@@ -34,17 +35,22 @@ export default function delegate(
   const nativeProps = removeProperties(props, ['target']);
   const trigger = props.trigger || defaultProps.trigger;
 
-  const returnValue = tippy(targets, {...nativeProps, trigger: 'manual'});
+  const returnValue = tippy(
+    targets,
+    {...nativeProps, trigger: 'manual'},
+    plugins,
+  );
 
   function onTrigger(event: Event): void {
     if (event.target) {
       const targetNode = (event.target as Element).closest(target);
 
       if (targetNode) {
-        const instance = tippy(targetNode, {
-          ...nativeProps,
-          showOnCreate: true,
-        });
+        const instance = tippy(
+          targetNode,
+          {...nativeProps, showOnCreate: true},
+          plugins,
+        );
 
         if (instance) {
           childTippyInstances = childTippyInstances.concat(instance);

--- a/src/types.ts
+++ b/src/types.ts
@@ -154,14 +154,16 @@ declare const hideAll: HideAll;
 export type CreateTippyWithPlugins = (outerPlugins: Plugin[]) => Tippy;
 declare const createTippyWithPlugins: CreateTippyWithPlugins;
 
-export type Delegate = (
+export type Delegate<TProps = Props> = (
   targets: Targets,
-  props: Partial<Props> & {target: string},
+  props: Partial<TProps> & {target: string},
+  plugins?: Plugin[],
 ) => Instance | Instance[];
 
-export type CreateSingleton = (
+export type CreateSingleton<TProps = Props> = (
   tippyInstances: Instance[],
-  optionalProps?: Props,
+  optionalProps?: Partial<TProps>,
+  plugins?: Plugin[],
 ) => Instance;
 
 declare const delegate: Delegate;

--- a/test/integration/addons/createSingleton.test.js
+++ b/test/integration/addons/createSingleton.test.js
@@ -281,4 +281,11 @@ describe('createSingleton', () => {
       refs[0],
     );
   });
+
+  it('can accept plugins', () => {
+    const plugins = [{fn: () => ({})}];
+    const singletonInstance = createSingleton(tippy([h(), h()]), {}, plugins);
+
+    expect(singletonInstance.plugins).toEqual(plugins);
+  });
 });

--- a/test/integration/addons/delegate.test.js
+++ b/test/integration/addons/delegate.test.js
@@ -116,4 +116,15 @@ describe('delegate', () => {
 
     expect(button._tippy).toBeDefined();
   });
+
+  it('can accept plugins', () => {
+    const button = h('button');
+    const plugins = [{fn: () => ({})}];
+    const instance = delegate(document.body, {target: 'button'}, plugins);
+
+    button.dispatchEvent(new MouseEvent('mouseover', {bubbles: true}));
+
+    expect(instance.plugins).toEqual(plugins);
+    expect(button._tippy.plugins).toEqual(plugins);
+  });
 });


### PR DESCRIPTION
Allows ability to pass plugins as 3rd arg to addons, like `tippy()`

Fixes #588 

/cc @KubaJastrz for the types