### PR TITLE
Fix mentions to old ‘touchHold’ prop, which has been replaced with the ‘touch’ prop in version 6

### DIFF
--- a/test/integration/createTippy.test.js
+++ b/test/integration/createTippy.test.js
@@ -462,7 +462,7 @@ describe('instance.setProps()', () => {
     expect(instance.popper._tippy).toBe(instance);
   });
 
-  it('changing `trigger` or `touchHold` changes listeners', () => {
+  it('changing `trigger` changes listeners', () => {
     const ref = h();
     instance = createTippy(ref, defaultProps);
 

--- a/website/src/pages/v6/misc.mdx
+++ b/website/src/pages/v6/misc.mdx
@@ -83,7 +83,7 @@ click event.
 Depending on your use case, one of these will be preferred, so user agent
 checking may be needed.
 
-If neither behavior is preferred, consider using the `touchHold` prop which
+If neither behavior is preferred, consider using the `touch` prop which
 allows the user to see the tooltip while pressing and holding the button, but
 won't fire a click event unless the click appears to be intentional.
 


### PR DESCRIPTION
In the documentation, simply change the prop name. In the test, remove the mention to the ‘touchHold’ prop, which doesn’t seem to be exercised in the test.