### PR TITLE
Export Boundary as a type

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -4,6 +4,8 @@ export type BasePlacement = 'top' | 'bottom' | 'left' | 'right';
 
 export type Placement = Popper.Placement;
 
+export type Boundary = Popper.Boundary | HTMLElement;
+
 export type Content = string | Element | ((ref: Element) => Element | string);
 
 export type SingleTarget = Element;
@@ -52,7 +54,7 @@ export interface Props extends LifecycleHooks {
   appendTo: 'parent' | Element | ((ref: Element) => Element);
   aria: 'describedby' | 'labelledby' | null;
   arrow: boolean | string | SVGElement;
-  boundary: 'scrollParent' | 'window' | 'viewport' | HTMLElement;
+  boundary: Boundary;
   content: Content;
   delay: number | [number | null, number | null];
   distance: number | string;


### PR DESCRIPTION
Export the boundary so that we also use it from Tippy then the Popper itself. Currently, I have something like this...

```js
import Popper from 'popper.js';

class PopoverComponent implements OnChanges, OnDestroy, OnInit {
  @Input()
  public boundariesElement: Popper.Boundary = 'window';
  ...
}
```

and would like to replace it with

```js
import {
  Boundary as TippyBoundary,
  Instance as TippyInstance,
  Placement as TippyPlacement,
  SingleTarget as TippySingleTarget
} from 'tippy.js';

class PopoverComponent implements OnChanges, OnDestroy, OnInit {
  @Input()
  public boundariesElement: TippyBoundary = 'window';
  ...
}
```
Let me know if I missed something so that I can adjust it :)