### PR TITLE
fix: filter out duplicate plugins

### DIFF
--- a/src/addons/createSingleton.ts
+++ b/src/addons/createSingleton.ts
@@ -24,7 +24,7 @@ export default function createSingleton(
     );
   }
 
-  plugins = defaultProps.plugins.concat(optionalProps.plugins || plugins);
+  plugins = optionalProps.plugins || plugins;
 
   tippyInstances.forEach(instance => {
     instance.disable();

--- a/src/addons/delegate.ts
+++ b/src/addons/delegate.ts
@@ -35,7 +35,7 @@ export default function delegate(
     );
   }
 
-  plugins = defaultProps.plugins.concat(props.plugins || plugins);
+  plugins = props.plugins || plugins;
 
   let listeners: ListenerObj[] = [];
   let childTippyInstances: Instance[] = [];

--- a/src/createTippy.ts
+++ b/src/createTippy.ts
@@ -46,6 +46,7 @@ import {
   pushIfUnique,
   arrayFrom,
   appendPxIfNumber,
+  unique,
 } from './utils';
 import {warnWhen, validateProps, createMemoryLeakWarning} from './validation';
 
@@ -72,7 +73,6 @@ export default function createTippy(
   collectionProps: Props,
 ): Instance | null {
   const props = getExtendedProps(evaluateProps(reference, collectionProps));
-  const {plugins} = props;
 
   // If the reference shouldn't have multiple tippys, return null early
   if (!props.multiple && reference._tippy) {
@@ -103,6 +103,7 @@ export default function createTippy(
   const popper = createPopperElement(id, props);
   const popperChildren = getChildren(popper);
   const popperInstance: PopperInstance | null = null;
+  const plugins = unique(props.plugins);
 
   // These two elements are static
   const {tooltip, content} = popperChildren;

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -300,3 +300,10 @@ export function pushIfUnique<T>(arr: T[], value: T): void {
 export function appendPxIfNumber(value: string | number): string {
   return typeof value === 'number' ? `${value}px` : value;
 }
+
+/**
+ * Filters out duplicate elements in an array
+ */
+export function unique<T>(arr: T[]): T[] {
+  return arr.filter((item, index) => arr.indexOf(item) === index);
+}

--- a/test/integration/createTippy.test.js
+++ b/test/integration/createTippy.test.js
@@ -94,6 +94,15 @@ describe('createTippy', () => {
 
     expect(instance.props.animateFill).toBe(animateFill.defaultValue);
   });
+
+  it('`instance.plugins` does not contain duplicate plugins', () => {
+    instance = createTippy(h(), {
+      ...defaultProps,
+      plugins: [animateFill, animateFill],
+    });
+
+    expect(instance.plugins).toEqual([animateFill]);
+  });
 });
 
 describe('instance.destroy()', () => {

--- a/test/unit/utils.test.js
+++ b/test/unit/utils.test.js
@@ -376,3 +376,12 @@ describe('appendPxIfNumber', () => {
     expect(Utils.appendPxIfNumber('10px')).toBe('10px');
   });
 });
+
+describe('unique', () => {
+  it('filters out duplicate elements', () => {
+    const ref1 = {};
+    const ref2 = {};
+    expect(Utils.unique([0, 1, 0, 2, 3, 2, 3, 3, 4])).toEqual([0, 1, 2, 3, 4]);
+    expect(Utils.unique([ref1, ref1, ref2])).toEqual([ref1, ref2]);
+  });
+});


### PR DESCRIPTION
- Addons were `.concat`ing `defaultProps.plugins` unnecessarily since `tippy()` does it.
- Duplicate plugins should be filtered out at `createTippy()` for extra safety.

Most exported plugins when duplicated don't cause issues but make performance worse.

`unique()` could use `[...new Set(plugins)]` which is faster I think, but I'm not sure of how well-supported it is, best to use this one?