### PR TITLE
Modify trigger: 'mouseenter click' behaviour.

### DIFF
--- a/src/createTippy.ts
+++ b/src/createTippy.ts
@@ -82,7 +82,7 @@ export default function createTippy(
   let hideTimeout: any;
   let scheduleHideAnimationFrame: number;
   let isBeingDestroyed = false;
-  let tipIsVisibleFromClick = false;
+  let isVisibleFromClick = false;
   let didHideDueToDocumentMouseDown = false;
   let popperUpdates = 0;
   let lastTriggerEvent: Event;
@@ -310,7 +310,7 @@ export default function createTippy(
     }
 
     if (instance.props.hideOnClick === true) {
-      tipIsVisibleFromClick = false;
+      isVisibleFromClick = false;
       instance.clearDelayTimeouts();
       instance.hide();
 
@@ -449,8 +449,7 @@ export default function createTippy(
     // Toggle show/hide when clicking click-triggered tooltips
     if (
       event.type === 'click' &&
-      (!includes(instance.props.trigger, 'mouseenter') ||
-        tipIsVisibleFromClick) &&
+      (!includes(instance.props.trigger, 'mouseenter') || isVisibleFromClick) &&
       instance.props.hideOnClick !== false &&
       instance.state.isVisible
     ) {
@@ -470,7 +469,7 @@ export default function createTippy(
     }
 
     if (event.type === 'click') {
-      tipIsVisibleFromClick = !shouldScheduleClickHide;
+      isVisibleFromClick = !shouldScheduleClickHide;
     }
 
     if (shouldScheduleClickHide) {
@@ -521,7 +520,7 @@ export default function createTippy(
       return;
     }
 
-    if (includes(instance.props.trigger, 'click') && tipIsVisibleFromClick) {
+    if (includes(instance.props.trigger, 'click') && isVisibleFromClick) {
       return;
     }
 

--- a/src/createTippy.ts
+++ b/src/createTippy.ts
@@ -773,11 +773,11 @@ export default function createTippy(
 
         Using a wrapper <div> or <span> tag around the reference element solves
         this by creating a new parentNode context.
-        
+
         Specifying \`appendTo: document.body\` silences this warning, but it
         assumes you are using a focus management solution to handle keyboard
         navigation.
-        
+
         See: https://atomiks.github.io/tippyjs/accessibility/#interactivity`,
       );
     }

--- a/src/createTippy.ts
+++ b/src/createTippy.ts
@@ -449,11 +449,8 @@ export default function createTippy(
     // Toggle show/hide when clicking click-triggered tooltips
     if (
       event.type === 'click' &&
-      // If triggering with mouseenter as well, only toggle when hideOnClick
-      // is explicitly set to 'toggle', and the tip has been shown via click
-      // (so the tip doesn't hide on click while hovered).
       (!includes(instance.props.trigger, 'mouseenter') ||
-        (instance.props.hideOnClick === 'toggle' && tipIsVisibleFromClick)) &&
+        tipIsVisibleFromClick) &&
       instance.props.hideOnClick !== false &&
       instance.state.isVisible
     ) {

--- a/test/integration/createTippy.test.js
+++ b/test/integration/createTippy.test.js
@@ -85,8 +85,9 @@ describe('createTippy', () => {
     fireEvent.click(instance.reference);
     expect(instance.state.isVisible).toBe(true);
 
+    // Clicking the reference only toggles the tippy when hideOnClick='toggle'.
     fireEvent.click(instance.reference);
-    expect(instance.state.isVisible).toBe(false);
+    expect(instance.state.isVisible).toBe(true);
   });
 
   it('extends `instance.props` with plugin props', () => {

--- a/test/integration/createTippy.test.js
+++ b/test/integration/createTippy.test.js
@@ -85,9 +85,11 @@ describe('createTippy', () => {
     fireEvent.click(instance.reference);
     expect(instance.state.isVisible).toBe(true);
 
-    // Clicking the reference only toggles the tippy when hideOnClick='toggle'.
-    fireEvent.click(instance.reference);
+    fireEvent.mouseLeave(instance.reference);
     expect(instance.state.isVisible).toBe(true);
+
+    fireEvent.click(instance.reference);
+    expect(instance.state.isVisible).toBe(false);
   });
 
   it('extends `instance.props` with plugin props', () => {


### PR DESCRIPTION
This is an implementation proposal for the changes required for the behaviour change proposed at https://github.com/atomiks/tippyjs/issues/649. Currently, the `mouseenter` behaviour always overrides the `click` behaviour. At a high-level, the behaviour change here amounts to respecting the `mouseenter` behaviour only _until_ the reference element is clicked. Then, the existing click behaviour is respected, until the tippy is hidden (e.g. as per `hideOnClick` = `true` || `'toggle'`). Once hidden again, the existing `mouseenter` behaviour is respected once more.

Lower-level description:
- When both mouseenter and click `trigger`s are specified, respect existing mouseenter behaviour until reference element is clicked.
- On click, show the tippy and no longer hide on mouseleave.
- Respect all pre-existing `hideOnClick` behaviour (true, false, 'toggle').
- ~Only toggle the tippy on clicking the reference element when hideOnClick='toggle' (currently the tippy is _always_ toggled on click (unless `hideOnClick` is set to `false`).~ This conflicts with the preceding point, hence removed (see discussion below).