### PR TITLE
fix wrong target

### DIFF
--- a/src/createTippy.ts
+++ b/src/createTippy.ts
@@ -300,8 +300,9 @@ export default function createTippy(
       }
     }
 
-    // Clicked on interactive popper
     const actualTarget = (event.composedPath && event.composedPath()[0]) || event.target;
+
+    // Clicked on interactive popper
     if (
       instance.props.interactive &&
       popper.contains(actualTarget as Element)
@@ -310,7 +311,7 @@ export default function createTippy(
     }
 
     // Clicked on the event listeners target
-    if (getCurrentTarget().contains(event.target as Element)) {
+    if (getCurrentTarget().contains(actualTarget as Element)) {
       if (currentInput.isTouch) {
         return;
       }


### PR DESCRIPTION
the following fix of https://github.com/atomiks/tippyjs/pull/913

in `onDocumentPress`, the check for `event.target` should all be replaced with `actualTarget`.

Otherwise, if the target is inside shadow root, click the reference won't hide tippy properly, see

![Kapture 2021-03-02 at 11 58 51](https://user-images.githubusercontent.com/3808838/109595035-b8060580-7b4e-11eb-9dd8-32fc97d3c67a.gif)
