### PR TITLE
feat: add arrowInheritsStyles prop

### DIFF
--- a/src/createTippy.ts
+++ b/src/createTippy.ts
@@ -1,3 +1,4 @@
+import {ARROW_CLASS} from './constants';
 import {createPopper, Modifier} from '@popperjs/core';
 import {currentInput} from './bindGlobalEventListeners';
 import {isIE, isIOS} from './browser';
@@ -562,6 +563,33 @@ export default function createTippy(
       : false;
   }
 
+  function styleArrow (): void {
+    const arrow = popper.getElementsByClassName(ARROW_CLASS)[0]
+    if (!arrow) return;
+
+    const boxStyle = window.getComputedStyle(popper.children[0])
+    const styleTags = Array.from(document.head.getElementsByTagName('style'))
+
+    let tippyStyleTag = styleTags.filter(tag => {
+      return tag.getAttribute('name') === 'tippyjs-styles'
+    })[0]
+
+    if (!tippyStyleTag) {
+      tippyStyleTag = document.head.appendChild(document.createElement('style'))
+      tippyStyleTag.setAttribute('name', 'tippyjs-styles');
+    }
+    const placement = instance.props.placement.split('-')[0]
+
+    tippyStyleTag.innerHTML += `
+      #${popper.id} .${ARROW_CLASS}::before {
+        border-${placement}-color: ${boxStyle['background-color']};
+      }
+      #${popper.id} .${ARROW_CLASS}::after {
+        border-${placement}-color: ${boxStyle['border-color']};
+      }
+    `
+  }
+
   function createPopperInstance(): void {
     destroyPopperInstance();
 
@@ -689,6 +717,10 @@ export default function createTippy(
     // updated as Popper needs to read its dimensions
     if (!parentNode.contains(popper)) {
       parentNode.appendChild(popper);
+    }
+
+    if (instance.props.arrowInheritsStyles) {
+      styleArrow();
     }
 
     createPopperInstance();


### PR DESCRIPTION
#720 solution that causes no breaking changes.

Considerations: 
- Style tag creation would be not necessary, but 'css inheritance way' demand CSS rewrite (breaking changes - possibility for version 7),
- JavaScript handling is inevitable if we want to style arrow based on box background-color,
- Performance measured from 6milisecons for first and 1ms for later calls of styleArrow(), first call time is caused by style tag creation, it could be created beforehand for optimization

Demo:
1.   set 'arrowInheritsStyles: true'
2. add
```
.tippy-box[data-theme~='light-border'] {
  border-color: teal;
  background-color: wheat;
}
```
result:
![image](https://user-images.githubusercontent.com/32914662/75987929-11facd80-5ef1-11ea-9aa4-133798968477.png)

