### PR TITLE
Add show, showNext, showPrevious methods to singletons

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -187,6 +187,9 @@ export type CreateSingletonInstance<TProps = CreateSingletonProps> = Instance<
   TProps
 > & {
   setInstances(instances: Instance<any>[]): void;
+  show(target?: ReferenceElement | Instance | number): void;
+  showNext(): void;
+  showPrevious(): void;
 };
 
 export type CreateSingleton<TProps = Props> = (

--- a/test/integration/addons/createSingleton.test.js
+++ b/test/integration/addons/createSingleton.test.js
@@ -293,3 +293,159 @@ describe('.setInstances() method', () => {
     expect(singleton.state.isVisible).toBe(true);
   });
 });
+
+describe('.show() method', () => {
+  const getInstances = () =>
+    [{content: 'first'}, {content: 'second'}, {content: 'last'}].map((props) =>
+      tippy(h(), props)
+    );
+
+  it('shows the first tippy instance when no parameters are passed', () => {
+    const singletonInstance = createSingleton(getInstances());
+
+    singletonInstance.show();
+
+    expect(singletonInstance.state.isVisible).toBe(true);
+    expect(singletonInstance.props.content).toBe('first');
+  });
+
+  it('shows the tippy instance passed as an argument', () => {
+    const tippyInstances = getInstances();
+    const singletonInstance = createSingleton(tippyInstances);
+
+    singletonInstance.show(tippyInstances[1]);
+
+    expect(singletonInstance.state.isVisible).toBe(true);
+    expect(singletonInstance.props.content).toBe('second');
+  });
+
+  it('shows the tippy instance related to the reference element passed as an argument', () => {
+    const tippyInstances = getInstances();
+    const singletonInstance = createSingleton(tippyInstances);
+
+    singletonInstance.show(tippyInstances[1].reference);
+
+    expect(singletonInstance.state.isVisible).toBe(true);
+    expect(singletonInstance.props.content).toBe('second');
+  });
+
+  it('shows the tippy instance at the given index number', () => {
+    const singletonInstance = createSingleton(getInstances());
+
+    singletonInstance.show(1);
+
+    expect(singletonInstance.state.isVisible).toBe(true);
+    expect(singletonInstance.props.content).toBe('second');
+  });
+});
+
+describe('.showNext() method', () => {
+  const getInstances = () =>
+    [{content: 'first'}, {content: 'second'}, {content: 'last'}].map((props) =>
+      tippy(h(), props)
+    );
+
+  it('shows the first tippy instance if none is visible', () => {
+    const singletonInstance = createSingleton(getInstances());
+
+    singletonInstance.showNext();
+
+    expect(singletonInstance.state.isVisible).toBe(true);
+    expect(singletonInstance.props.content).toBe('first');
+  });
+  it('shows the tippy instance after the currently visible one', () => {
+    const singletonInstance = createSingleton(getInstances());
+
+    singletonInstance.show();
+
+    expect(singletonInstance.props.content).toBe('first');
+    singletonInstance.showNext();
+    expect(singletonInstance.props.content).toBe('second');
+    singletonInstance.showNext();
+    expect(singletonInstance.props.content).toBe('last');
+  });
+  it('loops to the beginning if the last instance is visible', () => {
+    const singletonInstance = createSingleton(getInstances());
+
+    singletonInstance.show(2);
+
+    expect(singletonInstance.props.content).toBe('last');
+    singletonInstance.showNext();
+    expect(singletonInstance.props.content).toBe('first');
+  });
+});
+
+describe('.showPrevious() method', () => {
+  const getInstances = () =>
+    [{content: 'first'}, {content: 'second'}, {content: 'last'}].map((props) =>
+      tippy(h(), props)
+    );
+
+  it('shows the last tippy instance if none is visible', () => {
+    const singletonInstance = createSingleton(getInstances());
+
+    singletonInstance.showPrevious();
+
+    expect(singletonInstance.state.isVisible).toBe(true);
+    expect(singletonInstance.props.content).toBe('last');
+  });
+  it('shows the tippy instance before the currently visible one', () => {
+    const singletonInstance = createSingleton(getInstances(), {
+      showOnCreate: true,
+    });
+
+    singletonInstance.hide();
+    singletonInstance.show(2);
+
+    expect(singletonInstance.props.content).toBe('last');
+    singletonInstance.showPrevious();
+    expect(singletonInstance.props.content).toBe('second');
+    singletonInstance.showPrevious();
+    expect(singletonInstance.props.content).toBe('first');
+  });
+  it('loops to the end if the first instance is visible', () => {
+    const singletonInstance = createSingleton(getInstances());
+
+    singletonInstance.show();
+
+    expect(singletonInstance.props.content).toBe('first');
+    singletonInstance.showPrevious();
+    expect(singletonInstance.props.content).toBe('last');
+  });
+});
+
+describe('showOnCreate prop', () => {
+  it('shows the first tippy instance on creation', () => {
+    const tippyInstances = [
+      {content: 'first'},
+      {content: 'second'},
+    ].map((props) => tippy(h(), props));
+
+    const singletonInstance = createSingleton(tippyInstances, {
+      showOnCreate: true,
+    });
+
+    expect(singletonInstance.state.isVisible).toBe(true);
+    expect(singletonInstance.props.content).toBe('first');
+  });
+
+  it('resets correctly if showOnCreate is cancelled by a click outside', () => {
+    const tippyInstances = [
+      {content: 'first'},
+      {content: 'second'},
+    ].map((props) => tippy(h(), props));
+
+    const singletonInstance = createSingleton(tippyInstances, {
+      showOnCreate: true,
+      delay: 500,
+    });
+
+    fireEvent.mouseDown(document.body);
+    jest.runAllTimers();
+    fireEvent.mouseEnter(tippyInstances[1].reference);
+    jest.runAllTimers();
+
+    expect(singletonInstance.state.isVisible).toBe(true);
+    expect(singletonInstance.props.content).toBe('second');
+  });
+});

--- a/test/visual/tests.js
+++ b/test/visual/tests.js
@@ -266,6 +266,7 @@ tests.createSingleton = () => {
   const singleton = createSingleton(instances, {
     delay: 500,
     overrides: ['placement', 'duration'],
+    showOnCreate: true,
   });
 
   instances = instances.concat(

--- a/website/src/pages/v6/addons.mdx
+++ b/website/src/pages/v6/addons.mdx
@@ -64,6 +64,46 @@ const singleton = createSingleton(tippyInstances, {
 });
 ```
 
+### Showing specific tippy instance
+
+The `.show()` method of singleton accepts an additional parameter:
+
+```js
+// Show first child tippy instance if no parameter given
+singleton.show();
+
+// Show given child tippy instance
+singleton.show(tippyInstances[1]);
+
+// Show child tippy instance related to given reference element
+singleton.show(document.querySelector('button'));
+
+// Show child tippy instance at given index
+singleton.show(2); // i.e equivalent to passing tippyInstances[2]
+```
+
+### Show instances in order
+
+The `.showNext()` and `showPrevious()` methods allow you to loop through and
+show the child tippy instances in forward or reverse order respectively,
+relative to `tippyInstances` array given in `createSingleton`
+
+```js
+// if no child tippy is shown, show first one, otherwise show the next one
+singleton.showNext();
+
+// if no child tippy is shown, show last one, otherwise show the previous one
+singleton.showPrevious();
+```
+
+Both methods will loop to the other end, like pac-man
+
+```js
+singleton.show(0); // show first
+singleton.showPrevious(); // loops back and shows last item
+singleton.showNext(); // loops to the front and shows first item
+```
+
 #### Update
 
 You can update the singleton's instances with the `.setInstances()` method:


### PR DESCRIPTION
This PR adds the following features/changes to Singleton addon

- Refactored logic from `onTrigger` into `prepareInstance` so that it can be reused in `show`
- Fixed `show` method  for Singletons and introduced 3 overloads
  - Specific tippy instance
  - Specific reference element
  - Index number (relative to references array)
  - Show first tippy instance if no argument is passed (this was broken and showing empty tippy at top left)
- Introduced `showNext` and `showPrevious` methods on Singletons
  - Both methods will cycle once you reach last/first tippy instance
- `showOnCreate` now works correctly for singletons
- Updated `addons.mdx` docs

Our use-case for these changes: We are trying to create a guide/intro where we need to programatically show a singleton instance, but we realised that show method didn't work correctly (shows empty tooltip on top left of screen). So we fixed that and also introduced show next/previous to simplify cycling through the steps of the guide.