### PR TITLE
docs: add the trigger props detail for hideOnClick

### DIFF
--- a/website/src/pages/v6/all-props.mdx
+++ b/website/src/pages/v6/all-props.mdx
@@ -430,7 +430,7 @@ tippy(targets, {
 });
 ```
 
-`hideOnClick: true` with `click`:
+`hideOnClick: true` with `trigger: "click"`:
 
 <Demo>
   <Tippy hideOnClick={true} trigger="click">
@@ -438,7 +438,7 @@ tippy(targets, {
   </Tippy>
 </Demo>
 
-`hideOnClick: "toggle"` with `click`:
+`hideOnClick: "toggle"` with `trigger: "click"`:
 
 <Demo>
   <Tippy hideOnClick="toggle" trigger="click">
@@ -446,7 +446,7 @@ tippy(targets, {
   </Tippy>
 </Demo>
 
-`hideOnClick: false` with `mouseenter` (a `click` trigger will never hide):
+`hideOnClick: false` with `trigger: "mouseenter"` (a `click` trigger will never hide):
 
 <Demo>
   <Tippy hideOnClick={false} trigger="mouseenter">


### PR DESCRIPTION
docs: add the trigger props detail for hideOnClick

It's the first time I use tippyjs. the doc of hideOnClick is so confuse, I try too many times, but it not work.

finaly, in the source code of the doc, I found it should use with trigger props...

It should add the props detail for fresh user. 

thanks.