### PR TITLE
Check for popperInstance before calling forceUpdate()

### DIFF
--- a/src/createTippy.ts
+++ b/src/createTippy.ts
@@ -898,9 +898,13 @@ export default function createTippy(
       // https://github.com/atomiks/tippyjs-react/issues/177
       // TODO: find a cleaner / more efficient solution(!)
       getNestedPopperTree().forEach((nestedPopper) => {
-        // React (and other UI libs likely) requires a rAF wrapper as it flushes
-        // its work in one
-        requestAnimationFrame(nestedPopper._tippy!.popperInstance!.forceUpdate);
+        const popperInstance = nestedPopper._tippy?.popperInstance;
+        
+        if (popperInstance) {
+          // React (and other UI libs likely) requires a rAF wrapper as it flushes
+          // its work in one
+          requestAnimationFrame(popperInstance.forceUpdate);
+        }
       });
     }
 


### PR DESCRIPTION
Like the typings already hinting, the popperInstance can be null and thus should be checked before accessing it to avoid TypeErrors.