### PR TITLE
Fix bug: hovering a hiding content leads to incorrect position.

### DIFF
--- a/src/plugins/inlinePositioning.ts
+++ b/src/plugins/inlinePositioning.ts
@@ -87,6 +87,9 @@ const inlinePositioning: InlinePositioning = {
           cursorRectIndex = index > -1 ? index : cursorRectIndex;
         }
       },
+      onHidden(): void {
+        cursorRectIndex = -1;
+      },
     };
   },
 };

--- a/src/plugins/inlinePositioning.ts
+++ b/src/plugins/inlinePositioning.ts
@@ -83,12 +83,9 @@ const inlinePositioning: InlinePositioning = {
               rect.top - 2 <= event.clientY &&
               rect.bottom + 2 >= event.clientY
           );
-
-          cursorRectIndex = rects.indexOf(cursorRect);
+          const index = rects.indexOf(cursorRect);
+          cursorRectIndex = index > -1 ? index : cursorRectIndex;
         }
-      },
-      onUntrigger(): void {
-        cursorRectIndex = -1;
       },
     };
   },


### PR DESCRIPTION
Currently there is a bug when hovering the hiding content, it will be re-triggered but the position is wrong, since the previous cursor index is lost.

![Kapture 2020-12-11 at 01 20 55](https://user-images.githubusercontent.com/3808838/101807472-1fb04400-3b50-11eb-8984-8e4a9fa47b0e.gif)

This PR fix it by retain the cursor index.