### PR TITLE
types: refactor interfaces

### DIFF
--- a/src/addons/createSingleton.ts
+++ b/src/addons/createSingleton.ts
@@ -1,4 +1,4 @@
-import {Instance, Props, Plugin} from '../types';
+import {Instance, Props, CreateSingleton} from '../types';
 import tippy from '..';
 import {preserveInvocation, useIfDefined} from '../utils';
 import {defaultProps} from '../props';
@@ -8,12 +8,12 @@ import {throwErrorWhen} from '../validation';
  * Re-uses a single tippy element for many different tippy instances.
  * Replaces v4's `tippy.group()`.
  */
-export default function createSingleton(
-  tippyInstances: Instance[],
-  optionalProps: Partial<Props> = {},
+const createSingleton: CreateSingleton = (
+  tippyInstances,
+  optionalProps = {},
   /** @deprecated use Props.plugins */
-  plugins: Plugin[] = [],
-): Instance {
+  plugins = [],
+) => {
   if (__DEV__) {
     throwErrorWhen(
       !Array.isArray(tippyInstances),
@@ -33,15 +33,14 @@ export default function createSingleton(
   let currentAria: string | null | undefined;
   let currentTarget: Element;
 
-  const userProps: Partial<Props> = {};
+  const userProps = {...defaultProps, ...optionalProps};
 
   function setUserProps(props: Partial<Props>): void {
-    Object.keys(props).forEach(prop => {
-      userProps[prop] = useIfDefined(props[prop], userProps[prop]);
+    const keys = Object.keys(props) as Array<keyof Props>;
+    keys.forEach(prop => {
+      (userProps as any)[prop] = useIfDefined(props[prop], userProps[prop]);
     });
   }
-
-  setUserProps({...defaultProps, ...optionalProps});
 
   function handleAriaDescribedByAttribute(
     id: string,
@@ -138,4 +137,6 @@ export default function createSingleton(
   };
 
   return tippy(document.createElement('div'), props) as Instance;
-}
+};
+
+export default createSingleton;

--- a/src/addons/delegate.ts
+++ b/src/addons/delegate.ts
@@ -1,4 +1,4 @@
-import {Targets, Instance, Props, Plugin} from '../types';
+import {Instance, Delegate} from '../types';
 import tippy from '..';
 import {throwErrorWhen} from '../validation';
 import {removeProperties, normalizeToArray, includes} from '../utils';
@@ -15,12 +15,7 @@ const BUBBLING_EVENTS_MAP = {
  * Creates a delegate instance that controls the creation of tippy instances
  * for child elements (`target` CSS selector).
  */
-export default function delegate(
-  targets: Targets,
-  props: Partial<Props> & {target: string},
-  /** @deprecated use Props.plugins */
-  plugins: Plugin[] = [],
-): Instance | Instance[] {
+const delegate: Delegate = (targets, props, plugins = []) => {
   if (__DEV__) {
     throwErrorWhen(
       !props || !props.target,
@@ -121,4 +116,6 @@ export default function delegate(
   normalizedReturnValue.forEach(applyMutations);
 
   return returnValue;
-}
+};
+
+export default delegate;

--- a/src/addons/delegate.ts
+++ b/src/addons/delegate.ts
@@ -1,4 +1,4 @@
-import {Instance, Delegate} from '../types';
+import {Instance, Targets, Plugin, Props} from '../types';
 import tippy from '..';
 import {throwErrorWhen} from '../validation';
 import {removeProperties, normalizeToArray, includes} from '../utils';
@@ -15,7 +15,12 @@ const BUBBLING_EVENTS_MAP = {
  * Creates a delegate instance that controls the creation of tippy instances
  * for child elements (`target` CSS selector).
  */
-const delegate: Delegate = (targets, props, plugins = []) => {
+function delegate(
+  targets: Targets,
+  props: Partial<Props> & {target: string},
+  /** @deprecated use Props.plugins */
+  plugins: Plugin[] = [],
+): Instance | Instance[] {
   if (__DEV__) {
     throwErrorWhen(
       !props || !props.target,
@@ -116,6 +121,6 @@ const delegate: Delegate = (targets, props, plugins = []) => {
   normalizedReturnValue.forEach(applyMutations);
 
   return returnValue;
-};
+}
 
 export default delegate;

--- a/src/index.ts
+++ b/src/index.ts
@@ -124,5 +124,6 @@ export function createTippyWithPlugins(outerPlugins: Plugin[]): Tippy {
   tippyPluginsWrapper.setDefaultProps = setDefaultProps;
   tippyPluginsWrapper.currentInput = currentInput;
 
+  // @ts-ignore
   return tippyPluginsWrapper;
 }

--- a/src/plugins/animateFill.ts
+++ b/src/plugins/animateFill.ts
@@ -1,13 +1,13 @@
-import {LifecycleHooks, AnimateFillInstance} from '../types';
+import {AnimateFill} from '../types';
 import {BACKDROP_CLASS} from '../constants';
 import {div, setVisibilityState} from '../utils';
 import {isUCBrowser} from '../browser';
 import {warnWhen} from '../validation';
 
-export default {
+const animateFill: AnimateFill = {
   name: 'animateFill',
   defaultValue: false,
-  fn(instance: AnimateFillInstance): Partial<LifecycleHooks> {
+  fn(instance) {
     const {tooltip, content} = instance.popperChildren;
 
     const backdrop =
@@ -84,6 +84,8 @@ export default {
     };
   },
 };
+
+export default animateFill;
 
 function createBackdropElement(): HTMLDivElement {
   const backdrop = div();

--- a/src/plugins/followCursor.ts
+++ b/src/plugins/followCursor.ts
@@ -1,9 +1,9 @@
 import {
-  Props,
   PopperElement,
-  LifecycleHooks,
   Placement,
-  Instance,
+  FollowCursor,
+  FollowCursorProps,
+  Props,
 } from '../types';
 import {
   includes,
@@ -15,10 +15,12 @@ import {
 import {getBasePlacement} from '../popper';
 import {currentInput} from '../bindGlobalEventListeners';
 
-export default {
+type ExtendedProps = Props & FollowCursorProps;
+
+const followCursor: FollowCursor = {
   name: 'followCursor',
   defaultValue: false,
-  fn(instance: Instance): Partial<LifecycleHooks> {
+  fn(instance) {
     const {reference, popper} = instance;
 
     // Support iframe contexts
@@ -35,9 +37,10 @@ export default {
     // original prop value
     const userProps = instance.props;
 
-    function setUserProps(props: Partial<Props>): void {
-      Object.keys(props).forEach(prop => {
-        userProps[prop] = useIfDefined(props[prop], userProps[prop]);
+    function setUserProps(props: Partial<ExtendedProps>): void {
+      const keys = Object.keys(props) as Array<keyof ExtendedProps>;
+      keys.forEach(prop => {
+        (userProps as any)[prop] = useIfDefined(props[prop], userProps[prop]);
       });
     }
 
@@ -245,6 +248,8 @@ export default {
     };
   },
 };
+
+export default followCursor;
 
 export function getVirtualOffsets(
   popper: PopperElement,

--- a/src/plugins/inlinePositioning.ts
+++ b/src/plugins/inlinePositioning.ts
@@ -1,6 +1,5 @@
 import {
-  Instance,
-  LifecycleHooks,
+  InlinePositioning,
   InlinePositioningProps,
   BasePlacement,
 } from '../types';
@@ -10,10 +9,10 @@ import {getBasePlacement} from '../popper';
 // TODO: Work on a "cursor" value so it chooses a rect optimal to the cursor
 // position. This will require the `followCursor` plugin's fixes for overflow
 // due to using event.clientX/Y values. (normalizedPlacement, getVirtualOffsets)
-export default {
+const inlinePositioning: InlinePositioning = {
   name: 'inlinePositioning',
   defaultValue: false,
-  fn(instance: Instance): Partial<LifecycleHooks> {
+  fn(instance) {
     const {reference} = instance;
 
     function getIsEnabled(): InlinePositioningProps['inlinePositioning'] {
@@ -49,6 +48,8 @@ export default {
     };
   },
 };
+
+export default inlinePositioning;
 
 export function getInlineBoundingClientRect(
   currentBasePlacement: BasePlacement | null,

--- a/src/plugins/sticky.ts
+++ b/src/plugins/sticky.ts
@@ -1,9 +1,9 @@
-import {LifecycleHooks, Instance} from '../types';
+import {Sticky} from '../types';
 
-export default {
+const sticky: Sticky = {
   name: 'sticky',
   defaultValue: false,
-  fn(instance: Instance): Partial<LifecycleHooks> {
+  fn(instance) {
     const {reference, popper} = instance;
 
     function shouldCheck(value: 'reference' | 'popper'): boolean {
@@ -45,6 +45,8 @@ export default {
     };
   },
 };
+
+export default sticky;
 
 function areRectsDifferent(
   rectA: ClientRect | null,

--- a/src/props.ts
+++ b/src/props.ts
@@ -5,6 +5,7 @@ import {PropsV4} from './types-internal';
 
 export const defaultProps: DefaultProps = {
   allowHTML: true,
+  animateFill: false,
   animation: 'fade',
   appendTo: () => document.body,
   aria: 'describedby',
@@ -17,8 +18,10 @@ export const defaultProps: DefaultProps = {
   flip: true,
   flipBehavior: 'flip',
   flipOnUpdate: false,
+  followCursor: false,
   hideOnClick: true,
   ignoreAttributes: false,
+  inlinePositioning: false,
   inertia: false,
   interactive: false,
   interactiveBorder: 2,
@@ -43,6 +46,7 @@ export const defaultProps: DefaultProps = {
   popperOptions: {},
   role: 'tooltip',
   showOnCreate: false,
+  sticky: false,
   theme: '',
   touch: true,
   trigger: 'mouseenter focus',

--- a/src/types-internal.ts
+++ b/src/types-internal.ts
@@ -1,6 +1,17 @@
+import {Props} from './types';
+
 export interface ListenerObject {
   node: Element;
   eventType: string;
   handler: EventListenerOrEventListenerObject;
   options: boolean | object;
+}
+
+export interface PropsV4 extends Props {
+  a11y: boolean;
+  arrowType: 'sharp' | 'round';
+  showOnInit: boolean;
+  size: 'small' | 'regular' | 'large';
+  target: string;
+  touchHold: boolean;
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -25,18 +25,24 @@ export interface PopperInstance extends Popper {
   modifiers: {name: string; padding: object | number}[];
 }
 
-export interface LifecycleHooks {
-  onAfterUpdate(instance: Instance, partialProps: Partial<Props>): void;
-  onBeforeUpdate(instance: Instance, partialProps: Partial<Props>): void;
-  onCreate(instance: Instance): void;
-  onDestroy(instance: Instance): void;
-  onHidden(instance: Instance): void;
-  onHide(instance: Instance): void | false;
-  onMount(instance: Instance): void;
-  onShow(instance: Instance): void | false;
-  onShown(instance: Instance): void;
-  onTrigger(instance: Instance, event: Event): void;
-  onUntrigger(instance: Instance, event: Event): void;
+export interface LifecycleHooks<TProps = Props> {
+  onAfterUpdate(
+    instance: Instance<TProps>,
+    partialProps: Partial<TProps>,
+  ): void;
+  onBeforeUpdate(
+    instance: Instance<TProps>,
+    partialProps: Partial<TProps>,
+  ): void;
+  onCreate(instance: Instance<TProps>): void;
+  onDestroy(instance: Instance<TProps>): void;
+  onHidden(instance: Instance<TProps>): void;
+  onHide(instance: Instance<TProps>): void | false;
+  onMount(instance: Instance<TProps>): void;
+  onShow(instance: Instance<TProps>): void | false;
+  onShown(instance: Instance<TProps>): void;
+  onTrigger(instance: Instance<TProps>, event: Event): void;
+  onUntrigger(instance: Instance<TProps>, event: Event): void;
 }
 
 export interface Props extends LifecycleHooks {
@@ -74,7 +80,6 @@ export interface Props extends LifecycleHooks {
   triggerTarget: Element | Element[] | null;
   updateDuration: number;
   zIndex: number;
-  [key: string]: any;
 }
 
 export interface DefaultProps extends Props {
@@ -98,7 +103,7 @@ export interface StickyProps {
   sticky: boolean | 'reference' | 'popper';
 }
 
-export interface Instance {
+export interface Instance<TProps = Props> {
   clearDelayTimeouts(): void;
   destroy(): void;
   disable(): void;
@@ -109,10 +114,10 @@ export interface Instance {
   popper: PopperElement;
   popperChildren: PopperChildren;
   popperInstance: PopperInstance | null;
-  props: Props;
+  props: TProps;
   reference: ReferenceElement;
   setContent(content: Content): void;
-  setProps(partialProps: Partial<Props>): void;
+  setProps(partialProps: Partial<TProps>): void;
   show(duration?: number): void;
   state: {
     currentPlacement: Placement | null;
@@ -135,10 +140,10 @@ export interface HideAllOptions {
   exclude?: Instance | ReferenceElement;
 }
 
-export interface Plugin {
+export interface Plugin<TProps = Props> {
   name?: string;
   defaultValue?: any;
-  fn(instance: Instance): Partial<LifecycleHooks>;
+  fn(instance: Instance<TProps>): Partial<LifecycleHooks<TProps>>;
 }
 
 export interface Tippy<TProps = Props> {
@@ -147,7 +152,7 @@ export interface Tippy<TProps = Props> {
     optionalProps?: Partial<TProps>,
     /** @deprecated use Props.plugins */
     plugins?: Plugin[],
-  ): Instance | Instance[];
+  ): Instance<TProps> | Instance<TProps>[];
   readonly currentInput: {isTouch: boolean};
   readonly defaultProps: DefaultProps;
   readonly version: string;
@@ -171,46 +176,47 @@ export type Delegate<TProps = Props> = (
   props: Partial<TProps> & {target: string},
   /** @deprecated use Props.plugins */
   plugins?: Plugin[],
-) => Instance | Instance[];
+) => Instance<TProps> | Instance<TProps>[];
 
 export type CreateSingleton<TProps = Props> = (
   tippyInstances: Instance[],
   optionalProps?: Partial<TProps>,
   /** @deprecated use Props.plugins */
   plugins?: Plugin[],
-) => Instance;
+) => Instance<TProps>;
 
 declare const delegate: Delegate;
 declare const createSingleton: CreateSingleton;
 
-export interface AnimateFillInstance extends Instance {
+export interface AnimateFillInstance
+  extends Instance<Props & AnimateFillProps> {
   popperChildren: PopperChildren & {
     backdrop: HTMLDivElement | null;
   };
 }
 
-export interface AnimateFill {
+export interface AnimateFill extends Plugin<Props & AnimateFillProps> {
   name: 'animateFill';
   defaultValue: false;
-  fn(instance: AnimateFillInstance): Partial<LifecycleHooks>;
+  fn(
+    instance: AnimateFillInstance,
+  ): Partial<LifecycleHooks<Props & AnimateFillProps>>;
 }
 
-export interface FollowCursor {
+export interface FollowCursor extends Plugin<Props & FollowCursorProps> {
   name: 'followCursor';
   defaultValue: false;
-  fn(instance: Instance): Partial<LifecycleHooks>;
 }
 
-export interface InlinePositioning {
+export interface InlinePositioning
+  extends Plugin<Props & InlinePositioningProps> {
   name: 'inlinePositioning';
   defaultValue: false;
-  fn(instance: Instance): Partial<LifecycleHooks>;
 }
 
-export interface Sticky {
+export interface Sticky extends Plugin<Props & StickyProps> {
   name: 'sticky';
   defaultValue: false;
-  fn(instance: Instance): Partial<LifecycleHooks>;
 }
 
 declare const animateFill: AnimateFill;

--- a/src/types.ts
+++ b/src/types.ts
@@ -51,6 +51,7 @@ export interface LifecycleHooks<TProps = Props> {
 
 export interface Props extends LifecycleHooks {
   allowHTML: boolean;
+  animateFill: boolean;
   animation: string;
   appendTo: 'parent' | Element | ((ref: Element) => Element);
   aria: 'describedby' | 'labelledby' | null;
@@ -63,9 +64,11 @@ export interface Props extends LifecycleHooks {
   flip: boolean;
   flipBehavior: 'flip' | Placement[];
   flipOnUpdate: boolean;
+  followCursor: boolean | 'horizontal' | 'vertical' | 'initial';
   hideOnClick: boolean | 'toggle';
   ignoreAttributes: boolean;
   inertia: boolean;
+  inlinePositioning: boolean;
   interactive: boolean;
   interactiveBorder: number;
   interactiveDebounce: number;
@@ -78,6 +81,7 @@ export interface Props extends LifecycleHooks {
   popperOptions: Popper.PopperOptions;
   role: string;
   showOnCreate: boolean;
+  sticky: boolean | 'reference' | 'popper';
   theme: string;
   touch: boolean | 'hold' | ['hold', number];
   trigger: string;
@@ -89,22 +93,6 @@ export interface Props extends LifecycleHooks {
 export interface DefaultProps extends Props {
   delay: number | [number, number];
   duration: number | [number, number];
-}
-
-export interface AnimateFillProps {
-  animateFill: boolean;
-}
-
-export interface FollowCursorProps {
-  followCursor: boolean | 'horizontal' | 'vertical' | 'initial';
-}
-
-export interface InlinePositioningProps {
-  inlinePositioning: boolean;
-}
-
-export interface StickyProps {
-  sticky: boolean | 'reference' | 'popper';
 }
 
 export interface Instance<TProps = Props> {
@@ -176,16 +164,9 @@ export interface Tippy<TProps = Props> extends TippyStatics {
 }
 
 declare const tippy: Tippy;
-export default tippy;
 
 export type HideAll = (options: HideAllOptions) => void;
 declare const hideAll: HideAll;
-
-/**
- * @deprecated use tippy.setDefaultProps({plugins: [...]});
- */
-export type CreateTippyWithPlugins = (outerPlugins: Plugin[]) => Tippy;
-declare const createTippyWithPlugins: CreateTippyWithPlugins;
 
 export interface Delegate<TProps = Props> {
   (
@@ -215,33 +196,29 @@ export type CreateSingleton<TProps = Props> = (
 declare const delegate: Delegate;
 declare const createSingleton: CreateSingleton;
 
-export interface AnimateFillInstance
-  extends Instance<Props & AnimateFillProps> {
+export interface AnimateFillInstance extends Instance {
   popperChildren: PopperChildren & {
     backdrop: HTMLDivElement | null;
   };
 }
 
-export interface AnimateFill extends Plugin<Props & AnimateFillProps> {
+export interface AnimateFill extends Plugin {
   name: 'animateFill';
   defaultValue: false;
-  fn(
-    instance: AnimateFillInstance,
-  ): Partial<LifecycleHooks<Props & AnimateFillProps>>;
+  fn(instance: AnimateFillInstance): Partial<LifecycleHooks>;
 }
 
-export interface FollowCursor extends Plugin<Props & FollowCursorProps> {
+export interface FollowCursor extends Plugin {
   name: 'followCursor';
   defaultValue: false;
 }
 
-export interface InlinePositioning
-  extends Plugin<Props & InlinePositioningProps> {
+export interface InlinePositioning extends Plugin {
   name: 'inlinePositioning';
   defaultValue: false;
 }
 
-export interface Sticky extends Plugin<Props & StickyProps> {
+export interface Sticky extends Plugin {
   name: 'sticky';
   defaultValue: false;
 }
@@ -253,6 +230,33 @@ declare const sticky: Sticky;
 
 declare const roundArrow: string;
 
+/**
+ * @deprecated use tippy.setDefaultProps({plugins: [...]});
+ */
+export type CreateTippyWithPlugins = (outerPlugins: Plugin[]) => Tippy;
+declare const createTippyWithPlugins: CreateTippyWithPlugins;
+
+/** @deprecated */
+export interface AnimateFillProps {
+  animateFill: Props['animateFill'];
+}
+
+/** @deprecated */
+export interface FollowCursorProps {
+  followCursor: Props['followCursor'];
+}
+
+/** @deprecated */
+export interface InlinePositioningProps {
+  inlinePositioning: Props['inlinePositioning'];
+}
+
+/** @deprecated */
+export interface StickyProps {
+  sticky: Props['sticky'];
+}
+
+export default tippy;
 export {
   hideAll,
   createTippyWithPlugins,

--- a/src/types.ts
+++ b/src/types.ts
@@ -6,7 +6,11 @@ export type Placement = Popper.Placement;
 
 export type Content = string | Element | ((ref: Element) => Element | string);
 
-export type Targets = string | Element | Element[] | NodeList;
+export type SingleTarget = Element;
+
+export type MultipleTargets = string | Element[] | NodeList;
+
+export type Targets = SingleTarget | MultipleTargets;
 
 export interface ReferenceElement extends Element {
   _tippy?: Instance;
@@ -146,17 +150,29 @@ export interface Plugin<TProps = Props> {
   fn(instance: Instance<TProps>): Partial<LifecycleHooks<TProps>>;
 }
 
-export interface Tippy<TProps = Props> {
-  (
-    targets: Targets,
-    optionalProps?: Partial<TProps>,
-    /** @deprecated use Props.plugins */
-    plugins?: Plugin[],
-  ): Instance<TProps> | Instance<TProps>[];
+export interface TippyStatics {
   readonly currentInput: {isTouch: boolean};
   readonly defaultProps: DefaultProps;
   readonly version: string;
   setDefaultProps(partialProps: Partial<DefaultProps>): void;
+}
+
+export interface Tippy<TProps = Props> extends TippyStatics {
+  (
+    targets: SingleTarget,
+    optionalProps?: Partial<TProps>,
+    /** @deprecated use Props.plugins */
+    plugins?: Plugin[],
+  ): Instance<TProps>;
+}
+
+export interface Tippy<TProps = Props> extends TippyStatics {
+  (
+    targets: MultipleTargets,
+    optionalProps?: Partial<TProps>,
+    /** @deprecated use Props.plugins */
+    plugins?: Plugin[],
+  ): Instance<TProps>[];
 }
 
 declare const tippy: Tippy;
@@ -171,12 +187,23 @@ declare const hideAll: HideAll;
 export type CreateTippyWithPlugins = (outerPlugins: Plugin[]) => Tippy;
 declare const createTippyWithPlugins: CreateTippyWithPlugins;
 
-export type Delegate<TProps = Props> = (
-  targets: Targets,
-  props: Partial<TProps> & {target: string},
-  /** @deprecated use Props.plugins */
-  plugins?: Plugin[],
-) => Instance<TProps> | Instance<TProps>[];
+export interface Delegate<TProps = Props> {
+  (
+    targets: SingleTarget,
+    props: Partial<TProps> & {target: string},
+    /** @deprecated use Props.plugins */
+    plugins?: Plugin[],
+  ): Instance<TProps>;
+}
+
+export interface Delegate<TProps = Props> {
+  (
+    targets: MultipleTargets,
+    props: Partial<TProps> & {target: string},
+    /** @deprecated use Props.plugins */
+    plugins?: Plugin[],
+  ): Instance<TProps>[];
+}
 
 export type CreateSingleton<TProps = Props> = (
   tippyInstances: Instance[],

--- a/src/types.ts
+++ b/src/types.ts
@@ -168,13 +168,17 @@ declare const tippy: Tippy;
 export type HideAll = (options: HideAllOptions) => void;
 declare const hideAll: HideAll;
 
+export interface DelegateInstance<TProps = Props> extends Instance<TProps> {
+  destroy(shouldDestroyTargetInstances?: boolean): void;
+}
+
 export interface Delegate<TProps = Props> {
   (
     targets: SingleTarget,
     props: Partial<TProps> & {target: string},
     /** @deprecated use Props.plugins */
     plugins?: Plugin[],
-  ): Instance<TProps>;
+  ): DelegateInstance<TProps>;
 }
 
 export interface Delegate<TProps = Props> {
@@ -183,7 +187,7 @@ export interface Delegate<TProps = Props> {
     props: Partial<TProps> & {target: string},
     /** @deprecated use Props.plugins */
     plugins?: Plugin[],
-  ): Instance<TProps>[];
+  ): DelegateInstance<TProps>[];
 }
 
 export type CreateSingleton<TProps = Props> = (

--- a/website/src/pages/plugins.mdx
+++ b/website/src/pages/plugins.mdx
@@ -97,3 +97,44 @@ tippy(reference, {
 Plugins are invoked per-instance and the plugin function definition takes the
 instance as an argument, so you can use private variables to create internal
 state in the plugin closure. This is how the `followCursor` plugin works.
+
+### TypeScript
+
+To enable type checking for custom props, you can create a central file with the
+plugins your app passes:
+
+```ts
+import tippy, {Tippy, Props, Plugin, LifecycleHooks} from 'tippy.js';
+
+interface CustomProps extends Omit<Props, keyof LifecycleHooks> {
+  myCustomProp: boolean;
+}
+
+type ExtendedProps = CustomProps & LifecycleHooks<CustomProps>;
+
+export const myCustomProp: Plugin<ExtendedProps> = {
+  name: 'myCustomProp',
+  defaultValue: false,
+  fn: () => ({}),
+};
+
+export default (tippy as unknown) as Tippy<ExtendedProps>;
+```
+
+In your app you can import from this file:
+
+```ts
+import tippy, {myCustomProp} from './tippy';
+
+tippy(reference, {
+  // Type checking for this prop now works
+  myCustomProp: true,
+  // There is a DEV warning if you forget to pass the plugin
+  plugins: [myCustomProp],
+  // LifecycleHooks `instance` is typed with the ExtendedProps
+  onCreate(instance) {
+    instance.props.myCustomProp;
+    instance.setProps({myCustomProp: false});
+  },
+});
+```


### PR DESCRIPTION
- Removes `[key: string]: any` from `Props` (see #631)
- Makes all interfaces that use `Props` become generic (to use `TProps`)
- Add included plugins to `Props` so typechecking is enabled by default even if the plugin isn't passed (there is a DEV warning for this)