### PR TITLE
docs: add info about Ember wrapper

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,8 @@ For detailed usage information,
 
 ## Component Wrappers
 
-React: [@tippyjs/react](https://github.com/atomiks/tippyjs-react)
+- React: [@tippyjs/react](https://github.com/atomiks/tippyjs-react) (official)
+- Ember: [ember-tippy](https://github.com/nag5000/ember-tippy) (unofficial)
 
 ## License
 

--- a/website/src/pages/v6/getting-started.mdx
+++ b/website/src/pages/v6/getting-started.mdx
@@ -76,11 +76,18 @@ don't get removed.
 </html>
 ```
 
-### React
+### Component Wrappers
+
+#### React
 
 Using React? Use the
 [official component package](https://github.com/atomiks/tippyjs-react) which
 integrates well with React, allowing you to use Tippy declaratively.
+
+#### Ember
+
+There is the unofficial [ember-tippy](https://github.com/nag5000/ember-tippy) addon
+for Emberistas.
 
 ### Optional extra imports
 


### PR DESCRIPTION
I recently published an Ember wrapper for tippyjs: https://github.com/nag5000/ember-tippy. 
Would you mind adding information about it to the readme and website?