### PR TITLE
chore: remove `--silent` flag

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "dev:addons": "parcel demo/addons/index.html -d .devserver",
     "dev:plugins": "parcel demo/plugins/index.html -d .devserver",
     "build": "node rollup.pre-build && rollup --config && bundlesize",
-    "test": "jest --coverage --silent",
+    "test": "jest --coverage",
     "check-types": "tsc",
     "lint": "eslint --report-unused-disable-directives . --ext .ts,.js",
     "format": "prettier --write \"**/*.{js,ts,json,md,mdx,scss,css}\"",
@@ -55,7 +55,7 @@
     "globals": {
       "__DEV__": true
     },
-    "setupFiles": [
+    "setupFilesAfterEnv": [
       "./test/setup.js"
     ],
     "testRegex": "./test/.*.test.js$"

--- a/test/integration/createTippy.test.js
+++ b/test/integration/createTippy.test.js
@@ -179,8 +179,6 @@ describe('instance.destroy()', () => {
     jest.advanceTimersByTime(500);
 
     expect(spy).not.toHaveBeenCalled();
-
-    spy.mockRestore();
   });
 });
 

--- a/test/setup.js
+++ b/test/setup.js
@@ -18,3 +18,13 @@ global.requestAnimationFrame = cb => cb();
 
 // Only relevant for bindGlobalEventListeners.test.js
 Object.defineProperty(window.navigator, 'platform', {value: 'iPhone'});
+
+// Prevents console from spamming test output while still allowing for debugging
+// while writting tests
+const nativeConsoleWarn = global.console.warn;
+beforeEach(() => {
+  global.console.warn = jest.fn();
+});
+afterEach(() => {
+  global.console.warn = nativeConsoleWarn;
+});

--- a/test/setup.js
+++ b/test/setup.js
@@ -20,7 +20,7 @@ global.requestAnimationFrame = cb => cb();
 Object.defineProperty(window.navigator, 'platform', {value: 'iPhone'});
 
 // Prevents console from spamming test output while still allowing for debugging
-// while writting tests
+// while writing tests
 const nativeConsoleWarn = global.console.warn;
 beforeEach(() => {
   global.console.warn = jest.fn();


### PR DESCRIPTION
I didn't like that I couldn't use `console.log` to debug some values in tests, so I mocked `console.warn` globally.

Not sure if this is the best solution but it works 🤷‍♂ 