### PR TITLE
chore: use `dom-testing-library` for testing events

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2015,6 +2015,26 @@
         "any-observable": "^0.3.0"
       }
     },
+    "@sheerun/mutationobserver-shim": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/@sheerun/mutationobserver-shim/-/mutationobserver-shim-0.3.2.tgz",
+      "integrity": "sha512-vTCdPp/T/Q3oSqwHmZ5Kpa9oI7iLtGl3RQaA/NyLHikvcrPxACkkKVr/XzkSPJWXHRhKGzVvb0urJsbMlRxi1Q==",
+      "dev": true
+    },
+    "@testing-library/dom": {
+      "version": "6.8.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-6.8.1.tgz",
+      "integrity": "sha512-b+Q4wryafqsSTFBV14cc5xqhN/OVB9oMeUQvZwy1kVx+kdqs4zQAcyvCsFkdcqx7NxibWpUN/fBIUaqyAEhitw==",
+      "dev": true,
+      "requires": {
+        "@babel/runtime": "^7.6.2",
+        "@sheerun/mutationobserver-shim": "^0.3.2",
+        "@types/testing-library__dom": "^6.0.0",
+        "aria-query": "3.0.0",
+        "pretty-format": "^24.9.0",
+        "wait-for-expect": "^3.0.0"
+      }
+    },
     "@types/babel__core": {
       "version": "7.1.2",
       "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.1.2.tgz",
@@ -2154,6 +2174,15 @@
       "resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-1.0.1.tgz",
       "integrity": "sha512-l42BggppR6zLmpfU6fq9HEa2oGPEI8yrSPL3GITjfRInppYFahObbIQOQK3UGxEnyQpltZLaPe75046NOZQikw==",
       "dev": true
+    },
+    "@types/testing-library__dom": {
+      "version": "6.5.3",
+      "resolved": "https://registry.npmjs.org/@types/testing-library__dom/-/testing-library__dom-6.5.3.tgz",
+      "integrity": "sha512-E/LSnbzo25gCLy/YOHKY9KJ+rfI8hy5cfbScyZqVuFw9CUMn1faWEDnxMcVHgjAbWtTStfllB8TwNKCx8bAKeA==",
+      "dev": true,
+      "requires": {
+        "pretty-format": "^24.3.0"
+      }
     },
     "@types/yargs": {
       "version": "12.0.12",
@@ -2524,6 +2553,16 @@
         "sprintf-js": "~1.0.2"
       }
     },
+    "aria-query": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-3.0.0.tgz",
+      "integrity": "sha1-ZbP8wcoRVajJrmTW7uKX8V1RM8w=",
+      "dev": true,
+      "requires": {
+        "ast-types-flow": "0.0.7",
+        "commander": "^2.11.0"
+      }
+    },
     "arr-diff": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-4.0.0.tgz",
@@ -2629,6 +2668,12 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/assign-symbols/-/assign-symbols-1.0.0.tgz",
       "integrity": "sha1-WWZ/QfrdTyDMvCu5a41Pf3jsA2c=",
+      "dev": true
+    },
+    "ast-types-flow": {
+      "version": "0.0.7",
+      "resolved": "https://registry.npmjs.org/ast-types-flow/-/ast-types-flow-0.0.7.tgz",
+      "integrity": "sha1-9wtzXGvKGlycItmCw+Oef+ujva0=",
       "dev": true
     },
     "astral-regex": {
@@ -14666,6 +14711,12 @@
         "webidl-conversions": "^4.0.2",
         "xml-name-validator": "^3.0.0"
       }
+    },
+    "wait-for-expect": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/wait-for-expect/-/wait-for-expect-3.0.0.tgz",
+      "integrity": "sha512-9LyJL+MugZdcQn5V9PBSEC4d2UPTy1xX2U9wTc6LvG/18qeeYqdE/CgmAQJxc/Vcjs+VzH+wiyIXxz05F3nrpQ==",
+      "dev": true
     },
     "walker": {
       "version": "1.0.7",

--- a/package.json
+++ b/package.json
@@ -101,6 +101,7 @@
     "@babel/plugin-transform-template-literals": "^7.4.4",
     "@babel/preset-env": "^7.5.5",
     "@babel/preset-typescript": "^7.3.3",
+    "@testing-library/dom": "^6.8.1",
     "@types/node": "^12.7.2",
     "@typescript-eslint/eslint-plugin": "^2.0.0",
     "@typescript-eslint/parser": "^2.0.0",

--- a/test/integration/addons/createSingleton.test.js
+++ b/test/integration/addons/createSingleton.test.js
@@ -1,10 +1,5 @@
-import {
-  h,
-  cleanDocumentBody,
-  MOUSEENTER,
-  MOUSELEAVE,
-  setTestDefaultProps,
-} from '../../utils';
+import {fireEvent} from '@testing-library/dom';
+import {h, cleanDocumentBody, setTestDefaultProps} from '../../utils';
 
 import createSingleton from '../../../src/addons/createSingleton';
 import tippy from '../../../src';
@@ -20,7 +15,7 @@ describe('createSingleton', () => {
     const refs = [h(), h()];
     const singletonInstance = createSingleton(tippy(refs));
 
-    refs[0].dispatchEvent(MOUSEENTER);
+    fireEvent.mouseEnter(refs[0]);
 
     jest.runAllTimers();
 
@@ -33,7 +28,7 @@ describe('createSingleton', () => {
 
     createSingleton(tippy(refs));
 
-    firstRef.dispatchEvent(MOUSEENTER);
+    fireEvent.mouseEnter(firstRef);
 
     jest.runAllTimers();
 
@@ -45,12 +40,12 @@ describe('createSingleton', () => {
     const instances = configs.map(props => tippy(h(), props));
     const singletonInstance = createSingleton(instances);
 
-    instances[0].reference.dispatchEvent(MOUSEENTER);
+    fireEvent.mouseEnter(instances[0].reference);
 
     expect(singletonInstance.props.content).toBe('hi');
 
-    instances[0].reference.dispatchEvent(MOUSELEAVE);
-    instances[1].reference.dispatchEvent(MOUSEENTER);
+    fireEvent.mouseLeave(instances[0].reference);
+    fireEvent.mouseEnter(instances[1].reference);
 
     expect(singletonInstance.props.content).toBe('bye');
   });
@@ -60,7 +55,7 @@ describe('createSingleton', () => {
     const singletonInstance = createSingleton(tippy(refs), {delay: 1000});
     const firstRef = refs[0];
 
-    firstRef.dispatchEvent(MOUSEENTER);
+    fireEvent.mouseEnter(firstRef);
     jest.advanceTimersByTime(999);
 
     expect(singletonInstance.state.isVisible).toBe(false);
@@ -69,7 +64,7 @@ describe('createSingleton', () => {
 
     expect(singletonInstance.state.isVisible).toBe(true);
 
-    firstRef.dispatchEvent(MOUSELEAVE);
+    fireEvent.mouseLeave(firstRef);
     jest.advanceTimersByTime(999);
 
     expect(singletonInstance.state.isVisible).toBe(true);
@@ -86,7 +81,7 @@ describe('createSingleton', () => {
     });
     const firstRef = refs[0];
 
-    firstRef.dispatchEvent(MOUSEENTER);
+    fireEvent.mouseEnter(firstRef);
     jest.advanceTimersByTime(499);
 
     expect(singletonInstance.state.isVisible).toBe(false);
@@ -95,7 +90,7 @@ describe('createSingleton', () => {
 
     expect(singletonInstance.state.isVisible).toBe(true);
 
-    firstRef.dispatchEvent(MOUSELEAVE);
+    fireEvent.mouseLeave(firstRef);
     jest.advanceTimersByTime(999);
 
     expect(singletonInstance.state.isVisible).toBe(true);
@@ -138,7 +133,7 @@ describe('createSingleton', () => {
       onAfterUpdate: onAfterUpdateSpy,
     });
 
-    instances[0].reference.dispatchEvent(MOUSEENTER);
+    fireEvent.mouseEnter(instances[0].reference);
 
     expect(onTriggerSpy).toHaveBeenCalled();
 
@@ -166,7 +161,7 @@ describe('createSingleton', () => {
       onAfterUpdate: onAfterUpdateSpy,
     });
 
-    instances[0].reference.dispatchEvent(MOUSEENTER);
+    fireEvent.mouseEnter(instances[0].reference);
 
     expect(onTriggerSpy).toHaveBeenCalled();
 
@@ -186,7 +181,7 @@ describe('createSingleton', () => {
 
     singletonInstance.setProps({delay: 500});
 
-    firstRef.dispatchEvent(MOUSEENTER);
+    fireEvent.mouseEnter(firstRef);
     jest.advanceTimersByTime(499);
 
     expect(singletonInstance.state.isVisible).toBe(false);
@@ -195,7 +190,7 @@ describe('createSingleton', () => {
 
     expect(singletonInstance.state.isVisible).toBe(true);
 
-    firstRef.dispatchEvent(MOUSELEAVE);
+    fireEvent.mouseLeave(firstRef);
     jest.advanceTimersByTime(499);
 
     expect(singletonInstance.state.isVisible).toBe(true);
@@ -223,7 +218,7 @@ describe('createSingleton', () => {
 
     createSingleton(tippyInstances);
 
-    instance.reference.dispatchEvent(MOUSEENTER);
+    fireEvent.mouseEnter(instance.reference);
 
     jest.runAllTimers();
   });
@@ -245,27 +240,27 @@ describe('createSingleton', () => {
     const singletonInstance = createSingleton(tippyInstances, {delay: 100});
 
     const id = singletonInstance.popperChildren.tooltip.id;
-    const {reference: firstReference} = tippyInstances[0];
-    const {reference: secondReference} = tippyInstances[1];
+    const {reference: firstRef} = tippyInstances[0];
+    const {reference: secondRef} = tippyInstances[1];
 
-    firstReference.dispatchEvent(MOUSEENTER);
+    fireEvent.mouseEnter(firstRef);
     jest.runAllTimers();
 
-    expect(firstReference.getAttribute('aria-describedby')).toBe(id);
+    expect(firstRef.getAttribute('aria-describedby')).toBe(id);
 
-    firstReference.dispatchEvent(MOUSELEAVE);
-    secondReference.dispatchEvent(MOUSEENTER);
+    fireEvent.mouseLeave(firstRef);
+    fireEvent.mouseEnter(secondRef);
 
-    expect(firstReference.getAttribute('aria-describedby')).toBe(null);
-    expect(secondReference.getAttribute('aria-describedby')).toBe(id);
+    expect(firstRef.getAttribute('aria-describedby')).toBe(null);
+    expect(secondRef.getAttribute('aria-describedby')).toBe(id);
 
     singletonInstance.setProps({aria: null});
 
-    secondReference.dispatchEvent(MOUSELEAVE);
-    firstReference.dispatchEvent(MOUSEENTER);
+    fireEvent.mouseLeave(secondRef);
+    fireEvent.mouseEnter(firstRef);
 
-    expect(firstReference.getAttribute('aria-describedby')).toBe(null);
-    expect(secondReference.getAttribute('aria-describedby')).toBe(null);
+    expect(firstRef.getAttribute('aria-describedby')).toBe(null);
+    expect(secondRef.getAttribute('aria-describedby')).toBe(null);
   });
 
   it('specifying lifecycle hook does not override internal hooks', () => {
@@ -274,7 +269,7 @@ describe('createSingleton', () => {
       onTrigger() {},
     });
 
-    refs[0].dispatchEvent(MOUSEENTER);
+    fireEvent.mouseEnter(refs[0]);
     jest.runAllTimers();
 
     expect(singletonInstance.popperInstance.reference.referenceNode).toBe(

--- a/test/integration/addons/delegate.test.js
+++ b/test/integration/addons/delegate.test.js
@@ -1,4 +1,5 @@
-import {h, cleanDocumentBody, MOUSEENTER, CLICK} from '../../utils';
+import {fireEvent} from '@testing-library/dom';
+import {h, cleanDocumentBody} from '../../utils';
 
 import tippy from '../../../src';
 import delegate from '../../../src/addons/delegate';
@@ -25,7 +26,7 @@ describe('delegate', () => {
 
     expect(button._tippy).toBeUndefined();
 
-    button.dispatchEvent(new MouseEvent('mouseover', {bubbles: true}));
+    fireEvent.mouseOver(button);
 
     expect(button._tippy).toBeDefined();
 
@@ -41,7 +42,7 @@ describe('delegate', () => {
 
     expect(button._tippy).toBeUndefined();
 
-    button.dispatchEvent(CLICK);
+    fireEvent.click(button);
 
     expect(button._tippy).toBeDefined();
 
@@ -58,7 +59,7 @@ describe('delegate', () => {
 
     expect(button._tippy).toBeUndefined();
 
-    button.dispatchEvent(new MouseEvent('mouseover', {bubbles: true}));
+    fireEvent.mouseOver(button);
 
     expect(button._tippy).toBeDefined();
 
@@ -68,8 +69,8 @@ describe('delegate', () => {
   it('does not show its own tippy', () => {
     instance = delegate(document.body, {target: 'button'});
 
-    document.body.dispatchEvent(new MouseEvent('mouseover', {bubbles: true}));
-    document.body.dispatchEvent(MOUSEENTER);
+    fireEvent.mouseOver(document.body);
+    fireEvent.mouseEnter(document.body);
 
     jest.runAllTimers();
 
@@ -101,7 +102,7 @@ describe('delegate', () => {
     instance = delegate(document.body, {target: 'button'});
 
     instance.destroy();
-    button.dispatchEvent(new MouseEvent('mouseover', {bubbles: true}));
+    fireEvent.mouseOver(button);
 
     expect(button._tippy).toBeUndefined();
   });
@@ -110,7 +111,7 @@ describe('delegate', () => {
     const button = h('button');
     instance = delegate(document.body, {target: 'button'});
 
-    button.dispatchEvent(new MouseEvent('mouseover', {bubbles: true}));
+    fireEvent.mouseOver(button);
     instance.destroy();
 
     expect(button._tippy).toBeUndefined();
@@ -120,7 +121,7 @@ describe('delegate', () => {
     const button = h('button');
     instance = delegate(document.body, {target: 'button'});
 
-    button.dispatchEvent(new MouseEvent('mouseover', {bubbles: true}));
+    fireEvent.mouseOver(button);
     instance.destroy(false);
 
     expect(button._tippy).toBeDefined();
@@ -131,7 +132,7 @@ describe('delegate', () => {
     const plugins = [{fn: () => ({})}];
     instance = delegate(document.body, {target: 'button'}, plugins);
 
-    button.dispatchEvent(new MouseEvent('mouseover', {bubbles: true}));
+    fireEvent.mouseOver(button);
 
     expect(instance.plugins).toEqual(plugins);
     expect(button._tippy.plugins).toEqual(plugins);
@@ -146,16 +147,16 @@ describe('delegate', () => {
       trigger: 'mouseenter',
     });
 
-    clickButton.dispatchEvent(new MouseEvent('mouseover', {bubbles: true}));
+    fireEvent.mouseOver(clickButton);
     expect(clickButton._tippy).toBeUndefined();
 
-    clickButton.dispatchEvent(new MouseEvent('click', {bubbles: true}));
+    fireEvent.click(clickButton);
     expect(clickButton._tippy).toBeDefined();
 
-    focusButton.dispatchEvent(new MouseEvent('mouseover', {bubbles: true}));
+    fireEvent.mouseOver(focusButton);
     expect(focusButton._tippy).toBeUndefined();
 
-    focusButton.dispatchEvent(new FocusEvent('focusin', {bubbles: true}));
+    fireEvent.focusIn(focusButton);
     expect(focusButton._tippy).toBeDefined();
   });
 });

--- a/test/integration/createTippy.test.js
+++ b/test/integration/createTippy.test.js
@@ -1,11 +1,7 @@
+import {fireEvent} from '@testing-library/dom';
 import {
   h,
   cleanDocumentBody,
-  MOUSEENTER,
-  BLUR,
-  FOCUS,
-  MOUSELEAVE,
-  CLICK,
   setTestDefaultProps,
   enableTouchEnvironment,
   disableTouchEnvironment,
@@ -74,22 +70,22 @@ describe('createTippy', () => {
       trigger: 'mouseenter focus click',
     });
 
-    instance.reference.dispatchEvent(MOUSEENTER);
+    fireEvent.mouseEnter(instance.reference);
     expect(instance.state.isVisible).toBe(true);
 
-    instance.reference.dispatchEvent(MOUSELEAVE);
+    fireEvent.mouseLeave(instance.reference);
     expect(instance.state.isVisible).toBe(false);
 
-    instance.reference.dispatchEvent(FOCUS);
+    fireEvent.focus(instance.reference);
     expect(instance.state.isVisible).toBe(true);
 
-    instance.reference.dispatchEvent(BLUR);
+    fireEvent.blur(instance.reference);
     expect(instance.state.isVisible).toBe(false);
 
-    instance.reference.dispatchEvent(CLICK);
+    fireEvent.click(instance.reference);
     expect(instance.state.isVisible).toBe(true);
 
-    instance.reference.dispatchEvent(CLICK);
+    fireEvent.click(instance.reference);
     expect(instance.state.isVisible).toBe(false);
   });
 
@@ -128,7 +124,7 @@ describe('instance.destroy()', () => {
     });
 
     instance.destroy();
-    ref.dispatchEvent(new Event('mouseenter'));
+    fireEvent.mouseEnter(ref);
 
     expect(instance.state.isVisible).toBe(false);
   });
@@ -172,7 +168,7 @@ describe('instance.destroy()', () => {
     // show() will warn about memory leak
     const spy = jest.spyOn(console, 'warn');
 
-    instance.reference.dispatchEvent(MOUSEENTER);
+    fireEvent.mouseEnter(instance.reference);
 
     instance.destroy();
 
@@ -420,11 +416,11 @@ describe('instance.setProps()', () => {
     instance = createTippy(ref, defaultProps);
 
     instance.setProps({trigger: 'click'});
-    ref.dispatchEvent(MOUSEENTER);
+    fireEvent.mouseEnter(ref);
 
     expect(instance.state.isVisible).toBe(false);
 
-    ref.dispatchEvent(CLICK);
+    fireEvent.click(ref);
     expect(instance.state.isVisible).toBe(true);
   });
 

--- a/test/integration/plugins/followCursor.test.js
+++ b/test/integration/plugins/followCursor.test.js
@@ -1,3 +1,4 @@
+import {fireEvent} from '@testing-library/dom';
 import {
   h,
   cleanDocumentBody,
@@ -20,20 +21,10 @@ afterEach(cleanDocumentBody);
 describe('followCursor', () => {
   // NOTE: Jest's simulated window dimensions are 1024 x 768. These values
   // should be within that
-  const mouseenter = new MouseEvent('mouseenter', {clientX: 1, clientY: 1});
-  const mouseleave = new MouseEvent('mouseleave', {clientX: 1, clientY: 1});
+  const defaultPosition = {clientX: 1, clientY: 1};
 
   const first = {clientX: 317, clientY: 119};
   const second = {clientX: 240, clientY: 500};
-
-  const firstMouseMoveEvent = new MouseEvent('mousemove', {
-    ...first,
-    bubbles: true,
-  });
-  const secondMouseMoveEvent = new MouseEvent('mousemove', {
-    ...second,
-    bubbles: true,
-  });
 
   const placements = ['top', 'bottom', 'left', 'right'];
 
@@ -60,11 +51,11 @@ describe('followCursor', () => {
     placements.forEach(placement => {
       instance = tippy(h(), {followCursor: true, placement});
 
-      instance.reference.dispatchEvent(mouseenter);
+      fireEvent.mouseEnter(instance.reference, defaultPosition);
 
       jest.runAllTimers();
 
-      instance.reference.dispatchEvent(firstMouseMoveEvent);
+      fireEvent.mouseMove(instance.reference, first);
       rect = instance.popperInstance.reference.getBoundingClientRect();
       matches({
         top: first.clientY,
@@ -73,7 +64,7 @@ describe('followCursor', () => {
         right: first.clientX,
       });
 
-      instance.reference.dispatchEvent(secondMouseMoveEvent);
+      fireEvent.mouseMove(instance.reference, second);
       rect = instance.popperInstance.reference.getBoundingClientRect();
       matches({
         top: second.clientY,
@@ -92,11 +83,11 @@ describe('followCursor', () => {
       });
       const referenceRect = instance.reference.getBoundingClientRect();
 
-      instance.reference.dispatchEvent(mouseenter);
+      fireEvent.mouseEnter(instance.reference, defaultPosition);
 
       jest.runAllTimers();
 
-      instance.reference.dispatchEvent(firstMouseMoveEvent);
+      fireEvent.mouseMove(instance.reference, first);
       rect = instance.popperInstance.reference.getBoundingClientRect();
 
       matches({
@@ -106,7 +97,7 @@ describe('followCursor', () => {
         right: first.clientX,
       });
 
-      instance.reference.dispatchEvent(secondMouseMoveEvent);
+      fireEvent.mouseMove(instance.reference, second);
       rect = instance.popperInstance.reference.getBoundingClientRect();
       matches({
         top: referenceRect.top,
@@ -122,11 +113,11 @@ describe('followCursor', () => {
       instance = tippy(h(), {followCursor: 'vertical', placement});
       const referenceRect = instance.reference.getBoundingClientRect();
 
-      instance.reference.dispatchEvent(mouseenter);
+      fireEvent.mouseEnter(instance.reference, defaultPosition);
 
       jest.runAllTimers();
 
-      instance.reference.dispatchEvent(firstMouseMoveEvent);
+      fireEvent.mouseMove(instance.reference, first);
       rect = instance.popperInstance.reference.getBoundingClientRect();
       matches({
         top: first.clientY,
@@ -135,7 +126,7 @@ describe('followCursor', () => {
         right: referenceRect.right,
       });
 
-      instance.reference.dispatchEvent(secondMouseMoveEvent);
+      fireEvent.mouseMove(instance.reference, second);
       rect = instance.popperInstance.reference.getBoundingClientRect();
       matches({
         top: second.clientY,
@@ -157,7 +148,7 @@ describe('followCursor', () => {
 
       jest.runAllTimers();
 
-      instance.reference.dispatchEvent(firstMouseMoveEvent);
+      fireEvent.mouseMove(instance.reference, first);
       rect = instance.popperInstance.reference.getBoundingClientRect();
       matches({
         top: first.clientY,
@@ -166,7 +157,7 @@ describe('followCursor', () => {
         right: first.clientX,
       });
 
-      instance.reference.dispatchEvent(secondMouseMoveEvent);
+      fireEvent.mouseMove(instance.reference, second);
       rect = instance.popperInstance.reference.getBoundingClientRect();
       matches({
         top: first.clientY,
@@ -180,11 +171,11 @@ describe('followCursor', () => {
   it('is at correct position after a delay', () => {
     instance = tippy(h(), {followCursor: true, delay: 100});
 
-    instance.reference.dispatchEvent(mouseenter);
+    fireEvent.mouseEnter(instance.reference, defaultPosition);
 
     jest.runAllTimers();
 
-    instance.reference.dispatchEvent(firstMouseMoveEvent);
+    fireEvent.mouseMove(instance.reference, first);
 
     jest.advanceTimersByTime(100);
 
@@ -200,11 +191,11 @@ describe('followCursor', () => {
   it('is at correct position after a content update', () => {
     instance = tippy(h(), {followCursor: true});
 
-    instance.reference.dispatchEvent(mouseenter);
+    fireEvent.mouseEnter(instance.reference, defaultPosition);
 
     jest.runAllTimers();
 
-    instance.reference.dispatchEvent(firstMouseMoveEvent);
+    fireEvent.mouseMove(instance.reference, first);
 
     rect = instance.popperInstance.reference.getBoundingClientRect();
     matches({
@@ -233,16 +224,16 @@ describe('followCursor', () => {
       interactive: true,
     });
 
-    instance.reference.dispatchEvent(mouseenter);
+    fireEvent.mouseEnter(instance.reference, defaultPosition);
 
     jest.runAllTimers();
 
-    instance.reference.dispatchEvent(firstMouseMoveEvent);
+    fireEvent.mouseMove(instance.reference, first);
 
     const referenceRect = instance.reference.getBoundingClientRect();
     rect = instance.popperInstance.reference.getBoundingClientRect();
 
-    instance.reference.dispatchEvent(secondMouseMoveEvent);
+    fireEvent.mouseMove(instance.reference, second);
 
     matches({
       top: referenceRect.top,
@@ -257,11 +248,11 @@ describe('followCursor', () => {
 
     instance = tippy(h(), {followCursor: true, flip: false});
 
-    instance.reference.dispatchEvent(new MouseEvent('mouseenter', {...first}));
+    fireEvent.mouseEnter(instance.reference, first);
 
     jest.runAllTimers();
 
-    instance.reference.dispatchEvent(firstMouseMoveEvent);
+    fireEvent.mouseMove(instance.reference, first);
     rect = instance.popperInstance.reference.getBoundingClientRect();
     matches({
       top: first.clientY,
@@ -270,7 +261,7 @@ describe('followCursor', () => {
       right: first.clientX,
     });
 
-    instance.reference.dispatchEvent(secondMouseMoveEvent);
+    fireEvent.mouseMove(instance.reference, second);
     rect = instance.popperInstance.reference.getBoundingClientRect();
     matches({
       top: first.clientY,
@@ -289,16 +280,16 @@ describe('followCursor', () => {
       delay: 1000,
     });
 
-    instance.reference.dispatchEvent(mouseenter);
+    fireEvent.mouseEnter(instance.reference, defaultPosition);
 
     jest.advanceTimersByTime(100);
 
-    instance.reference.dispatchEvent(firstMouseMoveEvent);
-    instance.reference.dispatchEvent(new MouseEvent('mouseleave'));
+    fireEvent.mouseMove(instance.reference, first);
+    fireEvent.mouseLeave(instance.reference);
 
     jest.advanceTimersByTime(900);
 
-    instance.reference.dispatchEvent(secondMouseMoveEvent);
+    fireEvent.mouseMove(instance.reference, second);
 
     rect = instance.popperInstance.reference.getBoundingClientRect();
   });
@@ -310,18 +301,18 @@ describe('followCursor', () => {
       delay: 1000,
     });
 
-    instance.reference.dispatchEvent(mouseenter);
+    fireEvent.mouseEnter(instance.reference, defaultPosition);
 
     jest.runAllTimers();
 
-    instance.reference.dispatchEvent(firstMouseMoveEvent);
-    instance.reference.dispatchEvent(new MouseEvent('mouseleave'));
+    fireEvent.mouseMove(instance.reference, first);
+    fireEvent.mouseLeave(instance.reference);
 
-    instance.reference.dispatchEvent(secondMouseMoveEvent);
+    fireEvent.mouseMove(instance.reference, second);
 
     instance.hide();
 
-    instance.reference.dispatchEvent(new FocusEvent('focus'));
+    fireEvent.focus(instance.reference);
 
     expect(instance.popperInstance.reference).toBe(instance.reference);
   });
@@ -331,11 +322,11 @@ describe('followCursor', () => {
       followCursor: 'initial',
     });
 
-    instance.reference.dispatchEvent(new MouseEvent('mouseenter', {...first}));
+    fireEvent.mouseEnter(instance.reference, first);
 
     jest.runAllTimers();
 
-    instance.reference.dispatchEvent(secondMouseMoveEvent);
+    fireEvent.mouseMove(instance.reference, second);
 
     rect = instance.popperInstance.reference.getBoundingClientRect();
 
@@ -353,7 +344,7 @@ describe('followCursor', () => {
       followCursor: true,
     });
 
-    instance.reference.dispatchEvent(mouseenter);
+    fireEvent.mouseEnter(instance.reference, defaultPosition);
     jest.runAllTimers();
 
     expect(instance.props.placement).toBe('top-end');
@@ -364,8 +355,8 @@ describe('followCursor', () => {
 
     instance.setProps({followCursor: false});
 
-    instance.reference.dispatchEvent(mouseleave);
-    instance.reference.dispatchEvent(mouseenter);
+    fireEvent.mouseLeave(instance.reference, defaultPosition);
+    fireEvent.mouseEnter(instance.reference, defaultPosition);
     jest.runAllTimers();
 
     expect(instance.props.placement).toBe('left-end');
@@ -376,7 +367,7 @@ describe('followCursor', () => {
       followCursor: true,
     });
 
-    instance.reference.dispatchEvent(new MouseEvent('mouseenter'));
+    fireEvent.mouseEnter(instance.reference);
     jest.runAllTimers();
 
     expect(instance.popperInstance.reference).toBe(instance.reference);
@@ -387,7 +378,7 @@ describe('followCursor', () => {
       followCursor: true,
     });
 
-    instance.reference.dispatchEvent(mouseenter);
+    fireEvent.mouseEnter(instance.reference, defaultPosition);
     jest.runAllTimers();
 
     expect(instance.popperInstance.state.eventsEnabled).toBe(true);
@@ -398,7 +389,7 @@ describe('followCursor', () => {
       followCursor: false,
     });
 
-    instance.reference.dispatchEvent(mouseenter);
+    fireEvent.mouseEnter(instance.reference, defaultPosition);
     jest.runAllTimers();
 
     expect(instance.popperInstance.state.eventsEnabled).toBe(true);
@@ -409,7 +400,7 @@ describe('followCursor', () => {
       followCursor: 'initial',
     });
 
-    instance.reference.dispatchEvent(mouseenter);
+    fireEvent.mouseEnter(instance.reference, defaultPosition);
     jest.runAllTimers();
 
     expect(instance.popperInstance.state.eventsEnabled).toBe(false);
@@ -420,7 +411,7 @@ describe('followCursor', () => {
       followCursor: 'horizontal',
     });
 
-    instance.reference.dispatchEvent(mouseenter);
+    fireEvent.mouseEnter(instance.reference, defaultPosition);
     jest.runAllTimers();
 
     expect(instance.popperInstance.state.eventsEnabled).toBe(false);
@@ -431,7 +422,7 @@ describe('followCursor', () => {
       followCursor: 'vertical',
     });
 
-    instance.reference.dispatchEvent(mouseenter);
+    fireEvent.mouseEnter(instance.reference, defaultPosition);
     jest.runAllTimers();
 
     expect(instance.popperInstance.state.eventsEnabled).toBe(false);
@@ -446,7 +437,7 @@ describe('followCursor', () => {
     instance.show();
     jest.runAllTimers();
 
-    document.dispatchEvent(firstMouseMoveEvent);
+    fireEvent.mouseMove(document, first);
 
     rect = instance.popperInstance.reference.getBoundingClientRect();
     matches({

--- a/test/integration/plugins/inlinePositioning.test.js
+++ b/test/integration/plugins/inlinePositioning.test.js
@@ -1,9 +1,5 @@
-import {
-  h,
-  cleanDocumentBody,
-  MOUSEENTER,
-  setTestDefaultProps,
-} from '../../utils';
+import {fireEvent} from '@testing-library/dom';
+import {h, cleanDocumentBody, setTestDefaultProps} from '../../utils';
 
 import tippy from '../../../src';
 import inlinePositioning, {
@@ -27,7 +23,7 @@ describe('inlinePositioning', () => {
       },
     });
 
-    instance.reference.dispatchEvent(MOUSEENTER);
+    fireEvent.mouseEnter(instance.reference);
     jest.runAllTimers();
   });
 
@@ -39,7 +35,7 @@ describe('inlinePositioning', () => {
       },
     });
 
-    instance.reference.dispatchEvent(MOUSEENTER);
+    fireEvent.mouseEnter(instance.reference);
     jest.runAllTimers();
   });
 
@@ -50,7 +46,7 @@ describe('inlinePositioning', () => {
       },
     });
 
-    instance.reference.dispatchEvent(MOUSEENTER);
+    fireEvent.mouseEnter(instance.reference);
     jest.runAllTimers();
     instance.hide();
   });

--- a/test/integration/props.test.js
+++ b/test/integration/props.test.js
@@ -1,17 +1,10 @@
+import {fireEvent} from '@testing-library/dom';
 import {
   h,
   cleanDocumentBody,
   withTestProps,
   enableTouchEnvironment,
   disableTouchEnvironment,
-  MOUSEENTER,
-  MOUSELEAVE,
-  FOCUS,
-  TOUCHEND,
-  TOUCHSTART,
-  MOUSEDOWN,
-  CLICK,
-  BLUR,
   setTestDefaultProps,
 } from '../utils';
 
@@ -123,7 +116,7 @@ describe('delay', () => {
       delay,
     });
 
-    ref.dispatchEvent(MOUSEENTER);
+    fireEvent.mouseEnter(ref);
 
     expect(state.isVisible).toBe(false);
 
@@ -139,11 +132,11 @@ describe('delay', () => {
       delay,
     });
 
-    instance.reference.dispatchEvent(MOUSEENTER);
+    fireEvent.mouseEnter(instance.reference);
 
     jest.advanceTimersByTime(delay);
 
-    instance.reference.dispatchEvent(MOUSELEAVE);
+    fireEvent.mouseLeave(instance.reference);
 
     expect(instance.state.isVisible).toBe(true);
 
@@ -156,7 +149,7 @@ describe('delay', () => {
     const delay = [20, 100];
     const instance = tippy(h(), {trigger: 'mouseenter', delay});
 
-    instance.reference.dispatchEvent(new Event('mouseenter'));
+    fireEvent.mouseEnter(instance.reference);
 
     expect(instance.state.isVisible).toBe(false);
 
@@ -169,7 +162,7 @@ describe('delay', () => {
     const delay = [100, 20];
     const instance = tippy(h(), {trigger: 'mouseenter', delay});
 
-    instance.reference.dispatchEvent(MOUSEENTER);
+    fireEvent.mouseEnter(instance.reference);
 
     expect(instance.state.isVisible).toBe(false);
 
@@ -177,7 +170,7 @@ describe('delay', () => {
 
     expect(instance.state.isVisible).toBe(true);
 
-    instance.reference.dispatchEvent(new Event('mouseleave'));
+    fireEvent.mouseLeave(instance.reference);
     jest.advanceTimersByTime(delay[1]);
 
     expect(instance.state.isVisible).toBe(false);
@@ -188,7 +181,7 @@ describe('delay', () => {
 
     const instance = tippy(h(), {delay: 100});
 
-    instance.reference.dispatchEvent(MOUSEENTER);
+    fireEvent.mouseEnter(instance.reference);
 
     expect(instance.state.isVisible).toBe(true);
 
@@ -198,48 +191,42 @@ describe('delay', () => {
   it('is 0 in keyboard context', () => {
     const instance = tippy(h(), {delay: 100});
 
-    instance.reference.dispatchEvent(FOCUS);
+    fireEvent.focus(instance.reference);
 
     expect(instance.state.isVisible).toBe(true);
   });
 
   it('instance does not hide if cursor returned after leaving before delay finished', () => {
     const instance = tippy(h(), {delay: 100, interactive: true});
-    instance.reference.dispatchEvent(MOUSEENTER);
+    fireEvent.mouseEnter(instance.reference);
 
     jest.advanceTimersByTime(100);
 
-    instance.popper.dispatchEvent(MOUSELEAVE);
-    document.body.dispatchEvent(
-      new MouseEvent('mousemove', {
-        bubbles: true,
-        clientX: 1000,
-        clientY: 1000,
-      }),
-    );
+    fireEvent.mouseLeave(instance.popper);
+    fireEvent.mouseMove(document.body, {
+      clientX: 1000,
+      clientY: 1000,
+    });
 
     expect(instance.state.isVisible).toBe(true);
 
     jest.advanceTimersByTime(99);
 
-    instance.popper.dispatchEvent(MOUSEENTER);
+    fireEvent.mouseEnter(instance.popper);
 
     jest.advanceTimersByTime(1);
 
     expect(instance.state.isVisible).toBe(true);
 
-    instance.popper.dispatchEvent(MOUSELEAVE);
-    document.body.dispatchEvent(
-      new MouseEvent('mousemove', {
-        bubbles: true,
-        clientX: 1000,
-        clientY: 1000,
-      }),
-    );
+    fireEvent.mouseLeave(instance.popper);
+    fireEvent.mouseMove(document.body, {
+      clientX: 1000,
+      clientY: 1000,
+    });
 
     jest.advanceTimersByTime(101);
 
-    instance.popper.dispatchEvent(MOUSEENTER);
+    fireEvent.mouseEnter(instance.popper);
 
     expect(instance.state.isVisible).toBe(false);
   });
@@ -251,40 +238,34 @@ describe('delay', () => {
       trigger: 'click',
     });
 
-    instance.reference.dispatchEvent(CLICK);
+    fireEvent.click(instance.reference);
     jest.advanceTimersByTime(100);
 
-    instance.popper.dispatchEvent(MOUSELEAVE);
-    document.body.dispatchEvent(
-      new MouseEvent('mousemove', {
-        bubbles: true,
-        clientX: 1000,
-        clientY: 1000,
-      }),
-    );
+    fireEvent.mouseLeave(instance.popper);
+    fireEvent.mouseMove(document.body, {
+      clientX: 1000,
+      clientY: 1000,
+    });
 
     expect(instance.state.isVisible).toBe(true);
 
     jest.advanceTimersByTime(99);
 
-    instance.popper.dispatchEvent(MOUSEENTER);
+    fireEvent.mouseEnter(instance.popper);
 
     jest.advanceTimersByTime(1);
 
     expect(instance.state.isVisible).toBe(true);
 
-    instance.popper.dispatchEvent(MOUSELEAVE);
-    document.body.dispatchEvent(
-      new MouseEvent('mousemove', {
-        bubbles: true,
-        clientX: 1000,
-        clientY: 1000,
-      }),
-    );
+    fireEvent.mouseLeave(instance.popper);
+    fireEvent.mouseMove(document.body, {
+      clientX: 1000,
+      clientY: 1000,
+    });
 
     jest.advanceTimersByTime(101);
 
-    instance.popper.dispatchEvent(MOUSEENTER);
+    fireEvent.mouseEnter(instance.popper);
 
     expect(instance.state.isVisible).toBe(true);
   });
@@ -353,74 +334,74 @@ describe('trigger', () => {
   it('default: many triggers', () => {
     const instance = tippy(h());
 
-    instance.reference.dispatchEvent(MOUSEENTER);
+    fireEvent.mouseEnter(instance.reference);
     expect(instance.state.isVisible).toBe(true);
 
-    instance.reference.dispatchEvent(MOUSELEAVE);
+    fireEvent.mouseLeave(instance.reference);
     expect(instance.state.isVisible).toBe(false);
 
-    instance.reference.dispatchEvent(FOCUS);
+    fireEvent.focus(instance.reference);
     expect(instance.state.isVisible).toBe(true);
 
-    instance.reference.dispatchEvent(BLUR);
+    fireEvent.blur(instance.reference);
     expect(instance.state.isVisible).toBe(false);
   });
 
   it('mouseenter', () => {
     const instance = tippy(h(), {trigger: 'mouseenter'});
 
-    instance.reference.dispatchEvent(MOUSEENTER);
+    fireEvent.mouseEnter(instance.reference);
     expect(instance.state.isVisible).toBe(true);
 
-    instance.reference.dispatchEvent(MOUSELEAVE);
+    fireEvent.mouseLeave(instance.reference);
     expect(instance.state.isVisible).toBe(false);
   });
 
   it('focus', () => {
     const instance = tippy(h(), {trigger: 'focus'});
 
-    instance.reference.dispatchEvent(FOCUS);
+    fireEvent.focus(instance.reference);
     expect(instance.state.isVisible).toBe(true);
 
-    instance.reference.dispatchEvent(BLUR);
+    fireEvent.blur(instance.reference);
     expect(instance.state.isVisible).toBe(false);
   });
 
   it('focus + interactive: focus switching to inside popper does not hide tippy', () => {
     const instance = tippy(h(), {interactive: true, trigger: 'focus'});
 
-    instance.reference.dispatchEvent(new Event('focus'));
+    fireEvent.focus(instance.reference);
     expect(instance.state.isVisible).toBe(true);
 
-    instance.reference.dispatchEvent(
-      new FocusEvent('blur', {relatedTarget: instance.popper}),
-    );
+    fireEvent.blur(instance.reference, {
+      relatedTarget: instance.popper,
+    });
     expect(instance.state.isVisible).toBe(true);
   });
 
   it('click', () => {
     const instance = tippy(h(), {trigger: 'click'});
 
-    instance.reference.dispatchEvent(new Event('click'));
+    fireEvent.click(instance.reference);
     expect(instance.state.isVisible).toBe(true);
 
-    instance.reference.dispatchEvent(new Event('click'));
+    fireEvent.click(instance.reference);
     expect(instance.state.isVisible).toBe(false);
   });
 
   it('manual', () => {
     const instance = tippy(h(), {trigger: 'manual'});
 
-    instance.reference.dispatchEvent(MOUSEENTER);
+    fireEvent.mouseEnter(instance.reference);
     expect(instance.state.isVisible).toBe(false);
 
-    instance.reference.dispatchEvent(FOCUS);
+    fireEvent.focus(instance.reference);
     expect(instance.state.isVisible).toBe(false);
 
-    instance.reference.dispatchEvent(CLICK);
+    fireEvent.click(instance.reference);
     expect(instance.state.isVisible).toBe(false);
 
-    instance.reference.dispatchEvent(new Event('touchstart'));
+    fireEvent.touchStart(instance.reference);
     expect(instance.state.isVisible).toBe(false);
   });
 });
@@ -430,7 +411,7 @@ describe('interactive', () => {
     const instance = tippy(h(), {interactive: true});
 
     instance.show();
-    instance.popperChildren.tooltip.dispatchEvent(CLICK);
+    fireEvent.click(instance.popperChildren.tooltip);
 
     expect(instance.state.isVisible).toBe(true);
   });
@@ -441,38 +422,29 @@ describe('interactive', () => {
     instance.show();
     jest.runAllTimers();
 
-    instance.popperChildren.tooltip.dispatchEvent(
-      new MouseEvent('mousedown', {bubbles: true}),
-    );
+    fireEvent.mouseDown(instance.popperChildren.tooltip);
 
     expect(instance.state.isVisible).toBe(false);
   });
 
   it('tippy does not hide as cursor moves over it or the reference', () => {
     const instance = tippy(h(), {interactive: true});
-    instance.reference.dispatchEvent(new Event('mouseenter'));
+    fireEvent.mouseEnter(instance.reference);
 
-    instance.reference.dispatchEvent(new Event('mouseleave'));
-    instance.popper.dispatchEvent(new MouseEvent('mousemove', {bubbles: true}));
+    fireEvent.mouseLeave(instance.reference);
+    fireEvent.mouseMove(instance.popper);
     expect(instance.state.isVisible).toBe(true);
 
-    instance.popperChildren.tooltip.dispatchEvent(
-      new Event('mousemove', {bubbles: true}),
-    );
+    fireEvent.mouseMove(instance.popperChildren.tooltip);
     expect(instance.state.isVisible).toBe(true);
 
-    instance.reference.dispatchEvent(
-      new MouseEvent('mousemove', {bubbles: true}),
-    );
+    fireEvent.mouseMove(instance.reference);
     expect(instance.state.isVisible).toBe(true);
 
-    document.body.dispatchEvent(
-      new MouseEvent('mousemove', {
-        bubbles: true,
-        clientX: 1000,
-        clientY: 1000,
-      }),
-    );
+    fireEvent.mouseMove(document.body, {
+      clientX: 1000,
+      clientY: 1000,
+    });
     expect(instance.state.isVisible).toBe(false);
   });
 
@@ -493,7 +465,7 @@ describe('interactive', () => {
 
     instance.setProps({triggerTarget});
 
-    triggerTarget.dispatchEvent(MOUSEENTER);
+    fireEvent.mouseEnter(triggerTarget);
     jest.runAllTimers();
 
     expect(instance.reference.getAttribute('aria-expanded')).toBe(null);
@@ -551,11 +523,11 @@ describe('interactive', () => {
 
         Using a wrapper <div> or <span> tag around the reference element solves
         this by creating a new parentNode context.
-        
+
         Specifying \`appendTo: document.body\` silences this warning, but it
         assumes you are using a focus management solution to handle keyboard
         navigation.
-        
+
         See: https://atomiks.github.io/tippyjs/accessibility/#interactivity`,
       ),
     );
@@ -806,9 +778,9 @@ describe('onTrigger', () => {
     const spy = jest.fn();
     const instance = tippy(h(), {onTrigger: spy});
 
-    instance.reference.dispatchEvent(MOUSEENTER);
+    fireEvent.mouseEnter(instance.reference);
 
-    expect(spy).toHaveBeenCalledWith(instance, MOUSEENTER);
+    expect(spy).toHaveBeenCalledWith(instance, new MouseEvent('mouseenter'));
   });
 
   it('is not called without an event to pass (showOnCreate)', () => {
@@ -1092,11 +1064,14 @@ describe('touch', () => {
   it('"hold": uses `touch` listeners instead', () => {
     const ref = h();
     const instance = tippy(ref, {touch: 'hold'});
-    ref.dispatchEvent(new Event('mouseenter'));
+
+    fireEvent.mouseEnter(ref);
     expect(instance.state.isVisible).toBe(false);
-    ref.dispatchEvent(new Event('focus'));
+
+    fireEvent.focus(ref);
     expect(instance.state.isVisible).toBe(false);
-    ref.dispatchEvent(new Event('touchstart'));
+
+    fireEvent.touchStart(ref);
     expect(instance.state.isVisible).toBe(true);
   });
 
@@ -1104,13 +1079,13 @@ describe('touch', () => {
     const ref = h();
     const instance = tippy(ref, {touch: 'hold'});
 
-    ref.dispatchEvent(TOUCHSTART);
+    fireEvent.touchStart(ref);
     expect(instance.state.isVisible).toBe(true);
 
-    ref.dispatchEvent(MOUSELEAVE);
+    fireEvent.mouseLeave(ref);
     expect(instance.state.isVisible).toBe(true);
 
-    ref.dispatchEvent(TOUCHEND);
+    fireEvent.touchEnd(ref);
     expect(instance.state.isVisible).toBe(false);
   });
 
@@ -1118,16 +1093,13 @@ describe('touch', () => {
     const ref = h();
     const instance = tippy(ref, {touch: ['hold', 100]});
 
-    ref.dispatchEvent(TOUCHSTART);
-
+    fireEvent.touchStart(ref);
     expect(instance.state.isVisible).toBe(false);
 
     jest.advanceTimersByTime(99);
-
     expect(instance.state.isVisible).toBe(false);
 
     jest.advanceTimersByTime(1);
-
     expect(instance.state.isVisible).toBe(true);
   });
 
@@ -1135,13 +1107,11 @@ describe('touch', () => {
     const ref = h();
     const instance = tippy(ref, {touch: ['hold', 100]});
 
-    ref.dispatchEvent(TOUCHSTART);
-
+    fireEvent.touchStart(ref);
     expect(instance.state.isVisible).toBe(false);
 
-    ref.dispatchEvent(TOUCHEND);
+    fireEvent.touchEnd(ref);
     jest.advanceTimersByTime(100);
-
     expect(instance.state.isVisible).toBe(false);
   });
 });
@@ -1192,11 +1162,11 @@ describe('triggerTarget', () => {
     const node = h('div');
     const instance = tippy(h(), {triggerTarget: node});
 
-    instance.reference.dispatchEvent(MOUSEENTER);
+    fireEvent.mouseEnter(instance.reference);
 
     expect(instance.state.isVisible).toBe(false);
 
-    node.dispatchEvent(MOUSEENTER);
+    fireEvent.mouseEnter(node);
 
     expect(instance.state.isVisible).toBe(true);
   });
@@ -1208,11 +1178,11 @@ describe('triggerTarget', () => {
 
     instance.setProps({triggerTarget: node2});
 
-    node.dispatchEvent(new Event('mouseenter'));
+    fireEvent.mouseEnter(node);
 
     expect(instance.state.isVisible).toBe(false);
 
-    node2.dispatchEvent(new Event('mouseenter'));
+    fireEvent.mouseEnter(node2);
 
     expect(instance.state.isVisible).toBe(true);
   });
@@ -1224,15 +1194,15 @@ describe('triggerTarget', () => {
     const instance = tippy(h(), {triggerTarget: nodes});
 
     nodes.forEach(node => {
-      instance.reference.dispatchEvent(MOUSEENTER);
+      fireEvent.mouseEnter(instance.reference);
 
       expect(instance.state.isVisible).toBe(false);
 
-      node.dispatchEvent(MOUSEENTER);
+      fireEvent.mouseEnter(node);
 
       expect(instance.state.isVisible).toBe(true);
 
-      node.dispatchEvent(MOUSELEAVE);
+      fireEvent.mouseLeave(node);
 
       expect(instance.state.isVisible).toBe(false);
     });
@@ -1244,7 +1214,7 @@ describe('hideOnClick', () => {
     const instance = tippy(h(), {hideOnClick: true});
 
     instance.show();
-    instance.reference.dispatchEvent(MOUSEDOWN);
+    fireEvent.mouseDown(instance.reference);
 
     expect(instance.state.isVisible).toBe(false);
   });
@@ -1254,8 +1224,8 @@ describe('hideOnClick', () => {
 
     instance.show();
 
-    instance.popperChildren.tooltip.dispatchEvent(MOUSEDOWN);
-    instance.popperChildren.tooltip.dispatchEvent(CLICK);
+    fireEvent.mouseDown(instance.popperChildren.tooltip);
+    fireEvent.click(instance.popperChildren.tooltip);
 
     expect(instance.state.isVisible).toBe(true);
   });
@@ -1266,8 +1236,8 @@ describe('hideOnClick', () => {
     instance.show();
     jest.runAllTimers();
 
-    instance.popperChildren.tooltip.dispatchEvent(MOUSEDOWN);
-    instance.popperChildren.tooltip.dispatchEvent(CLICK);
+    fireEvent.mouseDown(instance.popperChildren.tooltip);
+    fireEvent.click(instance.popperChildren.tooltip);
 
     expect(instance.state.isVisible).toBe(false);
   });
@@ -1277,8 +1247,8 @@ describe('hideOnClick', () => {
 
     instance.show();
 
-    instance.reference.dispatchEvent(MOUSEDOWN);
-    instance.reference.dispatchEvent(CLICK);
+    fireEvent.mouseDown(instance.reference);
+    fireEvent.click(instance.reference);
 
     expect(instance.state.isVisible).toBe(true);
   });
@@ -1288,12 +1258,12 @@ describe('hideOnClick', () => {
 
     instance.show();
 
-    instance.popperChildren.tooltip.dispatchEvent(MOUSEDOWN);
-    instance.popperChildren.tooltip.dispatchEvent(CLICK);
-    instance.reference.dispatchEvent(MOUSEDOWN);
-    instance.reference.dispatchEvent(CLICK);
-    document.body.dispatchEvent(MOUSEDOWN);
-    document.body.dispatchEvent(CLICK);
+    fireEvent.mouseDown(instance.popperChildren.tooltip);
+    fireEvent.click(instance.popperChildren.tooltip);
+    fireEvent.mouseDown(instance.reference);
+    fireEvent.click(instance.reference);
+    fireEvent.mouseDown(document.body);
+    fireEvent.click(document.body);
 
     expect(instance.state.isVisible).toBe(true);
   });
@@ -1305,15 +1275,15 @@ describe('hideOnClick', () => {
 
     jest.runAllTimers();
 
-    document.body.dispatchEvent(MOUSEDOWN);
-    document.body.dispatchEvent(CLICK);
-    instance.popperChildren.tooltip.dispatchEvent(MOUSEDOWN);
-    instance.popperChildren.tooltip.dispatchEvent(CLICK);
+    fireEvent.mouseDown(document.body);
+    fireEvent.click(document.body);
+    fireEvent.mouseDown(instance.popperChildren.tooltip);
+    fireEvent.click(instance.popperChildren.tooltip);
 
     expect(instance.state.isVisible).toBe(true);
 
-    instance.reference.dispatchEvent(MOUSEDOWN);
-    instance.reference.dispatchEvent(CLICK);
+    fireEvent.mouseDown(instance.reference);
+    fireEvent.click(instance.reference);
 
     expect(instance.state.isVisible).toBe(false);
   });
@@ -1321,9 +1291,9 @@ describe('hideOnClick', () => {
   it('handles `mousedown` -> `focus` quirk', () => {
     const instance = tippy(h(), {hideOnClick: true});
 
-    instance.reference.dispatchEvent(MOUSEENTER);
-    instance.reference.dispatchEvent(MOUSEDOWN);
-    instance.reference.dispatchEvent(FOCUS);
+    fireEvent.mouseEnter(instance.reference);
+    fireEvent.mouseDown(instance.reference);
+    fireEvent.click(instance.reference);
 
     expect(instance.state.isVisible).toBe(false);
   });

--- a/test/utils.js
+++ b/test/utils.js
@@ -6,15 +6,6 @@ import tippy from '../src';
 
 export const IDENTIFIER = '__tippy';
 
-export const MOUSEENTER = new MouseEvent('mouseenter', {bubbles: true});
-export const MOUSELEAVE = new MouseEvent('mouseleave', {bubbles: true});
-export const MOUSEDOWN = new MouseEvent('mousedown', {bubbles: true});
-export const CLICK = new MouseEvent('click', {bubbles: true});
-export const FOCUS = new FocusEvent('focus');
-export const BLUR = new FocusEvent('blur');
-export const TOUCHSTART = new TouchEvent('touchstart', {bubbles: true});
-export const TOUCHEND = new TouchEvent('touchend', {bubbles: true});
-
 export function cleanDocumentBody() {
   document.body.innerHTML = '';
 }


### PR DESCRIPTION
Use `fireEvent` to standardize dispatching events in painless way.

