### PR TITLE
Elements created via a <template> have an ownerDocument with no reference to the body

### DIFF
--- a/src/dom-utils.ts
+++ b/src/dom-utils.ts
@@ -64,7 +64,9 @@ export function getOwnerDocument(
   elementOrElements: Element | Element[]
 ): Document {
   const [element] = normalizeToArray(elementOrElements);
-  return element ? element.ownerDocument || document : document;
+
+  // Elements created via a <template> have an ownerDocument with no reference to the body
+  return element?.ownerDocument?.body ? element.ownerDocument : document;
 }
 
 export function isCursorOutsideInteractiveBorder(

--- a/test/unit/dom-utils.test.js
+++ b/test/unit/dom-utils.test.js
@@ -98,3 +98,19 @@ describe('isReferenceElement', () => {
     expect(DomUtils.isReferenceElement(instance.popper)).toBe(false);
   });
 });
+
+describe('getOwnerDocument', () => {
+  it('finds the ownerDocument of an element', () => {
+    expect(DomUtils.getOwnerDocument(document.createElement('div'))).toBe(document);
+  });
+
+  it('uses the default document if the element was created from a template', () => {
+    const template = document.createElement('template');
+
+    template.innerHTML = '<div></div>';
+
+    const div = template.content.firstChild;
+
+    expect(DomUtils.getOwnerDocument(div)).toBe(document);
+  });
+});


### PR DESCRIPTION
This causes the followCursor plugin to not work when a tooltip is initialized before the template's element is added to the DOM.