### PR TITLE
types: remove ts-ignore in `normalizeToArray`

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -266,8 +266,7 @@ export function useIfDefined(nextValue: any, currentValue: any): any {
  * Converts a value that's an array or single value to an array
  */
 export function normalizeToArray<T>(value: T | T[]): T[] {
-  // @ts-ignore
-  return [].concat(value);
+  return ([] as T[]).concat(value);
 }
 
 /**


### PR DESCRIPTION
I think this is caused by microsoft/TypeScript#26378