### PR TITLE
Handle onClickOutside props for tippy instance

### DIFF
--- a/src/createTippy.ts
+++ b/src/createTippy.ts
@@ -312,6 +312,8 @@ export default function createTippy(
       ) {
         return;
       }
+    } else {
+      instance.props.onClickOutside(instance, event);
     }
 
     if (instance.props.hideOnClick === true) {

--- a/src/props.ts
+++ b/src/props.ts
@@ -53,6 +53,7 @@ export const defaultProps: DefaultProps = {
   onShown() {},
   onTrigger() {},
   onUntrigger() {},
+  onClickOutside() {},
   placement: 'top',
   plugins: [],
   popperOptions: {},

--- a/src/types.ts
+++ b/src/types.ts
@@ -38,6 +38,7 @@ export interface LifecycleHooks<TProps = Props> {
   onShown(instance: Instance<TProps>): void;
   onTrigger(instance: Instance<TProps>, event: Event): void;
   onUntrigger(instance: Instance<TProps>, event: Event): void;
+  onClickOutside(instance: Instance<TProps>, event: Event): void;
 }
 
 export interface RenderProps {

--- a/test/integration/__snapshots__/createTippy.test.js.snap
+++ b/test/integration/__snapshots__/createTippy.test.js.snap
@@ -64,6 +64,7 @@ Object {
     ],
     "onAfterUpdate": [Function],
     "onBeforeUpdate": [Function],
+    "onClickOutside": [Function],
     "onCreate": [Function],
     "onDestroy": [Function],
     "onHidden": [Function],

--- a/test/integration/props.test.js
+++ b/test/integration/props.test.js
@@ -1,4 +1,4 @@
-import {fireEvent} from '@testing-library/dom';
+import {fireEvent, createEvent} from '@testing-library/dom';
 import {h, enableTouchEnvironment, disableTouchEnvironment} from '../utils';
 
 import tippy from '../../src';
@@ -316,6 +316,46 @@ describe('getReferenceClientRect', () => {
     expect(instance.popperInstance.state.elements.reference).toBe(
       instance.reference,
     );
+  });
+});
+
+describe('onClickOutside', () => {
+  it('should be called on document mousedown if provided', () => {
+    const onClickOutside = jest.fn();
+    const instance = tippy(h(), {onClickOutside});
+
+    instance.show();
+    jest.runAllTimers();
+    const outsideClickEvent = createEvent.mouseDown(document.body);
+    fireEvent(document.body, outsideClickEvent);
+    // fire events multiple times to be sure its called once
+    fireEvent(document.body, outsideClickEvent);
+    fireEvent(document.body, outsideClickEvent);
+
+    expect(onClickOutside).toHaveBeenCalledTimes(1);
+    expect(onClickOutside).toHaveBeenCalledWith(instance, outsideClickEvent);
+  });
+
+  it('should not be called if instance not shown', () => {
+    const onClickOutside = jest.fn();
+    tippy(h(), {onClickOutside});
+
+    fireEvent.mouseDown(document.body);
+
+    expect(onClickOutside).toHaveBeenCalledTimes(0);
+  });
+
+  it('should not be called if instance already hidden', () => {
+    const onClickOutside = jest.fn();
+    const instance = tippy(h(), {onClickOutside});
+
+    instance.show();
+    jest.runAllTimers();
+    instance.hide();
+    jest.runAllTimers();
+    fireEvent.mouseDown(document.body);
+
+    expect(onClickOutside).toHaveBeenCalledTimes(0);
   });
 });
 

--- a/test/unit/__snapshots__/tippy.test.js.snap
+++ b/test/unit/__snapshots__/tippy.test.js.snap
@@ -31,6 +31,7 @@ Object {
   ],
   "onAfterUpdate": [Function],
   "onBeforeUpdate": [Function],
+  "onClickOutside": [Function],
   "onCreate": [Function],
   "onDestroy": [Function],
   "onHidden": [Function],


### PR DESCRIPTION
This new props allows to pass a new listener when the user click outside of a shown tippy instance.
Related to https://github.com/atomiks/tippyjs-react/issues/166