### PR TITLE
Prevent Object [object Performance] has no method 'now' issue

### DIFF
--- a/src/bindGlobalEventListeners.ts
+++ b/src/bindGlobalEventListeners.ts
@@ -17,7 +17,7 @@ export function onDocumentTouchStart(): void {
 
   currentInput.isTouch = true;
 
-  if (window.performance) {
+  if (window.performance && window.performance.now) {
     document.addEventListener('mousemove', onDocumentMouseMove);
   }
 }
@@ -28,7 +28,7 @@ export function onDocumentTouchStart(): void {
  * well, but very rarely that quickly.
  */
 export function onDocumentMouseMove(): void {
-  const now = performance.now();
+  const now = window.performance.now();
 
   if (now - lastMouseMoveTime < 20) {
     currentInput.isTouch = false;


### PR DESCRIPTION
Browsers on Android <= 4.4 seems to not have `now` property on the `window.performance` object, this PR should fix that.

Original issue:
```
TypeError
Object [object Performance] has no method 'now'
```
<img width="1045" alt="Screenshot 2019-12-31 at 10 52 59" src="https://user-images.githubusercontent.com/10224453/71617526-c3147d00-2bbb-11ea-8929-3b7323972c95.png">

