### PR TITLE
Hide tippy on focusout from child element to fix #693

### DIFF
--- a/src/createTippy.ts
+++ b/src/createTippy.ts
@@ -422,10 +422,10 @@ export default function createTippy(
           on('mouseleave', onMouseLeave as EventListener);
           break;
         case 'focus':
-          on(isIE ? 'focusout' : 'blur', onBlur as EventListener);
+          on(isIE ? 'focusout' : 'blur', onBlurOrFocusOut as EventListener);
           break;
         case 'focusin':
-          on('focusout', onBlur as EventListener);
+          on('focusout', onBlurOrFocusOut as EventListener);
           break;
       }
     });
@@ -543,8 +543,8 @@ export default function createTippy(
     scheduleHide(event);
   }
 
-  function onBlur(event: FocusEvent): void {
-    if (event.target !== getCurrentTarget()) {
+  function onBlurOrFocusOut(event: FocusEvent): void {
+    if (event.type === 'blur' && event.target !== getCurrentTarget()) {
       return;
     }
 


### PR DESCRIPTION
This resolves the problem with the tooltip not disappearing when focus leaves the element. I was unable to write a test for this as I don't think it's possible to fire an event on one element while having the `target` of that event be a different element, but I could be wrong.