### PR TITLE
fix merging modifiers

### DIFF
--- a/src/createTippy.ts
+++ b/src/createTippy.ts
@@ -677,7 +677,17 @@ export default function createTippy(
       });
     }
 
-    modifiers.push(...(popperOptions?.modifiers || []));
+    (popperOptions?.modifiers || []).forEach((modifier) => {
+      const tippyModifier = modifiers.find((x) => x.name === modifier.name);
+      if (tippyModifier) {
+        modifiers[modifiers.indexOf(tippyModifier)] = {
+          ...tippyModifier,
+          ...modifier,
+        };
+      } else {
+        modifiers.push(modifier);
+      }
+    });
 
     instance.popperInstance = createPopper<ExtendedModifiers>(
       computedReference,


### PR DESCRIPTION
In tippy, modifiers used in the code cannot be modified or overridden. I tried to modify the `preventOverflow` modifier, but it didn't work, so I added a few lines of code to merge the modifiers.