### PR TITLE
fix: reset white-space to its initial value

### DIFF
--- a/src/scss/index.scss
+++ b/src/scss/index.scss
@@ -14,6 +14,7 @@ $color: #333;
   border-radius: 4px;
   font-size: 14px;
   line-height: 1.4;
+  white-space: initial;
   outline: 0;
   transition-property: transform, visibility, opacity;
 


### PR DESCRIPTION
When a tooltip is added to a `<pre>` element (or any elements that has `white-space: pre`), the arrow appears broken.

Example:

![image](https://user-images.githubusercontent.com/48261497/130640802-2a90ef34-39f1-4633-aa9e-602056731a2f.png)

(`white-space: pre` was added to the parent `<div>` to trigger the bug)
