### PR TITLE
Make mouseenter click behaviour consistent for interactive/non-interactive tippies

### DIFF
--- a/src/createTippy.ts
+++ b/src/createTippy.ts
@@ -838,7 +838,7 @@ export default function createTippy(
     if (
       includes(instance.props.trigger, 'mouseenter') &&
       includes(instance.props.trigger, 'click') &&
-      (event.type === 'mouseleave' || event.type === 'mousemove') &&
+      includes(['mouseleave', 'mousemove'], event.type) &&
       isVisibleFromClick
     ) {
       return;

--- a/src/createTippy.ts
+++ b/src/createTippy.ts
@@ -831,6 +831,19 @@ export default function createTippy(
       return;
     }
 
+    // For interactive tippies, scheduleHide is added to a document.body handler
+    // from onMouseLeave so must intercept scheduled hides from mousemove/leave
+    // events when trigger contains mouseenter and click, and the tip is
+    // currently shown as a result of a click.
+    if (
+      includes(instance.props.trigger, 'mouseenter') &&
+      includes(instance.props.trigger, 'click') &&
+      (event.type === 'mouseleave' || event.type === 'mousemove') &&
+      isVisibleFromClick
+    ) {
+      return;
+    }
+
     const delay = getDelay(false);
 
     if (delay) {

--- a/src/createTippy.ts
+++ b/src/createTippy.ts
@@ -515,15 +515,15 @@ export default function createTippy(
       return;
     }
 
+    if (includes(instance.props.trigger, 'click') && isVisibleFromClick) {
+      return;
+    }
+
     if (instance.props.interactive) {
       doc.body.addEventListener('mouseleave', scheduleHide);
       doc.addEventListener('mousemove', debouncedOnMouseMove);
       pushIfUnique(mouseMoveListeners, debouncedOnMouseMove);
 
-      return;
-    }
-
-    if (includes(instance.props.trigger, 'click') && isVisibleFromClick) {
       return;
     }
 


### PR DESCRIPTION
Addresses bug described at https://github.com/atomiks/tippyjs/issues/668

Also, adds test coverage for interactive tippies, given they involve special/separate event bubbling handling.