### PR TITLE
ensure singleton cleans up previous instances when updated

### DIFF
--- a/src/addons/createSingleton.ts
+++ b/src/addons/createSingleton.ts
@@ -244,7 +244,7 @@ const createSingleton: CreateSingleton = (
 
     enableInstances(false);
     setReferences();
-    interceptSetProps(singleton);
+    interceptSetPropsCleanups = interceptSetProps(singleton);
 
     singleton.setProps({triggerTarget: references});
   };


### PR DESCRIPTION
This is a fix for an issue where the singleton's target instances get updated. The current behaviour causes their `setProps` method to get repeatedly wrapped. In my scenario with 1000 target instances it was causing the browser to lock up for several seconds.

Thanks for all your work!