### PR TITLE
chore: use modern travis configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,5 @@
-dist: trusty
-sudo: false
+dist: xenial
 language: node_js
 node_js:
-  - "8"
-before_script:
-  - "export DISPLAY=:99.0"
-  - "sh -e /etc/init.d/xvfb start"
-  - sleep 3
+  - 8
+  - lts/*


### PR DESCRIPTION
- use `xenial` linux that doesn't need `before_script` config 
- remove deprecated `sudo: false`
- test on `8` and `lts` node versions, we can switch to v10 once [v8 is end-of-life (2020)](https://nodejs.org/en/about/releases/)