### PR TITLE
refactor(types): decrease specificity of lifecycle hook return type

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -36,9 +36,9 @@ export interface LifecycleHooks<TProps = Props> {
   onCreate(instance: Instance<TProps>): void;
   onDestroy(instance: Instance<TProps>): void;
   onHidden(instance: Instance<TProps>): void;
-  onHide(instance: Instance<TProps>): void | false;
+  onHide(instance: Instance<TProps>): void | boolean;
   onMount(instance: Instance<TProps>): void;
-  onShow(instance: Instance<TProps>): void | false;
+  onShow(instance: Instance<TProps>): void | boolean;
   onShown(instance: Instance<TProps>): void;
   onTrigger(instance: Instance<TProps>, event: Event): void;
   onUntrigger(instance: Instance<TProps>, event: Event): void;


### PR DESCRIPTION
I find it oddly specific and since I am using https://typescript-eslint.io/rules/explicit-function-return-type/ in my projects I have to explicitely say `false | void` instead of a simple boolean with it every time there is a tooltip that should have a `onShow` hook condition. Passing `true` should work the same as `void` as the implementation only checks for `false`.

```ts
const showTooltip = false

// There has to be a condition to satisfy the void return type
function onShow(): false | void {
  if (!showTooltip) {
    return false
  }
}

// Ideally this would work
function onShow(): boolean {
  return showTooltip
}
```