### PR TITLE
Adding an overload for the Targets type

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -156,6 +156,10 @@ export interface Tippy<TProps = Props> extends TippyStatics {
   >[];
 }
 
+export interface Tippy<TProps = Props> extends TippyStatics {
+  (targets: Targets, optionalProps?: Partial<TProps>): Instance<TProps> | Instance<TProps>[];
+}
+
 declare const tippy: Tippy;
 
 // =============================================================================


### PR DESCRIPTION
Hey.
Problem: Type Targets declared but not used:
![screen-0](https://user-images.githubusercontent.com/30486581/93846568-6031bb80-fcdf-11ea-9d29-18c7b5810f25.png)

Solution: Add overload for Targets.
![screen-1](https://user-images.githubusercontent.com/30486581/93846575-632cac00-fcdf-11ea-829b-70fde7c9ca35.png)