### PR TITLE
add Property getNestedPopperElements

### DIFF
--- a/src/createTippy.ts
+++ b/src/createTippy.ts
@@ -755,9 +755,16 @@ export default function createTippy(
   }
 
   function getNestedPopperTree(): PopperElement[] {
-    return arrayFrom(
-      popper.querySelectorAll('[data-__NAMESPACE_PREFIX__-root]')
+    const popperElements: PopperElement[] = [];
+    if (typeof instance.props.getNestedPopperElements === 'function') {
+      popperElements.push(...instance.props.getNestedPopperElements(popper));
+    }
+
+    popperElements.push(
+      ...arrayFrom(popper.querySelectorAll('[data-__NAMESPACE_PREFIX__-root]'))
     );
+
+    return popperElements;
   }
 
   function scheduleShow(event?: Event): void {

--- a/src/props.ts
+++ b/src/props.ts
@@ -35,6 +35,7 @@ export const defaultProps: DefaultProps = {
   delay: 0,
   duration: [300, 250],
   getReferenceClientRect: null,
+  getNestedPopperElements: null,
   hideOnClick: true,
   ignoreAttributes: false,
   interactive: false,

--- a/src/types.ts
+++ b/src/types.ts
@@ -73,6 +73,7 @@ export interface Props extends LifecycleHooks, RenderProps {
   duration: number | [number | null, number | null];
   followCursor: boolean | 'horizontal' | 'vertical' | 'initial';
   getReferenceClientRect: null | GetReferenceClientRect;
+  getNestedPopperElements: null | ((popper: PopperElement) => PopperElement[]);
   hideOnClick: boolean | 'toggle';
   ignoreAttributes: boolean;
   inlinePositioning: boolean;

--- a/website/src/pages/v6/all-props.mdx
+++ b/website/src/pages/v6/all-props.mdx
@@ -28,6 +28,7 @@ tippy(targets, {
 - [duration](#duration) <RenderIcon />
 - [followCursor](#followcursor) <PluginIcon />
 - [getReferenceClientRect](#getreferenceclientrect)
+- [getNestedPopperElements](#getnestedpopperelements)
 - [hideOnClick](#hideonclick)
 - [ignoreAttributes](#ignoreattributes)
 - [inertia](#inertia) <RenderIcon />
@@ -407,6 +408,21 @@ tippy(targets, {
     top: 100,
     bottom: 200,
   }),
+});
+```
+
+---
+
+### getNestedPopperElements
+
+Used for keeping tippy open when mouse is over child tippy instances.
+
+```js
+tippy(targets, {
+  // default (uses the reference passed as first argument)
+  getNestedPopperElements: null,
+  // function that returns custom popper elements
+  getNestedPopperElements: (popperElement) => Array.from(popperElement.querySelectorAll('.my-custom-tooltips'),
 });
 ```
 


### PR DESCRIPTION
I use tippy.js within the shadow dom of a custom element and need the callback to detect nested instances of tippy.

### Example
```typescript
const instance = tippy(element, {
  // ...
  getNestedPopperElements: (): PopperElement[] => {
    return Array.from<TooltipComponent>(this.querySelectorAll('my-tooltip') || [])
      .map<PopperElement>(tooltip => tooltip.renderRoot.querySelector('[data-tippy-root]') as PopperElement)
      .filter(element => !!element);
    },
});
```