### PR TITLE
docs: add disabling animations section

### DIFF
--- a/website/src/pages/v6/animations.mdx
+++ b/website/src/pages/v6/animations.mdx
@@ -65,6 +65,16 @@ tippy('button', {
 });
 ```
 
+### Disable animations
+
+If you don't want any animations, you can just pass `false` to the `animation` prop:
+
+```js
+tippy('button', {
+  animation: false,
+});
+```
+
 ### Inertia
 
 There's a prop named `inertia` that adds an elastic inertial effect to the


### PR DESCRIPTION
Add a "disabling animations" section to the animations page, so that it's more easier for the new users to find this option.

Let me know if there's anything else I need to do on this PR 😉 