### PR TITLE
Fix onWindowBlur activeElement broken condition

### DIFF
--- a/src/bindGlobalEventListeners.ts
+++ b/src/bindGlobalEventListeners.ts
@@ -1,4 +1,5 @@
 import {PASSIVE} from './constants';
+import {isReferenceElement} from './utils';
 
 export const currentInput = {isTouch: false};
 let lastMouseMoveTime = 0;
@@ -45,12 +46,12 @@ export function onDocumentMouseMove(): void {
  * TODO: find a better technique to solve this problem
  */
 export function onWindowBlur(): void {
-  const {activeElement}: {activeElement: any} = document;
+  const {activeElement} = document;
 
-  if (activeElement && activeElement.blur) {
-    const instance = activeElement._tippy;
+  if (isReferenceElement(activeElement)) {
+    const instance = activeElement._tippy!;
 
-    if (instance && !instance.state.isVisible) {
+    if (activeElement instanceof HTMLElement && !instance.state.isVisible) {
       activeElement.blur();
     }
   }

--- a/src/bindGlobalEventListeners.ts
+++ b/src/bindGlobalEventListeners.ts
@@ -46,15 +46,13 @@ export function onDocumentMouseMove(): void {
  */
 export function onWindowBlur(): void {
   const {activeElement}: {activeElement: any} = document;
-  const instance = activeElement._tippy;
 
-  if (
-    activeElement &&
-    activeElement.blur &&
-    instance &&
-    !instance.state.isVisible
-  ) {
-    activeElement.blur();
+  if (activeElement && activeElement.blur) {
+    const instance = activeElement._tippy;
+
+    if (instance && !instance.state.isVisible) {
+      activeElement.blur();
+    }
   }
 }
 

--- a/src/bindGlobalEventListeners.ts
+++ b/src/bindGlobalEventListeners.ts
@@ -46,12 +46,12 @@ export function onDocumentMouseMove(): void {
  * TODO: find a better technique to solve this problem
  */
 export function onWindowBlur(): void {
-  const {activeElement} = document;
+  const activeElement = document.activeElement as HTMLElement | null;
 
   if (isReferenceElement(activeElement)) {
     const instance = activeElement._tippy!;
 
-    if (activeElement instanceof HTMLElement && !instance.state.isVisible) {
+    if (activeElement.blur && !instance.state.isVisible) {
       activeElement.blur();
     }
   }


### PR DESCRIPTION
Access to the properties of `activeElement` occurs before condition, which leads to an error.
For example, error in IE11: `Unable to get property '_tippy' of undefined or null reference`.

## What I did
I changed the condition, moved access to the `activeElement` properties after condition.