### PR TITLE
feat: transitionDimensions plugin [wip]

### DIFF
--- a/build/base-iife.js
+++ b/build/base-iife.js
@@ -5,10 +5,17 @@ import animateFill from '../src/plugins/animateFill';
 import followCursor from '../src/plugins/followCursor';
 import inlinePositioning from '../src/plugins/inlinePositioning';
 import sticky from '../src/plugins/sticky';
+import transitionDimensions from '../src/plugins/transitionDimensions';
 import {ROUND_ARROW} from '../src/constants';
 
 tippy.setDefaultProps({
-  plugins: [animateFill, followCursor, inlinePositioning, sticky],
+  plugins: [
+    animateFill,
+    followCursor,
+    inlinePositioning,
+    sticky,
+    transitionDimensions,
+  ],
 });
 
 tippy.createSingleton = createSingleton;

--- a/build/base.js
+++ b/build/base.js
@@ -5,4 +5,7 @@ export {default as animateFill} from '../src/plugins/animateFill';
 export {default as followCursor} from '../src/plugins/followCursor';
 export {default as inlinePositioning} from '../src/plugins/inlinePositioning';
 export {default as sticky} from '../src/plugins/sticky';
+export {
+  default as transitionDimensions,
+} from '../src/plugins/transitionDimensions';
 export {ROUND_ARROW as roundArrow} from '../src/constants';

--- a/build/bundle-iife.js
+++ b/build/bundle-iife.js
@@ -8,6 +8,7 @@ import animateFill from '../src/plugins/animateFill';
 import followCursor from '../src/plugins/followCursor';
 import inlinePositioning from '../src/plugins/inlinePositioning';
 import sticky from '../src/plugins/sticky';
+import transitionDimensions from '../src/plugins/transitionDimensions';
 import {ROUND_ARROW} from '../src/constants';
 
 if (isBrowser) {
@@ -15,7 +16,13 @@ if (isBrowser) {
 }
 
 tippy.setDefaultProps({
-  plugins: [animateFill, followCursor, inlinePositioning, sticky],
+  plugins: [
+    animateFill,
+    followCursor,
+    inlinePositioning,
+    sticky,
+    transitionDimensions,
+  ],
 });
 
 tippy.createSingleton = createSingleton;

--- a/demo/addons/index.html
+++ b/demo/addons/index.html
@@ -9,6 +9,15 @@
     <script>
       process = {env: {}};
     </script>
+    <style>
+      #createSingleton {
+        text-align: right;
+      }
+
+      .__NAMESPACE_PREFIX__-tooltip {
+        text-align: left;
+      }
+    </style>
   </head>
 
   <body>
@@ -22,9 +31,19 @@
 
       <div id="createSingleton">
         <h1>createSingleton</h1>
-        <button class="createSingleton">One</button>
-        <button class="createSingleton">Two</button>
-        <button class="createSingleton">Three</button>
+        <p>feat. `transitionDimensions` plugin</p>
+        <button class="createSingleton">
+          One
+        </button>
+        <button class="createSingleton">
+          Two
+        </button>
+        <button class="createSingleton">
+          Three
+        </button>
+        <button class="createSingleton">
+          Four
+        </button>
       </div>
     </div>
     <!-- prettier-ignore -->

--- a/demo/addons/index.js
+++ b/demo/addons/index.js
@@ -2,8 +2,30 @@ import tippy from '../../src';
 import '../../src/scss/index.scss';
 import createSingleton from '../../src/addons/createSingleton';
 import delegate from '../../src/addons/delegate';
+import transitionDimensions from '../../src/plugins/transitionDimensions';
 
 delegate('#delegate', {target: 'button'});
 
-const instances = tippy('.createSingleton', {content: () => Math.random()});
-createSingleton(instances, {delay: 500, updateDuration: 300});
+let index = 0;
+
+const content = [
+  'Initial',
+  'See as the tooltip',
+  'Smoothly transitions in size',
+  'This is a button that causes the tooltip to change height as well as width.',
+];
+
+const instances = tippy('.createSingleton', {
+  content: () => content[index++],
+});
+
+const s = createSingleton(instances, {
+  placement: 'bottom',
+  flipOnUpdate: true,
+  updateDuration: 300,
+  delay: [0, 250],
+  hideOnClick: false,
+  boundary: 'viewport',
+  transitionDimensions: true,
+  plugins: [transitionDimensions],
+});

--- a/demo/plugins/index.html
+++ b/demo/plugins/index.html
@@ -43,6 +43,9 @@
           solution></span
         >, and some more text.
       </div>
+
+      <h1>transitionDimensions</h1>
+      <button class="transitionDimensions">text</button>
     </div>
     <!-- prettier-ignore -->
     <script> </script>

--- a/demo/plugins/index.js
+++ b/demo/plugins/index.js
@@ -3,13 +3,20 @@ import animateFill from '../../src/plugins/animateFill';
 import followCursor from '../../src/plugins/followCursor';
 import inlinePositioning from '../../src/plugins/inlinePositioning';
 import sticky from '../../src/plugins/sticky';
+import transitionDimensions from '../../src/plugins/transitionDimensions';
 
 import '../../src/scss/index.scss';
 import '../../src/scss/backdrop.scss';
 import '../../src/scss/animations/shift-away.scss';
 
 tippy.setDefaultProps({
-  plugins: [animateFill, followCursor, sticky, inlinePositioning],
+  plugins: [
+    animateFill,
+    followCursor,
+    sticky,
+    inlinePositioning,
+    transitionDimensions,
+  ],
 });
 
 tippy('.followCursor', {
@@ -45,4 +52,28 @@ placements.forEach(placement => {
     inlinePositioning: true,
     placement,
   });
+});
+
+let contentIndex = 0;
+const content = [
+  'text',
+  'text '.repeat(2),
+  'text '.repeat(5),
+  'text '.repeat(15),
+];
+
+const html = document.createElement('div');
+html.innerHTML = content[0];
+
+tippy('.transitionDimensions', {
+  content: html,
+  transitionDimensions: true,
+  updateDuration: 300,
+  onCreate(instance) {
+    setInterval(() => {
+      contentIndex = contentIndex === content.length - 1 ? 0 : ++contentIndex;
+      html.innerHTML = content[contentIndex];
+      instance.setContent(html);
+    }, 1000);
+  },
 });

--- a/src/plugins/transitionDimensions.ts
+++ b/src/plugins/transitionDimensions.ts
@@ -1,0 +1,188 @@
+import {PopperChildren, Instance, Props, TransitionDimensions} from '../types';
+import {div, getOwnerDocument, find} from '../utils';
+
+type Dimensions = {
+  width: number;
+  height: number;
+};
+
+const NAME = 'transitionDimensions';
+const TRANSITIONABLE_PROPERTIES = 'transform,top,left';
+
+function getWindow(element: Element): Window {
+  return getOwnerDocument(element).defaultView || window;
+}
+
+function buildTransitionString(ms: number, timingFn: string): string {
+  return [
+    `opacity ${ms}ms`,
+    `visibility ${ms}ms`,
+    `width ${ms}ms ${timingFn}`,
+    `height ${ms}ms ${timingFn}`,
+    `top ${ms / 2}ms`,
+    `left ${ms / 2}ms`,
+  ].join(',');
+}
+
+function getDimensions(element: HTMLElement): Dimensions {
+  return {
+    width: element.offsetWidth,
+    height: element.offsetHeight,
+  };
+}
+
+function setDimensions(elements: HTMLElement[], dimensions: Dimensions): void {
+  elements.forEach(element => {
+    element.style.width = `${dimensions.width}px`;
+    element.style.height = `${dimensions.height}px`;
+  });
+}
+
+function undoDimensions(elements: HTMLElement[]): void {
+  elements.forEach(element => {
+    element.style.width = '';
+    element.style.height = '';
+  });
+}
+
+const transitionDimensions: TransitionDimensions = {
+  name: NAME,
+  defaultValue: false,
+  fn(instance) {
+    let prevDimensions: Dimensions | null = null;
+    let nextDimensions: Dimensions | null = null;
+
+    const {popper} = instance;
+    const {tooltip, content} = instance.popperChildren;
+
+    const contentWrapper = div();
+    contentWrapper.className = '__NAMESPACE_PREFIX__-content-wrapper';
+    contentWrapper.style.position = 'relative';
+    contentWrapper.style.overflow = 'hidden';
+    contentWrapper.style.willChange = 'transform';
+
+    function getIsEnabled(): boolean {
+      const isPluginNameSelf =
+        find(instance.plugins, plugin => plugin.name === NAME) ===
+        transitionDimensions;
+
+      if (isPluginNameSelf) {
+        return !!instance.props[NAME];
+      }
+
+      return false;
+    }
+
+    function unset(): void {
+      undoDimensions([content, contentWrapper, tooltip, popper]);
+      const arrow = getArrow();
+      if (arrow) {
+        arrow.style.transitionProperty = '';
+        arrow.style.transitionTimingFunction = '';
+        arrow.style.transitionDuration = '';
+      }
+    }
+
+    function onCreate(): void {
+      contentWrapper.appendChild(content);
+      tooltip.appendChild(contentWrapper);
+    }
+
+    function getArrow(): PopperChildren['arrow'] {
+      return instance.popperChildren.arrow;
+    }
+
+    function onBeforeUpdate(
+      instance: Instance,
+      partialProps: Partial<Props>,
+    ): void {
+      if (!getIsEnabled()) {
+        return;
+      }
+
+      if (
+        partialProps[NAME] === false &&
+        partialProps[NAME] !== instance.props[NAME]
+      ) {
+        unset();
+      }
+
+      if (!instance.state.isMounted) {
+        return;
+      }
+
+      if (prevDimensions === null) {
+        prevDimensions = getDimensions(contentWrapper);
+      }
+    }
+
+    function onAfterUpdate(): void {
+      if (!getIsEnabled() || !instance.state.isMounted) {
+        return;
+      }
+
+      const {updateDuration} = instance.props;
+      const timingFn = getWindow(popper).getComputedStyle(popper)
+        .transitionTimingFunction;
+      const transition = buildTransitionString(updateDuration, timingFn);
+
+      const arrow = getArrow();
+      if (arrow) {
+        arrow.style.transitionProperty = TRANSITIONABLE_PROPERTIES;
+        arrow.style.transitionTimingFunction = timingFn;
+        arrow.style.transitionDuration = `${updateDuration}ms`;
+      }
+
+      contentWrapper.style.transition = '';
+      tooltip.style.transition = '';
+
+      undoDimensions([content, contentWrapper, tooltip, popper]);
+      nextDimensions = getDimensions(contentWrapper);
+
+      contentWrapper.style.transition = transition;
+      tooltip.style.transition = transition;
+
+      setDimensions([content], {
+        ...nextDimensions,
+        // TODO: figure out why this is needed/if it can be removed.
+        // The text reflows and cuts off otherwise
+        width: nextDimensions.width + 1,
+      });
+
+      if (prevDimensions) {
+        setDimensions([contentWrapper, tooltip, popper], prevDimensions);
+      }
+
+      // trigger reflow for transition
+      void tooltip.offsetHeight;
+
+      setDimensions([contentWrapper, tooltip, popper], nextDimensions);
+
+      prevDimensions = null;
+    }
+
+    function onShow(): void {
+      if (!getIsEnabled()) {
+        return;
+      }
+
+      if (!instance.state.isMounted) {
+        unset();
+      }
+    }
+
+    function onMount(): void {
+      prevDimensions = getDimensions(contentWrapper);
+    }
+
+    return {
+      onCreate,
+      onBeforeUpdate,
+      onAfterUpdate,
+      onShow,
+      onMount,
+    };
+  },
+};
+
+export default transitionDimensions;

--- a/src/props.ts
+++ b/src/props.ts
@@ -13,6 +13,7 @@ const pluginProps = {
   followCursor: false,
   inlinePositioning: false,
   sticky: false,
+  transitionDimensions: false,
 };
 
 export const defaultProps: DefaultProps = {
@@ -199,12 +200,8 @@ export function validateProps(
       typeof value === 'object' &&
       hasOwnProperty(value, 'placement');
 
-    const nonPluginProps = removeProperties(defaultProps, [
-      'animateFill',
-      'followCursor',
-      'inlinePositioning',
-      'sticky',
-    ]);
+    const pluginKeys = Object.keys(pluginProps) as Array<keyof DefaultProps>;
+    const nonPluginProps = removeProperties(defaultProps, pluginKeys);
 
     // These props have custom warnings
     const customWarningProps = [

--- a/src/types.ts
+++ b/src/types.ts
@@ -85,6 +85,7 @@ export interface Props extends LifecycleHooks {
   trigger: string;
   triggerTarget: Element | Element[] | null;
   updateDuration: number;
+  transitionDimensions: boolean;
   zIndex: number;
 }
 
@@ -223,10 +224,16 @@ export interface Sticky extends Plugin {
   defaultValue: false;
 }
 
+export interface TransitionDimensions extends Plugin {
+  name: 'transitionDimensions';
+  defaultValue: false;
+}
+
 declare const animateFill: AnimateFill;
 declare const followCursor: FollowCursor;
 declare const inlinePositioning: InlinePositioning;
 declare const sticky: Sticky;
+declare const transitionDimensions: TransitionDimensions;
 
 // =============================================================================
 // Misc types
@@ -280,5 +287,6 @@ export {
   followCursor,
   inlinePositioning,
   sticky,
+  transitionDimensions,
   roundArrow,
 };

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -352,3 +352,16 @@ export function getComputedPadding(
     return obj;
   }, freshPaddingObject);
 }
+
+/**
+ * Ponyfill for Array.prototype.find
+ */
+export function find<T>(
+  arr: T[],
+  callback: (item: T, index: number) => boolean,
+): T | undefined {
+  if (Array.prototype.find) {
+    return arr.find(callback);
+  }
+  return arr.filter(callback)[0];
+}


### PR DESCRIPTION
This transitions the dimensions of the tippy smoothly in size when its content is updated. This makes singleton transitions look a lot better.

Content inside should be able to be transitioned by the user by making an absolutely-positioned cloned node of the previous content in `onBeforeUpdate`, then transitioning it out in `onAfterUpdate`.

Unfortunately there is a bug in Safari regarding early cancellations of the transition. When cancelled early, the dimensions don't get updated to the next content's dimensions and stay at the dimensions they were when it got cancelled. Any help figuring that out would be great. 

No idea about IE11 but probably just don't bother with these effects on such an ancient browser 🤷‍♂ 