### PR TITLE
fix(inlinePositioning): infinite loop

### DIFF
--- a/src/plugins/inlinePositioning.ts
+++ b/src/plugins/inlinePositioning.ts
@@ -30,6 +30,7 @@ const inlinePositioning: InlinePositioning = {
     let placement: Placement;
     let cursorRectIndex = -1;
     let isInternalUpdate = false;
+    let triedPlacements: Array<string> = [];
 
     const modifier: Modifier<
       'tippyInlinePositioning',
@@ -40,7 +41,15 @@ const inlinePositioning: InlinePositioning = {
       phase: 'afterWrite',
       fn({state}) {
         if (isEnabled()) {
-          if (placement !== state.placement) {
+          if (triedPlacements.indexOf(state.placement) !== -1) {
+            triedPlacements = [];
+          }
+
+          if (
+            placement !== state.placement &&
+            triedPlacements.indexOf(state.placement) === -1
+          ) {
+            triedPlacements.push(state.placement);
             instance.setProps({
               // @ts-ignore - unneeded DOMRect properties
               getReferenceClientRect: () =>


### PR DESCRIPTION
 @kenticomartinh

This prevents `.setProps()` from being called if it encountered that placement already. It still resets the array so that flipping can continue to work again — it just breaks the loop. Tried it on your CodePen and the issue is gone.

Fixes #977 