### PR TITLE
Fix undefined listener invokes (bug #1027)

### DIFF
--- a/src/dom-utils.ts
+++ b/src/dom-utils.ts
@@ -107,8 +107,8 @@ export function updateTransitionEndListener(
   action: 'add' | 'remove',
   listener: (event: TransitionEvent) => void
 ): void {
-  if(listener) {
-      const method = `${action}EventListener` as
+  if (listener) {
+    const method = `${action}EventListener` as
       | 'addEventListener'
       | 'removeEventListener';
 

--- a/src/dom-utils.ts
+++ b/src/dom-utils.ts
@@ -107,15 +107,17 @@ export function updateTransitionEndListener(
   action: 'add' | 'remove',
   listener: (event: TransitionEvent) => void
 ): void {
-  const method = `${action}EventListener` as
-    | 'addEventListener'
-    | 'removeEventListener';
+  if(listener) {
+      const method = `${action}EventListener` as
+      | 'addEventListener'
+      | 'removeEventListener';
 
-  // some browsers apparently support `transition` (unprefixed) but only fire
-  // `webkitTransitionEnd`...
-  ['transitionend', 'webkitTransitionEnd'].forEach((event) => {
-    box[method](event, listener as EventListener);
-  });
+    // some browsers apparently support `transition` (unprefixed) but only fire
+    // `webkitTransitionEnd`...
+    ['transitionend', 'webkitTransitionEnd'].forEach((event) => {
+      box[method](event, listener as EventListener);
+    });
+  }
 }
 
 /**


### PR DESCRIPTION
Very simple solution for the bug I reported on:
[Tippy invokes removeEventListener and addEventListener with an undefined listener #1027
https://github.com/atomiks/tippyjs/issues/1027](https://github.com/atomiks/tippyjs/issues/1027)



Live demonstration available here: https://codepen.io/lazycompiler/pen/rNYxBjQ

![Screen Shot 2022-01-31 at 1 20 17 AM](https://user-images.githubusercontent.com/25502703/151722180-5dee359c-cfad-41d0-b3a8-9d6bd9356b4e.png)
