### PR TITLE
Pass plugins to `validateProps` in `setDefaultProps`

### DIFF
--- a/src/props.ts
+++ b/src/props.ts
@@ -71,7 +71,8 @@ const defaultKeys = Object.keys(defaultProps);
 export const setDefaultProps: Tippy['setDefaultProps'] = (partialProps) => {
   /* istanbul ignore else */
   if (__DEV__) {
-    validateProps(partialProps, []);
+    const plugins = defaultProps.plugins.concat(partialProps.plugins || []);
+    validateProps(partialProps, plugins);
   }
 
   const keys = Object.keys(partialProps) as Array<keyof DefaultProps>;


### PR DESCRIPTION
Plugins are not used when validating props in `setDefaultProps`

```js
import tippy, { followCursor } from 'tippy.js';

tippy.setDefaultProps({
    followCursor: true,
    plugins: [followCursor],
})
```

```
tippy.js

`followCursor` is not a valid prop. You may have spelled it incorrectly, or if it's a plugin, forgot to pass it in an array as props.plugins. 

All props: https://atomiks.github.io/tippyjs/v6/all-props/
Plugins: https://atomiks.github.io/tippyjs/v6/plugins/

👷‍ This is a development-only message. It will be removed in production.
```