### PR TITLE
fix contains algorithm for shadow dom

### DIFF
--- a/src/createTippy.ts
+++ b/src/createTippy.ts
@@ -3,6 +3,7 @@ import {currentInput} from './bindGlobalEventListeners';
 import {isIE} from './browser';
 import {TOUCH_OPTIONS} from './constants';
 import {
+  actualContains,
   div,
   getOwnerDocument,
   isCursorOutsideInteractiveBorder,
@@ -300,19 +301,9 @@ export default function createTippy(
       }
     }
 
-    const actualTarget = (event.composedPath && event.composedPath()[0]) || event.target;
+    const actualTarget =
+      (event.composedPath && event.composedPath()[0]) || event.target;
 
-    function actualContains(parent: Element, child: Element): boolean {
-      let target = child;
-      while(target) {
-        if (parent.contains(target)) {
-          return true;
-        }
-        target = (child.getRootNode() as any)?.host;
-      }
-      return false;
-    }
-    
     // Clicked on interactive popper
     if (
       instance.props.interactive &&

--- a/src/createTippy.ts
+++ b/src/createTippy.ts
@@ -302,16 +302,27 @@ export default function createTippy(
 
     const actualTarget = (event.composedPath && event.composedPath()[0]) || event.target;
 
+    function actualContains(parent: Element, child: Element): boolean {
+      let target = child;
+      while(target) {
+        if (parent.contains(target)) {
+          return true;
+        }
+        target = (child.getRootNode() as any)?.host;
+      }
+      return false;
+    }
+    
     // Clicked on interactive popper
     if (
       instance.props.interactive &&
-      popper.contains(actualTarget as Element)
+      actualContains(popper, actualTarget as Element)
     ) {
       return;
     }
 
     // Clicked on the event listeners target
-    if (getCurrentTarget().contains(actualTarget as Element)) {
+    if (actualContains(getCurrentTarget(), actualTarget as Element)) {
       if (currentInput.isTouch) {
         return;
       }

--- a/src/dom-utils.ts
+++ b/src/dom-utils.ts
@@ -117,3 +117,18 @@ export function updateTransitionEndListener(
     box[method](event, listener as EventListener);
   });
 }
+
+/**
+ * check if parent contains child
+ * compared to xxx.contains, this function works for dom structures with shadow dom
+ */
+export function actualContains(parent: Element, child: Element): boolean {
+  let target = child;
+  while (target) {
+    if (parent.contains(target)) {
+      return true;
+    }
+    target = (target.getRootNode() as any)?.host;
+  }
+  return false;
+}


### PR DESCRIPTION
For such a structure where content is a shadow dom:

```
popperContainer
  contentElement(shadowDom)
    innerElement
    innerElement
    ...
```

If we click on innerElement, the `popperContainer.contains(innerElement)` will return false since it is inside a shadow root. But in tippy's logic, we need to treat popperContainer containing innerElement as true.

So here comes `actualContains` function which check through the shadow dom to maintain the correct logic.

Without this fix, interactive option will not work for dom structure above, see:

![Kapture 2021-03-02 at 20 42 31](https://user-images.githubusercontent.com/3808838/109650287-f542b580-7b97-11eb-8f34-f19f5e389f58.gif)
