### PR TITLE
Update plugins to use the correct key code

### DIFF
--- a/website/src/pages/v6/plugins.mdx
+++ b/website/src/pages/v6/plugins.mdx
@@ -135,7 +135,7 @@ const hideOnEsc = {
   defaultValue: true,
   fn({hide}) {
     function onKeyDown(event) {
-      if (event.keyCode === 27) {
+      if (event.code === "Escape") {
         hide();
       }
     }


### PR DESCRIPTION
In the documentation for plugins you recommend to use`KeyboardEvent.keyCode` however this [is deprecated](https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent/keyCode), the current advice is to use `KeyboardEvent.code`. So I have updated the docs to reflect this very minor change. 