### PR TITLE
delegate: Don't process event for non Element targets.

### DIFF
--- a/src/addons/delegate.ts
+++ b/src/addons/delegate.ts
@@ -49,7 +49,7 @@ function delegate(
   const normalizedReturnValue = normalizeToArray(returnValue);
 
   function onTrigger(event: Event): void {
-    if (!event.target || disabled) {
+    if (!(event.target instanceof Element) || disabled) {
       return;
     }
 


### PR DESCRIPTION
In Firefox, event targets can be pseudo elements like `text` nodes which don't have `.closest` method. This results in error when delegate tries to handle trigger for a text node target.