### PR TITLE
docs: mention that delay is ignored on touch

### DIFF
--- a/website/src/pages/v6/all-props.mdx
+++ b/website/src/pages/v6/all-props.mdx
@@ -305,6 +305,10 @@ tippy(targets, {
 });
 ```
 
+> **Note**
+>
+> The delay is ignored when the tippy is triggered by touch input.
+
 <Demo>
   <Tippy delay={400}>
     <Button>delay: 400</Button>


### PR DESCRIPTION
I was wondering why my delay settings weren't working, so I looked into the code and found, that `getDelay` returns constant `0` if `currentInput.isTouch` is set. Having this documented could avoid some confusion for users later on.