### PR TITLE
fix not working interactive option

### DIFF
--- a/src/createTippy.ts
+++ b/src/createTippy.ts
@@ -301,9 +301,10 @@ export default function createTippy(
     }
 
     // Clicked on interactive popper
+    const actualTarget = (event.composedPath && event.composedPath()[0]) || event.target;
     if (
       instance.props.interactive &&
-      popper.contains(event.target as Element)
+      popper.contains(actualTarget as Element)
     ) {
       return;
     }


### PR DESCRIPTION
When tippy content is inside a shadow dom, the `interactive` option is not working.

The reason is 
> Events that happen in shadow DOM have the host element as the target, when caught outside of the component.
the popper is inside the host, so `popper.contains(target)` will always return false.
see https://javascript.info/shadow-dom-events

by using `event.composedPath` instead of the `event.target`, it will get the actual target and fix this bug.

see https://stackoverflow.com/questions/39245488/event-path-is-undefined-running-in-firefox/39245638#39245638