### PR TITLE
fix(followCursor): global mouse listener

### DIFF
--- a/src/plugins/followCursor.ts
+++ b/src/plugins/followCursor.ts
@@ -1,5 +1,20 @@
-import {getOwnerDocument, isMouseEvent} from '../dom-utils';
-import {FollowCursor} from '../types';
+import {getOwnerDocument} from '../dom-utils';
+import {FollowCursor, Instance} from '../types';
+
+let mouseCoords = {clientX: 0, clientY: 0};
+let activeInstances: Array<{instance: Instance; doc: Document}> = [];
+
+function storeMouseCoords({clientX, clientY}: MouseEvent): void {
+  mouseCoords = {clientX, clientY};
+}
+
+function addMouseCoordsListener(doc: Document): void {
+  doc.addEventListener('mousemove', storeMouseCoords);
+}
+
+function removeMouseCoordsListener(doc: Document): void {
+  doc.removeEventListener('mousemove', storeMouseCoords);
+}
 
 const followCursor: FollowCursor = {
   name: 'followCursor',
@@ -8,49 +23,14 @@ const followCursor: FollowCursor = {
     const reference = instance.reference;
     const doc = getOwnerDocument(instance.props.triggerTarget || reference);
 
-    let initialMouseCoords: {clientX: number; clientY: number} | null = null;
-
-    function getIsManual(): boolean {
-      return instance.props.trigger.trim() === 'manual';
-    }
-
-    function getIsEnabled(): boolean {
-      // #597
-      const isValidMouseEvent = getIsManual()
-        ? true
-        : // Check if a keyboard "click"
-          initialMouseCoords !== null &&
-          !(
-            initialMouseCoords.clientX === 0 && initialMouseCoords.clientY === 0
-          );
-
-      return instance.props.followCursor && isValidMouseEvent;
-    }
+    let isInternalUpdate = false;
+    let wasFocusEvent = false;
+    let isUnmounted = true;
 
     function getIsInitialBehavior(): boolean {
       return (
         instance.props.followCursor === 'initial' && instance.state.isVisible
       );
-    }
-
-    function unsetReferenceClientRect(shouldUnset: any): void {
-      if (shouldUnset) {
-        instance.setProps({getReferenceClientRect: null});
-      }
-    }
-
-    function handleMouseMoveListener(): void {
-      if (getIsEnabled()) {
-        addListener();
-      } else {
-        unsetReferenceClientRect(instance.props.followCursor);
-      }
-    }
-
-    function triggerLastMouseMove(): void {
-      if (getIsEnabled()) {
-        onMouseMove(initialMouseCoords as MouseEvent);
-      }
     }
 
     function addListener(): void {
@@ -61,12 +41,13 @@ const followCursor: FollowCursor = {
       doc.removeEventListener('mousemove', onMouseMove);
     }
 
-    function onMouseMove(event: MouseEvent): void {
-      initialMouseCoords = {
-        clientX: event.clientX,
-        clientY: event.clientY,
-      };
+    function unsetGetReferenceClientRect(): void {
+      isInternalUpdate = true;
+      instance.setProps({getReferenceClientRect: null});
+      isInternalUpdate = false;
+    }
 
+    function onMouseMove(event: MouseEvent): void {
       // If the instance is interactive, avoid updating the position unless it's
       // over the reference element
       const isCursorOverReference = event.target
@@ -108,58 +89,54 @@ const followCursor: FollowCursor = {
           },
         });
       }
+    }
 
-      if (getIsInitialBehavior()) {
-        removeListener();
+    function create(): void {
+      if (instance.props.followCursor) {
+        activeInstances.push({instance, doc});
+        addMouseCoordsListener(doc);
+      }
+    }
+
+    function destroy(): void {
+      activeInstances = activeInstances.filter(
+        (data) => data.instance !== instance
+      );
+
+      if (activeInstances.filter((data) => data.doc === doc).length === 0) {
+        removeMouseCoordsListener(doc);
       }
     }
 
     return {
+      onCreate: create,
+      onDestroy: destroy,
       onAfterUpdate(_, {followCursor}): void {
-        if (followCursor !== undefined && !followCursor) {
-          unsetReferenceClientRect(true);
+        if (!isInternalUpdate && followCursor === false) {
+          destroy();
+          removeListener();
+          unsetGetReferenceClientRect();
         }
       },
       onMount(): void {
-        triggerLastMouseMove();
-      },
-      onShow(): void {
-        if (getIsManual()) {
-          // Since there's no trigger event to use, we have to use these as
-          // baseline coords
-          initialMouseCoords = {
-            clientX: 0,
-            clientY: 0,
-          };
+        if (instance.props.followCursor) {
+          if (isUnmounted) {
+            onMouseMove(mouseCoords as MouseEvent);
+            isUnmounted = false;
+          }
 
-          handleMouseMoveListener();
+          if (!wasFocusEvent && !getIsInitialBehavior()) {
+            addListener();
+          }
         }
       },
-      onTrigger(_, event): void {
-        // Tapping on touch devices can trigger `mouseenter` then `focus`
-        if (initialMouseCoords) {
-          return;
-        }
-
-        if (isMouseEvent(event)) {
-          initialMouseCoords = {
-            clientX: event.clientX,
-            clientY: event.clientY,
-          };
-        }
-
-        handleMouseMoveListener();
-      },
-      onUntrigger(): void {
-        // If untriggered before showing (`onHidden` will never be invoked)
-        if (!instance.state.isVisible) {
-          removeListener();
-          initialMouseCoords = null;
-        }
+      onTrigger(_, {type}): void {
+        wasFocusEvent = type === 'focus';
       },
       onHidden(): void {
         removeListener();
-        initialMouseCoords = null;
+        unsetGetReferenceClientRect();
+        isUnmounted = true;
       },
     };
   },

--- a/test/integration/plugins/followCursor.test.js
+++ b/test/integration/plugins/followCursor.test.js
@@ -134,11 +134,9 @@ describe('followCursor', () => {
     placements.forEach((placement) => {
       instance = tippy(h(), {followCursor: 'initial', placement});
 
-      // lastMouseMove event is used in this case
-      instance.reference.dispatchEvent(
-        new MouseEvent('mouseenter', {...first})
-      );
+      fireEvent.mouseMove(instance.reference, first);
 
+      instance.show();
       jest.runAllTimers();
 
       fireEvent.mouseMove(instance.reference, first);
@@ -269,8 +267,9 @@ describe('followCursor', () => {
       followCursor: 'initial',
     });
 
-    fireEvent.mouseEnter(instance.reference, first);
+    fireEvent.mouseMove(instance.reference, first);
 
+    instance.show();
     jest.runAllTimers();
 
     fireEvent.mouseMove(instance.reference, second);


### PR DESCRIPTION
This switches the `followCursor` plugin to use a global mouse listener that stores the mouse coords at all times if the plugin is active for any alive instances. 

This allows the user to call `.show()` at any time and have the tippy position itself at the mouse cursor, which enables some esoteric use cases that bypasses the default `trigger` behavior.