### PR TITLE
Fix: Don't stringify zIndex

### DIFF
--- a/src/createTippy.ts
+++ b/src/createTippy.ts
@@ -218,7 +218,7 @@ export default function createTippy(
   function handleStyles(): void {
     popper.style.pointerEvents =
       instance.props.interactive && instance.state.isVisible ? '' : 'none';
-    popper.style.zIndex = `${instance.props.zIndex}`;
+    popper.style.zIndex = instance.props.zIndex ?? 9999;
   }
 
   function invokeHook(


### PR DESCRIPTION
Not sure if this is the right place to add this change.  I noticed in tippyjs/react, if you pass:

```jsx
<Tippy
   zIndex={props.zIndex}
>
```

with `props.zIndex` being `number | undefined`, then z-index defaults to `'undefined'` if it's not passed.  Maybe this is better solved somewhere else (wherever the props are being merged).  Obviously a work-around is `zIndex={props.zIndex ?? 9999}`, but that seems bizarre for consumers to have to re-establish the API's defaults. 

Thoughts?