### PR TITLE
Fix a typo in FAQ page

### DIFF
--- a/website/src/pages/v6/faq.mdx
+++ b/website/src/pages/v6/faq.mdx
@@ -208,4 +208,4 @@ An **addon** is an external function that calls the `tippy()` constructor
 because it's controlling or creating many different tippy instances.
 
 A **plugin** is a plain object that hooks into, and adds functionality, to a
-single tippy instance that has already already created.
+single tippy instance that has already created.


### PR DESCRIPTION
Removing extra word in the FAQ text